### PR TITLE
Update Gradle to 6.6.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 }
 
 shadowJar {
-    archiveName = 'addressbook.jar'
+    archiveFileName = 'addressbook.jar'
 }
 
 defaultTasks 'clean', 'test'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fixes #2 

The Gradle wrapper was used to update itself. The exact command used was `gradlew wrapper --gradle-version=6.6.1 --distribution-type=bin`.

Based on warnings generated by Gradle, I found that [property `archiveName` is deprecated](https://docs.gradle.org/6.6.1/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:archiveName) and will be removed from Gradle 7 onwards. To stay compliant with the future versions of Gradle, `archiveName` has been updated to `archiveFileName`.

Notes to reviewers:
- Using `distribution-type=all` makes the upgrade work differently from `distribution-type=bin`. In particular, there are changes made to `gradlew` and `gradlew.bat`. I've stuck to `bin` as that is what the existing project has used, but it may be worth exploring whether it is recommended/necessary to use `all` to upgrade the `gradlew` scripts as well.