### PR TITLE
Add Git pre-push hook

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'application'
     id 'jacoco'
     id 'info.solidsoft.pitest' version '1.5.2'
+    id 'com.github.jakemarsden.git-hooks' version '0.0.2'
 }
 
 mainClassName = 'seedu.address.Main'
@@ -45,6 +46,14 @@ pitest {
     targetClasses = ['seedu.address.*']
     junit5PluginVersion = '0.12'
     threads = 4
+}
+
+gitHooks {
+    hooksDirectory = file('.git/hooks')
+    gradleCommand = './gradlew'
+    hooks = [
+        'pre-push': 'clean check test'
+    ]
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ gitHooks {
     hooksDirectory = file('.git/hooks')
     gradleCommand = './gradlew'
     hooks = [
-        'pre-push': 'clean check test'
+        'pre-push': 'clean check'
     ]
 }
 


### PR DESCRIPTION
Resolves #4.

Unfortunately, the [Gradle Git Hook](https://plugins.gradle.org/plugin/com.star-zero.gradle.githook) library has compatibility issues with Windows. As such, we are currently using [git-hooks-gradle-plugin](https://plugins.gradle.org/plugin/com.github.jakemarsden.git-hooks).

Actions to be taken before this PR can be merged:
- [x] Testing by @zhaojj2209 or @siddarth2824 to verify that it works on Unix systems
- [x] Request for permission to use the new library (once the previous action is taken)