### PR TITLE
Achieve parity between pre-push hook and CI job

### DIFF
--- a/.github/check-eof-newline.sh
+++ b/.github/check-eof-newline.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Checks that all text files end with a newline.
+echo "Checking for newline at EOF..."
 
 ret=0
 

--- a/.github/check-line-endings.sh
+++ b/.github/check-line-endings.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # Checks for prohibited line endings.
 # Prohibited line endings: \r\n
+echo "Checking for prohibited line endings..."
 
 git grep --cached -I -n --no-color -P '\r$' -- ':/' |
 awk '

--- a/.github/check-trailing-whitespace.sh
+++ b/.github/check-trailing-whitespace.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Checks for trailing whitespace
+echo "Checking for trailing whitespace..."
 
 git grep --cached -I -n --no-color -P '[ \t]+$' -- ':/' |
 awk '
@@ -9,7 +10,7 @@ awk '
         ret = 0
     }
     {
-        # Only warn for markdown files (*.md) to accomodate text editors
+        # Only warn for markdown files (*.md) to accommodate text editors
         # which do not properly handle trailing whitespace.
         # (e.g. GitHub web editor)
         if ($1 ~ /\.md$/) {

--- a/.github/run-checks.sh
+++ b/.github/run-checks.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # Runs all check-* scripts, and returns a non-zero exit code if any of them fail.
 
+echo "Running formatting checks..."
 dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd) &&
 ret=0 &&
 for checkscript in "$dir"/check-*; do

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,8 @@ gitHooks {
     hooksDirectory = file('.git/hooks')
     gradleCommand = './gradlew'
     hooks = [
-        'pre-push': 'clean check'
+        // Git hooks run in a bash environment regardless of OS.
+        'pre-push': 'clean check && .github/run-checks.sh'
     ]
 }
 


### PR DESCRIPTION
Changes:
- Run `run-checks.sh` before pushing.
- Print check that is being carried out to provide more feedback to the user.
- Fix typo in `check-trailing-whitespace.sh`.

Resolves #19.