### PR TITLE
Add income commands

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommand.java
@@ -11,7 +11,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 
 /**
- * Adds a transaction to the address book.
+ * Adds an income to the finance tracker.
  */
 public class AddIncomeCommand extends Command {
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommand.java
@@ -1,0 +1,64 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.commands;
+
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_CATEGORY;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_DATE;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_NAME;
+import static java.util.Objects.requireNonNull;
+
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
+import ay2021s1_cs2103_w16_3.finesse.model.Model;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
+
+/**
+ * Adds a transaction to the address book.
+ */
+public class AddIncomeCommand extends Command {
+
+    public static final String COMMAND_WORD = "add-income";
+    public static final String COMMAND_ALIAS = "addi";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an income to the finance tracker. "
+            + "Parameters: "
+            + PREFIX_NAME + "NAME "
+            + PREFIX_AMOUNT + "AMOUNT "
+            + PREFIX_DATE + "DATE "
+            + "[" + PREFIX_CATEGORY + "CATEGORY]...\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NAME + "Internship "
+            + PREFIX_AMOUNT + "560 "
+            + PREFIX_DATE + "03/10/2020 "
+            + PREFIX_CATEGORY + "Work";
+
+    public static final String MESSAGE_SUCCESS = "New income added: %1$s";
+    public static final String MESSAGE_DUPLICATE_TRANSACTION = "This income already exists in the finance tracker";
+
+    private final Income toAdd;
+
+    /**
+     * Creates an AddIncomeCommand to add the specified {@code Income}
+     */
+    public AddIncomeCommand(Income income) {
+        requireNonNull(income);
+        toAdd = income;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (model.hasTransaction(toAdd)) {
+            throw new CommandException(MESSAGE_DUPLICATE_TRANSACTION);
+        }
+
+        model.addTransaction(toAdd);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AddIncomeCommand // instanceof handles nulls
+                && toAdd.equals(((AddIncomeCommand) other).toAdd));
+    }
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListIncomeCommand.java
@@ -1,0 +1,25 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.commands;
+
+import static ay2021s1_cs2103_w16_3.finesse.model.transaction.Income.PREDICATE_SHOW_ALL_INCOME;
+import static java.util.Objects.requireNonNull;
+
+import ay2021s1_cs2103_w16_3.finesse.model.Model;
+
+/**
+ * Lists all income in the finance tracker to the user.
+ */
+public class ListIncomeCommand extends Command {
+
+    public static final String COMMAND_WORD = "ls-income";
+    public static final String COMMAND_ALIAS = "lsi";
+
+    public static final String MESSAGE_SUCCESS = "Listed all income";
+
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredTransactionList(PREDICATE_SHOW_ALL_INCOME);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddIncomeCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddIncomeCommandParser.java
@@ -1,0 +1,57 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.parser;
+
+import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_CATEGORY;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_DATE;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_NAME;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddIncomeCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
+import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Name;
+
+/**
+ * Parses input arguments and creates a new AddIncomeCommand object
+ */
+public class AddIncomeCommandParser implements Parser<AddIncomeCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddIncomeCommand
+     * and returns an AddIncomeCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddIncomeCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_AMOUNT, PREFIX_DATE, PREFIX_CATEGORY);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_AMOUNT, PREFIX_DATE)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddIncomeCommand.MESSAGE_USAGE));
+        }
+
+        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
+        Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
+        Set<Category> categoryList = ParserUtil.parseCategories(argMultimap.getAllValues(PREFIX_CATEGORY));
+
+        Income income = new Income(name, amount, date, categoryList);
+
+        return new AddIncomeCommand(income);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddressBookParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddressBookParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddIncomeCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ClearCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.Command;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.DeleteCommand;
@@ -46,6 +47,10 @@ public class AddressBookParser {
 
         case AddCommand.COMMAND_WORD:
             return new AddCommandParser().parse(arguments);
+
+        case AddIncomeCommand.COMMAND_WORD:
+        case AddIncomeCommand.COMMAND_ALIAS:
+            return new AddIncomeCommandParser().parse(arguments);
 
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddressBookParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddressBookParser.java
@@ -16,6 +16,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.commands.ExitCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.FindCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.HelpCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListIncomeCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
 
 /**
@@ -66,6 +67,10 @@ public class AddressBookParser {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
+
+        case ListIncomeCommand.COMMAND_WORD:
+        case ListIncomeCommand.COMMAND_ALIAS:
+            return new ListIncomeCommand();
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Income.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Income.java
@@ -1,10 +1,15 @@
 package ay2021s1_cs2103_w16_3.finesse.model.transaction;
 
 import java.util.Set;
+import java.util.function.Predicate;
 
 import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
 
 public class Income extends Transaction {
+
+    /** {@code Predicate} that returns true only for {@code Income} transactions */
+    public static final Predicate<Transaction> PREDICATE_SHOW_ALL_INCOME = transaction -> transaction instanceof Income;
+
     public Income(Name name, Amount amount, Date date, Set<Category> categories) {
         super(name, amount, date, categories);
     }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommandTest.java
@@ -1,0 +1,196 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.commands;
+
+import static ay2021s1_cs2103_w16_3.finesse.testutil.Assert.assertThrows;
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+
+import ay2021s1_cs2103_w16_3.finesse.commons.core.GuiSettings;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
+import ay2021s1_cs2103_w16_3.finesse.model.AddressBook;
+import ay2021s1_cs2103_w16_3.finesse.model.Model;
+import ay2021s1_cs2103_w16_3.finesse.model.ReadOnlyAddressBook;
+import ay2021s1_cs2103_w16_3.finesse.model.ReadOnlyUserPrefs;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
+import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
+import javafx.collections.ObservableList;
+
+public class AddIncomeCommandTest {
+
+    @Test
+    public void constructor_nullTransaction_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddIncomeCommand(null));
+    }
+
+    @Test
+    public void execute_transactionAcceptedByModel_addSuccessful() throws Exception {
+        ModelStubAcceptingTransactionAdded modelStub = new ModelStubAcceptingTransactionAdded();
+        Income validIncome = new TransactionBuilder().buildIncome();
+
+        CommandResult commandResult = new AddIncomeCommand(validIncome).execute(modelStub);
+
+        assertEquals(String.format(AddIncomeCommand.MESSAGE_SUCCESS, validIncome), commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(validIncome), modelStub.transactionsAdded);
+    }
+
+    @Test
+    public void execute_duplicateTransaction_throwsCommandException() {
+        Income validIncome = new TransactionBuilder().buildIncome();
+        AddIncomeCommand addIncomeCommand = new AddIncomeCommand(validIncome);
+        ModelStub modelStub = new ModelStubWithTransaction(validIncome);
+
+        assertThrows(CommandException.class, AddIncomeCommand.MESSAGE_DUPLICATE_TRANSACTION, ()
+            -> addIncomeCommand.execute(modelStub));
+    }
+
+    @Test
+    public void equals() {
+        Income alice = new TransactionBuilder().withName("Alice").buildIncome();
+        Income bob = new TransactionBuilder().withName("Bob").buildIncome();
+        AddIncomeCommand addAliceCommand = new AddIncomeCommand(alice);
+        AddIncomeCommand addBobCommand = new AddIncomeCommand(bob);
+
+        // same object -> returns true
+        assertTrue(addAliceCommand.equals(addAliceCommand));
+
+        // same values -> returns true
+        AddIncomeCommand addAliceCommandCopy = new AddIncomeCommand(alice);
+        assertTrue(addAliceCommand.equals(addAliceCommandCopy));
+
+        // different types -> returns false
+        assertFalse(addAliceCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(addAliceCommand.equals(null));
+
+        // different transaction -> returns false
+        assertFalse(addAliceCommand.equals(addBobCommand));
+    }
+
+    /**
+     * A default model stub that have all of the methods failing.
+     */
+    private class ModelStub implements Model {
+        @Override
+        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyUserPrefs getUserPrefs() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public GuiSettings getGuiSettings() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setGuiSettings(GuiSettings guiSettings) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Path getAddressBookFilePath() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBookFilePath(Path addressBookFilePath) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addTransaction(Transaction transaction) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBook(ReadOnlyAddressBook newData) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyAddressBook getAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasTransaction(Transaction transaction) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteTransaction(Transaction target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setTransaction(Transaction target, Transaction editedTransaction) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Transaction> getFilteredTransactionList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredTransactionList(Predicate<Transaction> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+    }
+
+    /**
+     * A Model stub that contains a single transaction.
+     */
+    private class ModelStubWithTransaction extends ModelStub {
+        private final Transaction transaction;
+
+        ModelStubWithTransaction(Transaction transaction) {
+            requireNonNull(transaction);
+            this.transaction = transaction;
+        }
+
+        @Override
+        public boolean hasTransaction(Transaction transaction) {
+            requireNonNull(transaction);
+            return this.transaction.isSameTransaction(transaction);
+        }
+    }
+
+    /**
+     * A Model stub that always accept the transaction being added.
+     */
+    private class ModelStubAcceptingTransactionAdded extends ModelStub {
+        final ArrayList<Transaction> transactionsAdded = new ArrayList<>();
+
+        @Override
+        public boolean hasTransaction(Transaction transaction) {
+            requireNonNull(transaction);
+            return transactionsAdded.stream().anyMatch(transaction::isSameTransaction);
+        }
+
+        @Override
+        public void addTransaction(Transaction transaction) {
+            requireNonNull(transaction);
+            transactionsAdded.add(transaction);
+        }
+
+        @Override
+        public ReadOnlyAddressBook getAddressBook() {
+            return new AddressBook();
+        }
+    }
+
+}

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListIncomeCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListIncomeCommandTest.java
@@ -1,0 +1,54 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.commands;
+
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.getTypicalAddressBook;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import ay2021s1_cs2103_w16_3.finesse.model.Model;
+import ay2021s1_cs2103_w16_3.finesse.model.ModelManager;
+import ay2021s1_cs2103_w16_3.finesse.model.UserPrefs;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
+import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListIncomeCommand.
+ */
+public class ListIncomeCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_showsIncomeOnly() {
+        expectedModel.updateFilteredTransactionList(Income.PREDICATE_SHOW_ALL_INCOME);
+        assertCommandSuccess(new ListIncomeCommand(), model, ListIncomeCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_hasSomeIncome() {
+        model.addTransaction(new TransactionBuilder().buildIncome());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.updateFilteredTransactionList(transaction -> transaction instanceof Income);
+        assertCommandSuccess(new ListIncomeCommand(), model, ListIncomeCommand.MESSAGE_SUCCESS, expectedModel);
+        assertEquals(model.getFilteredTransactionList().size(), 1);
+    }
+
+    @Test
+    public void execute_hasSomeNonIncome() {
+        model.addTransaction(new TransactionBuilder().build()); // TODO replace with expense when implemented
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.updateFilteredTransactionList(transaction -> transaction instanceof Income);
+        assertCommandSuccess(new ListIncomeCommand(), model, ListIncomeCommand.MESSAGE_SUCCESS, expectedModel);
+        assertEquals(model.getFilteredTransactionList().size(), 0);
+    }
+
+}

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddIncomeCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddIncomeCommandParserTest.java
@@ -1,0 +1,120 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.parser;
+
+import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUNT_DESC_AMY;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUNT_DESC_BOB;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.CATEGORY_DESC_FRIEND;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.CATEGORY_DESC_HUSBAND;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DATE_DESC_AMY;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DATE_DESC_BOB;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.INVALID_AMOUNT_DESC;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.INVALID_CATEGORY_DESC;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_AMOUNT_BOB;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_CATEGORY_FRIEND;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_CATEGORY_HUSBAND;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_DATE_BOB;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.AMY;
+import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.BOB;
+
+import org.junit.jupiter.api.Test;
+
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddIncomeCommand;
+import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Name;
+import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
+
+public class AddIncomeCommandParserTest {
+    private AddIncomeCommandParser parser = new AddIncomeCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        Income expectedIncome = new TransactionBuilder(BOB).withCategories(VALID_CATEGORY_FRIEND).buildIncome();
+
+        // whitespace only preamble
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + AMOUNT_DESC_BOB + DATE_DESC_BOB
+                + CATEGORY_DESC_FRIEND, new AddIncomeCommand(expectedIncome));
+
+        // multiple names - last name accepted
+        assertParseSuccess(parser, NAME_DESC_AMY + NAME_DESC_BOB + AMOUNT_DESC_BOB + DATE_DESC_BOB
+                + CATEGORY_DESC_FRIEND, new AddIncomeCommand(expectedIncome));
+
+        // multiple amounts - last amount accepted
+        assertParseSuccess(parser, NAME_DESC_BOB + AMOUNT_DESC_AMY + AMOUNT_DESC_BOB + DATE_DESC_BOB
+                + CATEGORY_DESC_FRIEND, new AddIncomeCommand(expectedIncome));
+
+        // multiple dates - last date accepted
+        assertParseSuccess(parser, NAME_DESC_BOB + AMOUNT_DESC_BOB + DATE_DESC_AMY + DATE_DESC_BOB
+                + CATEGORY_DESC_FRIEND, new AddIncomeCommand(expectedIncome));
+
+        // multiple categories - all accepted
+        Income expectedIncomeMultipleTags = new TransactionBuilder(BOB)
+                .withCategories(VALID_CATEGORY_FRIEND, VALID_CATEGORY_HUSBAND).buildIncome();
+        assertParseSuccess(parser, NAME_DESC_BOB + AMOUNT_DESC_BOB + DATE_DESC_BOB + CATEGORY_DESC_HUSBAND
+                + CATEGORY_DESC_FRIEND, new AddIncomeCommand(expectedIncomeMultipleTags));
+    }
+
+    @Test
+    public void parse_optionalFieldsMissing_success() {
+        // zero categories
+        Income expectedIncome = new TransactionBuilder(AMY).withCategories().buildIncome();
+        assertParseSuccess(parser, NAME_DESC_AMY + AMOUNT_DESC_AMY + DATE_DESC_AMY,
+                new AddIncomeCommand(expectedIncome));
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddIncomeCommand.MESSAGE_USAGE);
+
+        // missing name prefix
+        assertParseFailure(parser, VALID_NAME_BOB + AMOUNT_DESC_BOB + DATE_DESC_BOB, expectedMessage);
+
+        // missing amount prefix
+        assertParseFailure(parser, NAME_DESC_BOB + VALID_AMOUNT_BOB + DATE_DESC_BOB, expectedMessage);
+
+        // missing date prefix
+        assertParseFailure(parser, NAME_DESC_BOB + AMOUNT_DESC_BOB + VALID_DATE_BOB, expectedMessage);
+
+        // all prefixes missing
+        assertParseFailure(parser, VALID_NAME_BOB + VALID_AMOUNT_BOB + VALID_DATE_BOB, expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid name
+        assertParseFailure(parser, INVALID_NAME_DESC + AMOUNT_DESC_BOB + DATE_DESC_BOB
+                + CATEGORY_DESC_HUSBAND + CATEGORY_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+
+        // invalid amount
+        assertParseFailure(parser, NAME_DESC_BOB + INVALID_AMOUNT_DESC + DATE_DESC_BOB
+                + CATEGORY_DESC_HUSBAND + CATEGORY_DESC_FRIEND, Amount.MESSAGE_CONSTRAINTS);
+
+        // invalid date
+        assertParseFailure(parser, NAME_DESC_BOB + AMOUNT_DESC_BOB + INVALID_DATE_DESC
+                + CATEGORY_DESC_HUSBAND + CATEGORY_DESC_FRIEND, Date.MESSAGE_CONSTRAINTS);
+
+        // invalid category
+        assertParseFailure(parser, NAME_DESC_BOB + AMOUNT_DESC_BOB + DATE_DESC_BOB
+                + INVALID_CATEGORY_DESC + VALID_CATEGORY_FRIEND, Category.MESSAGE_CONSTRAINTS);
+
+        // two invalid values, only first invalid value reported
+        assertParseFailure(parser, INVALID_NAME_DESC + AMOUNT_DESC_BOB + INVALID_DATE_DESC,
+                Name.MESSAGE_CONSTRAINTS);
+
+        // non-empty preamble
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + AMOUNT_DESC_BOB + DATE_DESC_BOB
+                + CATEGORY_DESC_HUSBAND + CATEGORY_DESC_FRIEND,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddIncomeCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddressBookParserTest.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddIncomeCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ClearCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.DeleteCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.EditCommand;
@@ -21,7 +22,9 @@ import ay2021s1_cs2103_w16_3.finesse.logic.commands.ExitCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.FindCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.HelpCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListIncomeCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.NameContainsKeywordsPredicate;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import ay2021s1_cs2103_w16_3.finesse.testutil.EditTransactionDescriptorBuilder;
@@ -37,6 +40,13 @@ public class AddressBookParserTest {
         Transaction transaction = new TransactionBuilder().build();
         AddCommand command = (AddCommand) parser.parseCommand(TransactionUtil.getAddCommand(transaction));
         assertEquals(new AddCommand(transaction), command);
+    }
+
+    @Test
+    public void parseCommand_addIncome() throws Exception {
+        Income income = new TransactionBuilder().buildIncome();
+        AddIncomeCommand command = (AddIncomeCommand) parser.parseCommand(TransactionUtil.getAddIncomeCommand(income));
+        assertEquals(new AddIncomeCommand(income), command);
     }
 
     @Test
@@ -86,6 +96,12 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_listIncome() throws Exception {
+        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD) instanceof ListIncomeCommand);
+        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD + " 3") instanceof ListIncomeCommand);
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/testutil/TransactionBuilder.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/testutil/TransactionBuilder.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Name;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import ay2021s1_cs2103_w16_3.finesse.model.util.SampleDataUtil;
@@ -79,6 +80,10 @@ public class TransactionBuilder {
 
     public Transaction build() {
         return new Transaction(name, amount, date, categories);
+    }
+
+    public Income buildIncome() {
+        return new Income(name, amount, date, categories);
     }
 
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/testutil/TransactionUtil.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/testutil/TransactionUtil.java
@@ -8,8 +8,10 @@ import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_NAME;
 import java.util.Set;
 
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddIncomeCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.EditCommand;
 import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 
 /**
@@ -22,6 +24,13 @@ public class TransactionUtil {
      */
     public static String getAddCommand(Transaction transaction) {
         return AddCommand.COMMAND_WORD + " " + getTransactionDetails(transaction);
+    }
+
+    /**
+     * Returns an add income command string for adding the {@code transaction}.
+     */
+    public static String getAddIncomeCommand(Income income) {
+        return AddIncomeCommand.COMMAND_WORD + " " + getTransactionDetails(income);
     }
 
     /**


### PR DESCRIPTION
Resolves #55 

Known bug:
- An added `Income` will revert to a `Transaction` once the application closes. This is possibly due to the storage feature not being able to support subtypes of `Transaction` yet.

Pitest report: https://ay2021s1-cs2103t-w16-3.github.io/reports/pitest/202010041709/