### PR TITLE
Add meeting minutes for 6 October 2020

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -16,4 +16,4 @@ gem 'jekyll-readme-index'
 gem 'jekyll-titles-from-headings'
 gem 'jekyll-relative-links'
 gem 'wdm', '~> 0.1.0' if Gem.win_platform?
-gem 'jekyll-spaceship', '~> 0.9.2'
+gem 'jekyll-spaceship', git: 'https://github.com/AY2021S1-CS2103T-W16-3/jekyll-spaceship.git'

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/AY2021S1-CS2103T-W16-3/jekyll-spaceship.git
+  revision: 710f3039aa9a7f344079cb9bd9532778805eb7b8
+  specs:
+    jekyll-spaceship (0.9.2)
+      gemoji (~> 4.0.0.rc2)
+      jekyll (>= 3.6, < 5.0)
+      nokogiri (~> 1.6)
+      rainbow (~> 3.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -18,7 +28,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     ffi (1.12.2-x64-mingw32)
     forwardable-extended (2.6.0)
-    gemoji (3.0.1)
+    gemoji (4.0.0.rc2)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -58,11 +68,6 @@ GEM
       sass (~> 3.4)
     jekyll-seo-tag (2.6.1)
       jekyll (>= 3.3, < 5.0)
-    jekyll-spaceship (0.9.2)
-      gemoji (~> 3.0)
-      jekyll (>= 3.6, < 5.0)
-      nokogiri (~> 1.6)
-      rainbow (~> 3.0)
     jekyll-titles-from-headings (0.5.3)
       jekyll (>= 3.3, < 5.0)
     jekyll-watch (2.2.1)
@@ -79,7 +84,7 @@ GEM
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     multipart-post (2.1.1)
-    nokogiri (1.10.9-x64-mingw32)
+    nokogiri (1.10.10-x64-mingw32)
       mini_portile2 (~> 2.4.0)
     octokit (4.18.0)
       faraday (>= 0.9)
@@ -116,7 +121,7 @@ DEPENDENCIES
   jekyll-paginate
   jekyll-readme-index
   jekyll-relative-links
-  jekyll-spaceship (~> 0.9.2)
+  jekyll-spaceship!
   jekyll-titles-from-headings
   minima
   wdm (~> 0.1.0)

--- a/docs/minutes/20201006.md
+++ b/docs/minutes/20201006.md
@@ -1,0 +1,45 @@
+---
+layout: minutes
+date: 2020-10-06
+---
+
+### Usage of Labels
+
+- Bug&nbsp;:bug:&nbsp;: Unintended behaviour that needs to be addressed
+- Enhancement&nbsp;:+1:&nbsp;: Any improvements to the product
+- Documentation&nbsp;:roll_of_paper:&nbsp;: Improvements or additions to documentation
+- Task&nbsp;:clipboard:&nbsp;: None of the above labels
+
+### Progress Update
+
+- Siddarth
+  - Working on UI styling currently
+  - To put up a PR with the base UI structure as soon as possible so that integration can begin
+- Wei Liang
+  - Fix Amount and Date validation
+  - To put PR by 6 Oct, target to merge by 7 Oct
+- Yong Ping
+  - Added expense and income lists
+  - Currently modifying `FinanceTracker` to include expense and income lists
+  - Require “Fix Amount and Date validation” from Wei Liang
+- Jingjing
+  - Renamed address book
+  - Removed duplicate checks
+- Ian
+  - Done with tasks
+  - Waiting to start work on new features
+
+Pull Request Review SOP
+
+- Clone PR to local machine
+- Run system tests
+- Perform exploratory testing
+- If there are code changes, run **pitest** to make sure the code is properly covered by tests
+  - Compare report with master branch
+- Check diff on github
+  - Make sure there are no unintended changes
+  - Make sure that intended changes are there
+  - Check for typos
+  - Check for AB3 residue (fix-as-you-go policy)
+    - AddressBook names
+    - Javadocs (missing full stop, wrong documentation, grammar problems)


### PR DESCRIPTION
In order to support :roll_of_paper:, a forked version of the `jekyll-spaceship` gem that is using an updated version of the `gemoji` gem is being used. See AY2021S1-CS2103T-W16-3/jekyll-spaceship#2.