### PR TITLE
Modify storage to handle expense and income

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/FinanceTracker.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/FinanceTracker.java
@@ -4,6 +4,10 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.ExpenseList;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.IncomeList;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.TransactionList;
 import javafx.collections.ObservableList;
@@ -14,6 +18,8 @@ import javafx.collections.ObservableList;
 public class FinanceTracker implements ReadOnlyFinanceTracker {
 
     private final TransactionList transactions;
+    private final ExpenseList expenses;
+    private final IncomeList incomes;
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -24,6 +30,8 @@ public class FinanceTracker implements ReadOnlyFinanceTracker {
      */
     {
         transactions = new TransactionList();
+        expenses = new ExpenseList();
+        incomes = new IncomeList();
     }
 
     public FinanceTracker() {}
@@ -46,12 +54,28 @@ public class FinanceTracker implements ReadOnlyFinanceTracker {
     }
 
     /**
+     * Replaces the contents of the expense list with {@code expenses}.
+     */
+    public void setExpenses(List<Expense> expenses) {
+        this.expenses.setExpenses(expenses);
+    }
+
+    /**
+     * Replaces the contents of the income list with {@code incomes}.
+     */
+    public void setIncomes(List<Income> incomes) {
+        this.incomes.setIncomes(incomes);
+    }
+
+    /**
      * Resets the existing data of this {@code FinanceTracker} with {@code newData}.
      */
     public void resetData(ReadOnlyFinanceTracker newData) {
         requireNonNull(newData);
 
         setTransactions(newData.getTransactionList());
+        setExpenses(newData.getExpenseList());
+        setIncomes(newData.getIncomeList());
     }
 
     //// transaction-level operations
@@ -61,6 +85,20 @@ public class FinanceTracker implements ReadOnlyFinanceTracker {
      */
     public void addTransaction(Transaction transaction) {
         transactions.add(transaction);
+    }
+
+    /**
+     * Adds an expense to the finance tracker.
+     */
+    public void addExpense(Expense expense) {
+        expenses.add(expense);
+    }
+
+    /**
+     * Adds an income to the finance tracker.
+     */
+    public void addIncome(Income income) {
+        incomes.add(income);
     }
 
     /**
@@ -74,11 +112,47 @@ public class FinanceTracker implements ReadOnlyFinanceTracker {
     }
 
     /**
+     * Replaces the given expense {@code target} in the list with {@code editedExpense}.
+     * {@code target} must exist in the finance tracker.
+     */
+    public void setExpense(Expense target, Expense editedExpense) {
+        requireNonNull(editedExpense);
+
+        expenses.setExpense(target, editedExpense);
+    }
+
+    /**
+     * Replaces the given income {@code target} in the list with {@code editedIncome}.
+     * {@code target} must exist in the finance tracker.
+     */
+    public void setIncome(Income target, Income editedIncome) {
+        requireNonNull(editedIncome);
+
+        incomes.setIncome(target, editedIncome);
+    }
+
+    /**
      * Removes {@code key} from this {@code FinanceTracker}.
      * {@code key} must exist in the finance tracker.
      */
     public void removeTransaction(Transaction key) {
         transactions.remove(key);
+    }
+
+    /**
+     * Removes {@code key} from this {@code FinanceTracker}.
+     * {@code key} must exist in the finance tracker.
+     */
+    public void removeExpense(Expense key) {
+        expenses.remove(key);
+    }
+
+    /**
+     * Removes {@code key} from this {@code FinanceTracker}.
+     * {@code key} must exist in the finance tracker.
+     */
+    public void removeIncome(Income key) {
+        incomes.remove(key);
     }
 
     //// util methods
@@ -95,10 +169,22 @@ public class FinanceTracker implements ReadOnlyFinanceTracker {
     }
 
     @Override
+    public ObservableList<Expense> getExpenseList() {
+        return expenses.asUnmodifiableObservableList();
+    }
+
+    @Override
+    public ObservableList<Income> getIncomeList() {
+        return incomes.asUnmodifiableObservableList();
+    }
+
+    @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof FinanceTracker // instanceof handles nulls
-                && transactions.equals(((FinanceTracker) other).transactions));
+                && transactions.equals(((FinanceTracker) other).transactions)
+                && expenses.equals(((FinanceTracker) other).expenses)
+                && incomes.equals(((FinanceTracker) other).incomes));
     }
 
     @Override

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/ReadOnlyFinanceTracker.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/ReadOnlyFinanceTracker.java
@@ -1,5 +1,7 @@
 package ay2021s1_cs2103_w16_3.finesse.model;
 
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import javafx.collections.ObservableList;
 
@@ -13,4 +15,13 @@ public interface ReadOnlyFinanceTracker {
      */
     ObservableList<Transaction> getTransactionList();
 
+    /**
+     * Returns an unmodifiable view of the transactions list.
+     */
+    ObservableList<Expense> getExpenseList();
+
+    /**
+     * Returns an unmodifiable view of the transactions list.
+     */
+    ObservableList<Income> getIncomeList();
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/ExpenseList.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/ExpenseList.java
@@ -1,0 +1,100 @@
+package ay2021s1_cs2103_w16_3.finesse.model.transaction;
+
+import static ay2021s1_cs2103_w16_3.finesse.commons.util.CollectionUtil.requireAllNonNull;
+import static java.util.Objects.requireNonNull;
+
+import java.util.Iterator;
+import java.util.List;
+
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.exceptions.TransactionNotFoundException;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+/**
+ * A list of expenses that does not allow nulls.
+ * The removal of an expense uses Expense#equals(Object) so as to ensure that the expense with exactly the
+ * same fields will be removed.
+ *
+ * Supports a minimal set of list operations.
+ */
+public class ExpenseList implements Iterable<Expense> {
+
+    private final ObservableList<Expense> internalList = FXCollections.observableArrayList();
+    private final ObservableList<Expense> internalUnmodifiableList =
+            FXCollections.unmodifiableObservableList(internalList);
+
+    /**
+     * Adds a expense to the list.
+     */
+    public void add(Expense toAdd) {
+        requireNonNull(toAdd);
+        internalList.add(toAdd);
+    }
+
+    /**
+     * Replaces the expense {@code target} in the list with {@code editedExpense}.
+     * {@code target} must exist in the list.
+     * The expense identity of {@code editedExpense} must not be the same as another existing expense in
+     * the list.
+     */
+    public void setExpense(Expense target, Expense editedExpense) {
+        requireAllNonNull(target, editedExpense);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw new TransactionNotFoundException();
+        }
+
+        internalList.set(index, editedExpense);
+    }
+
+    /**
+     * Removes the equivalent expense from the list.
+     * The expense must exist in the list.
+     */
+    public void remove(Expense toRemove) {
+        requireNonNull(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throw new TransactionNotFoundException();
+        }
+    }
+
+    public void setExpenses(ExpenseList replacement) {
+        requireNonNull(replacement);
+        internalList.setAll(replacement.internalList);
+    }
+
+    /**
+     * Replaces the contents of this list with {@code expenses}.
+     */
+    public void setExpenses(List<Expense> expenses) {
+        requireAllNonNull(expenses);
+
+        internalList.setAll(expenses);
+    }
+
+    /**
+     * Returns the backing list as an unmodifiable {@code ObservableList}.
+     */
+    public ObservableList<Expense> asUnmodifiableObservableList() {
+        return internalUnmodifiableList;
+    }
+
+    @Override
+    public Iterator<Expense> iterator() {
+        return internalList.iterator();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ExpenseList // instanceof handles nulls
+                && internalList.equals(((ExpenseList) other).internalList));
+    }
+
+    @Override
+    public int hashCode() {
+        return internalList.hashCode();
+    }
+
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/IncomeList.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/IncomeList.java
@@ -1,0 +1,100 @@
+package ay2021s1_cs2103_w16_3.finesse.model.transaction;
+
+import static ay2021s1_cs2103_w16_3.finesse.commons.util.CollectionUtil.requireAllNonNull;
+import static java.util.Objects.requireNonNull;
+
+import java.util.Iterator;
+import java.util.List;
+
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.exceptions.TransactionNotFoundException;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+/**
+ * A list of incomes that does not allow nulls.
+ * The removal of an income uses Income#equals(Object) so as to ensure that the income with exactly the
+ * same fields will be removed.
+ *
+ * Supports a minimal set of list operations.
+ */
+public class IncomeList implements Iterable<Income> {
+
+    private final ObservableList<Income> internalList = FXCollections.observableArrayList();
+    private final ObservableList<Income> internalUnmodifiableList =
+            FXCollections.unmodifiableObservableList(internalList);
+
+    /**
+     * Adds a income to the list.
+     */
+    public void add(Income toAdd) {
+        requireNonNull(toAdd);
+        internalList.add(toAdd);
+    }
+
+    /**
+     * Replaces the income {@code target} in the list with {@code editedIncome}.
+     * {@code target} must exist in the list.
+     * The income identity of {@code editedIncome} must not be the same as another existing income in
+     * the list.
+     */
+    public void setIncome(Income target, Income editedIncome) {
+        requireAllNonNull(target, editedIncome);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw new TransactionNotFoundException();
+        }
+
+        internalList.set(index, editedIncome);
+    }
+
+    /**
+     * Removes the equivalent income from the list.
+     * The income must exist in the list.
+     */
+    public void remove(Income toRemove) {
+        requireNonNull(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throw new TransactionNotFoundException();
+        }
+    }
+
+    public void setIncomes(IncomeList replacement) {
+        requireNonNull(replacement);
+        internalList.setAll(replacement.internalList);
+    }
+
+    /**
+     * Replaces the contents of this list with {@code incomes}.
+     */
+    public void setIncomes(List<Income> incomes) {
+        requireAllNonNull(incomes);
+
+        internalList.setAll(incomes);
+    }
+
+    /**
+     * Returns the backing list as an unmodifiable {@code ObservableList}.
+     */
+    public ObservableList<Income> asUnmodifiableObservableList() {
+        return internalUnmodifiableList;
+    }
+
+    @Override
+    public Iterator<Income> iterator() {
+        return internalList.iterator();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof IncomeList // instanceof handles nulls
+                && internalList.equals(((IncomeList) other).internalList));
+    }
+
+    @Override
+    public int hashCode() {
+        return internalList.hashCode();
+    }
+
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/util/SampleDataUtil.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/util/SampleDataUtil.java
@@ -18,17 +18,17 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 public class SampleDataUtil {
     public static Transaction[] getSampleTransactions() {
         return new Transaction[] {
-            new Transaction(new Title("Alex Yeoh"), new Amount("87438807"), new Date("alexyeoh@example.com"),
+            new Transaction(new Title("Alex Yeoh"), new Amount("87438807"), new Date("01/01/2020"),
                 getCategoriesSet("friends")),
-            new Transaction(new Title("Bernice Yu"), new Amount("99272758"), new Date("berniceyu@example.com"),
+            new Transaction(new Title("Bernice Yu"), new Amount("99272758"), new Date("02/01/2020"),
                 getCategoriesSet("colleagues", "friends")),
-            new Transaction(new Title("Charlotte Oliveiro"), new Amount("93210283"), new Date("charlotte@example.com"),
+            new Transaction(new Title("Charlotte Oliveiro"), new Amount("93210283"), new Date("03/01/2020"),
                 getCategoriesSet("neighbours")),
-            new Transaction(new Title("David Li"), new Amount("91031282"), new Date("lidavid@example.com"),
+            new Transaction(new Title("David Li"), new Amount("91031282"), new Date("04/01/2020"),
                 getCategoriesSet("family")),
-            new Transaction(new Title("Irfan Ibrahim"), new Amount("92492021"), new Date("irfan@example.com"),
+            new Transaction(new Title("Irfan Ibrahim"), new Amount("92492021"), new Date("05/01/2020"),
                 getCategoriesSet("classmates")),
-            new Transaction(new Title("Roy Balakrishnan"), new Amount("92624417"), new Date("royb@example.com"),
+            new Transaction(new Title("Roy Balakrishnan"), new Amount("92624417"), new Date("06/01/2020"),
                 getCategoriesSet("colleagues"))
         };
     }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedExpense.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedExpense.java
@@ -1,0 +1,97 @@
+package ay2021s1_cs2103_w16_3.finesse.storage;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import ay2021s1_cs2103_w16_3.finesse.commons.exceptions.IllegalValueException;
+import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
+
+/**
+ * JSON-friendly version of {@link Expense}.
+ */
+class JsonAdaptedExpense {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Expense's %s field is missing!";
+
+    private final String title;
+    private final String amount;
+    private final String date;
+    private final List<JsonAdaptedCategory> categories = new ArrayList<>();
+
+    /**
+     * Constructs a {@code JsonAdaptedExpense} with the given transaction details.
+     */
+    @JsonCreator
+    public JsonAdaptedExpense(@JsonProperty("title") String title, @JsonProperty("amount") String amount,
+                                  @JsonProperty("date") String date,
+                                  @JsonProperty("categories") List<JsonAdaptedCategory> categories) {
+        this.title = title;
+        this.amount = amount;
+        this.date = date;
+        if (categories != null) {
+            this.categories.addAll(categories);
+        }
+    }
+
+    /**
+     * Converts a given {@code Expense} into this class for Jackson use.
+     */
+    public JsonAdaptedExpense(Expense source) {
+        title = source.getTitle().fullTitle;
+        amount = source.getAmount().value;
+        date = source.getDate().value;
+        categories.addAll(source.getCategories().stream()
+                .map(JsonAdaptedCategory::new)
+                .collect(Collectors.toList()));
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted expense object into the model's {@code Expense} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted transaction.
+     */
+    public Expense toModelType() throws IllegalValueException {
+        final List<Category> transactionCategories = new ArrayList<>();
+        for (JsonAdaptedCategory category : categories) {
+            transactionCategories.add(category.toModelType());
+        }
+
+        if (title == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Title.class.getSimpleName()));
+        }
+        if (!Title.isValidTitle(title)) {
+            throw new IllegalValueException(Title.MESSAGE_CONSTRAINTS);
+        }
+        final Title modelTitle = new Title(title);
+
+        if (amount == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Amount.class.getSimpleName()));
+        }
+        if (!Amount.isValidAmount(amount)) {
+            throw new IllegalValueException(Amount.MESSAGE_CONSTRAINTS);
+        }
+        final Amount modelAmount = new Amount(amount);
+
+        if (date == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Date.class.getSimpleName()));
+        }
+        if (!Date.isValidDate(date)) {
+            throw new IllegalValueException(Date.MESSAGE_CONSTRAINTS);
+        }
+        final Date modelDate = new Date(date);
+
+        final Set<Category> modelCategories = new HashSet<>(transactionCategories);
+        return new Expense(modelTitle, modelAmount, modelDate, modelCategories);
+    }
+
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedIncome.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedIncome.java
@@ -1,0 +1,97 @@
+package ay2021s1_cs2103_w16_3.finesse.storage;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import ay2021s1_cs2103_w16_3.finesse.commons.exceptions.IllegalValueException;
+import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
+
+/**
+ * JSON-friendly version of {@link Income}.
+ */
+class JsonAdaptedIncome {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Income's %s field is missing!";
+
+    private final String title;
+    private final String amount;
+    private final String date;
+    private final List<JsonAdaptedCategory> categories = new ArrayList<>();
+
+    /**
+     * Constructs a {@code JsonAdaptedIncome} with the given transaction details.
+     */
+    @JsonCreator
+    public JsonAdaptedIncome(@JsonProperty("title") String title, @JsonProperty("amount") String amount,
+                                  @JsonProperty("date") String date,
+                                  @JsonProperty("categories") List<JsonAdaptedCategory> categories) {
+        this.title = title;
+        this.amount = amount;
+        this.date = date;
+        if (categories != null) {
+            this.categories.addAll(categories);
+        }
+    }
+
+    /**
+     * Converts a given {@code Income} into this class for Jackson use.
+     */
+    public JsonAdaptedIncome(Income source) {
+        title = source.getTitle().fullTitle;
+        amount = source.getAmount().value;
+        date = source.getDate().value;
+        categories.addAll(source.getCategories().stream()
+                .map(JsonAdaptedCategory::new)
+                .collect(Collectors.toList()));
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted transaction object into the model's {@code Income} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted transaction.
+     */
+    public Income toModelType() throws IllegalValueException {
+        final List<Category> transactionCategories = new ArrayList<>();
+        for (JsonAdaptedCategory category : categories) {
+            transactionCategories.add(category.toModelType());
+        }
+
+        if (title == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Title.class.getSimpleName()));
+        }
+        if (!Title.isValidTitle(title)) {
+            throw new IllegalValueException(Title.MESSAGE_CONSTRAINTS);
+        }
+        final Title modelTitle = new Title(title);
+
+        if (amount == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Amount.class.getSimpleName()));
+        }
+        if (!Amount.isValidAmount(amount)) {
+            throw new IllegalValueException(Amount.MESSAGE_CONSTRAINTS);
+        }
+        final Amount modelAmount = new Amount(amount);
+
+        if (date == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Date.class.getSimpleName()));
+        }
+        if (!Date.isValidDate(date)) {
+            throw new IllegalValueException(Date.MESSAGE_CONSTRAINTS);
+        }
+        final Date modelDate = new Date(date);
+
+        final Set<Category> modelCategories = new HashSet<>(transactionCategories);
+        return new Income(modelTitle, modelAmount, modelDate, modelCategories);
+    }
+
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonSerializableFinanceTracker.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonSerializableFinanceTracker.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import ay2021s1_cs2103_w16_3.finesse.commons.exceptions.IllegalValueException;
 import ay2021s1_cs2103_w16_3.finesse.model.FinanceTracker;
 import ay2021s1_cs2103_w16_3.finesse.model.ReadOnlyFinanceTracker;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 
 /**
@@ -20,13 +22,19 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 class JsonSerializableFinanceTracker {
 
     private final List<JsonAdaptedTransaction> transactions = new ArrayList<>();
+    private final List<JsonAdaptedExpense> expenses = new ArrayList<>();
+    private final List<JsonAdaptedIncome> incomes = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonSerializableFinanceTracker} with the given transactions.
      */
     @JsonCreator
-    public JsonSerializableFinanceTracker(@JsonProperty("transactions") List<JsonAdaptedTransaction> transactions) {
+    public JsonSerializableFinanceTracker(@JsonProperty("transactions") List<JsonAdaptedTransaction> transactions,
+                                          @JsonProperty("expenses") List<JsonAdaptedExpense> expenses,
+                                          @JsonProperty("incomes") List<JsonAdaptedIncome> incomes) {
         this.transactions.addAll(transactions);
+        this.expenses.addAll(expenses);
+        this.incomes.addAll(incomes);
     }
 
     /**
@@ -36,6 +44,10 @@ class JsonSerializableFinanceTracker {
      */
     public JsonSerializableFinanceTracker(ReadOnlyFinanceTracker source) {
         transactions.addAll(source.getTransactionList().stream().map(JsonAdaptedTransaction::new)
+                .collect(Collectors.toList()));
+        expenses.addAll(source.getExpenseList().stream().map(JsonAdaptedExpense::new)
+                .collect(Collectors.toList()));
+        incomes.addAll(source.getIncomeList().stream().map(JsonAdaptedIncome::new)
                 .collect(Collectors.toList()));
     }
 
@@ -49,6 +61,14 @@ class JsonSerializableFinanceTracker {
         for (JsonAdaptedTransaction jsonAdaptedTransaction : transactions) {
             Transaction transaction = jsonAdaptedTransaction.toModelType();
             financeTracker.addTransaction(transaction);
+        }
+        for (JsonAdaptedExpense jsonAdaptedExpense : expenses) {
+            Expense expense = jsonAdaptedExpense.toModelType();
+            financeTracker.addExpense(expense);
+        }
+        for (JsonAdaptedIncome jsonAdaptedIncome : incomes) {
+            Income income = jsonAdaptedIncome.toModelType();
+            financeTracker.addIncome(income);
         }
         return financeTracker;
     }

--- a/src/test/data/JsonSerializableFinanceTrackerTest/invalidPersonFinanceTracker.json
+++ b/src/test/data/JsonSerializableFinanceTrackerTest/invalidPersonFinanceTracker.json
@@ -3,5 +3,15 @@
     "title": "Hans Muster",
     "amount": "9482424",
     "date": "invalid@email!3e"
+  } ],
+  "expenses": [ {
+    "title": "Hans Muster",
+    "amount": "9482424",
+    "date": "invalid@email!3e"
+  } ],
+  "incomes": [ {
+    "title": "Hans Muster",
+    "amount": "9482424",
+    "date": "invalid@email!3e"
   } ]
 }

--- a/src/test/data/JsonSerializableFinanceTrackerTest/typicalPersonsFinanceTracker.json
+++ b/src/test/data/JsonSerializableFinanceTrackerTest/typicalPersonsFinanceTracker.json
@@ -35,5 +35,77 @@
     "amount" : "7",
     "date" : "06/10/2020",
     "categories" : [ ]
+  } ],
+  "expenses" : [ {
+    "title" : "Alice Pauline",
+    "amount" : "$1",
+    "date" : "06/09/2020",
+    "categories" : [ "friends" ]
+  }, {
+    "title" : "Benson Meier",
+    "amount" : "2",
+    "date" : "05/10/2020",
+    "categories" : [ "owesMoney", "friends" ]
+  }, {
+    "title" : "Carl Kurz",
+    "amount" : "3.50",
+    "date" : "06/10/2020",
+    "categories" : [ ]
+  }, {
+    "title" : "Daniel Meier",
+    "amount" : "4",
+    "date" : "06/10/2020",
+    "categories" : [ "friends" ]
+  }, {
+    "title" : "Elle Meyer",
+    "amount" : "5",
+    "date" : "06/10/2020",
+    "categories" : [ ]
+  }, {
+    "title" : "Fiona Kunz",
+    "amount" : "6",
+    "date" : "06/10/2020",
+    "categories" : [ ]
+  }, {
+    "title" : "George Best",
+    "amount" : "7",
+    "date" : "06/10/2020",
+    "categories" : [ ]
+  } ],
+  "incomes" : [ {
+    "title" : "Alice Pauline",
+    "amount" : "$1",
+    "date" : "06/09/2020",
+    "categories" : [ "friends" ]
+  }, {
+    "title" : "Benson Meier",
+    "amount" : "2",
+    "date" : "05/10/2020",
+    "categories" : [ "owesMoney", "friends" ]
+  }, {
+    "title" : "Carl Kurz",
+    "amount" : "3.50",
+    "date" : "06/10/2020",
+    "categories" : [ ]
+  }, {
+    "title" : "Daniel Meier",
+    "amount" : "4",
+    "date" : "06/10/2020",
+    "categories" : [ "friends" ]
+  }, {
+    "title" : "Elle Meyer",
+    "amount" : "5",
+    "date" : "06/10/2020",
+    "categories" : [ ]
+  }, {
+    "title" : "Fiona Kunz",
+    "amount" : "6",
+    "date" : "06/10/2020",
+    "categories" : [ ]
+  }, {
+    "title" : "George Best",
+    "amount" : "7",
+    "date" : "06/10/2020",
+    "categories" : [ ]
   } ]
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/FinanceTrackerTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/FinanceTrackerTest.java
@@ -34,4 +34,13 @@ public class FinanceTrackerTest {
         assertThrows(UnsupportedOperationException.class, () -> financeTracker.getTransactionList().remove(0));
     }
 
+    @Test
+    public void getExpenseList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> financeTracker.getExpenseList().remove(0));
+    }
+
+    @Test
+    public void getIncomeList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> financeTracker.getIncomeList().remove(0));
+    }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/ExpenseListTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/ExpenseListTest.java
@@ -1,0 +1,125 @@
+package ay2021s1_cs2103_w16_3.finesse.model.transaction;
+
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_CATEGORY_HUSBAND;
+import static ay2021s1_cs2103_w16_3.finesse.testutil.Assert.assertThrows;
+import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.ALICE;
+import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.BOB;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.exceptions.TransactionNotFoundException;
+import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
+
+public class ExpenseListTest {
+
+    private static final Expense ALICE_EXPENSE = new TransactionBuilder(ALICE).buildExpense();
+    private static final Expense BOB_EXPENSE = new TransactionBuilder(BOB).buildExpense();
+
+    private final ExpenseList expenseList = new ExpenseList();
+
+    @Test
+    public void add_nullExpense_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> expenseList.add(null));
+    }
+
+    @Test
+    public void setExpense_nullTargetExpense_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> expenseList.setExpense(null, ALICE_EXPENSE));
+    }
+
+    @Test
+    public void setExpense_nullEditedExpense_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> expenseList.setExpense(ALICE_EXPENSE, null));
+    }
+
+    @Test
+    public void setExpense_targetExpenseNotInList_throwsTransactionNotFoundException() {
+        assertThrows(TransactionNotFoundException.class, () -> expenseList.setExpense(ALICE_EXPENSE, ALICE_EXPENSE));
+    }
+
+    @Test
+    public void setExpense_editedExpenseIsSameExpense_success() {
+        expenseList.add(ALICE_EXPENSE);
+        expenseList.setExpense(ALICE_EXPENSE, ALICE_EXPENSE);
+        ExpenseList expectedExpenseList = new ExpenseList();
+        expectedExpenseList.add(ALICE_EXPENSE);
+        assertEquals(expectedExpenseList, expenseList);
+    }
+
+    @Test
+    public void setExpense_editedExpenseHasSameIdentity_success() {
+        expenseList.add(ALICE_EXPENSE);
+        Expense editedAlice = new TransactionBuilder(ALICE).withCategories(VALID_CATEGORY_HUSBAND).buildExpense();
+        expenseList.setExpense(ALICE_EXPENSE, editedAlice);
+        ExpenseList expectedExpenseList = new ExpenseList();
+        expectedExpenseList.add(editedAlice);
+        assertEquals(expectedExpenseList, expenseList);
+    }
+
+    @Test
+    public void setExpense_editedExpenseHasDifferentIdentity_success() {
+        expenseList.add(ALICE_EXPENSE);
+        expenseList.setExpense(ALICE_EXPENSE, BOB_EXPENSE);
+        ExpenseList expectedExpenseList = new ExpenseList();
+        expectedExpenseList.add(BOB_EXPENSE);
+        assertEquals(expectedExpenseList, expenseList);
+    }
+
+    @Test
+    public void remove_nullExpense_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> expenseList.remove(null));
+    }
+
+    @Test
+    public void remove_expenseDoesNotExist_throwsTransactionNotFoundException() {
+        assertThrows(TransactionNotFoundException.class, () -> expenseList.remove(ALICE_EXPENSE));
+    }
+
+    @Test
+    public void remove_existingExpense_removesExpense() {
+        expenseList.add(ALICE_EXPENSE);
+        expenseList.remove(ALICE_EXPENSE);
+        ExpenseList expectedExpenseList = new ExpenseList();
+        assertEquals(expectedExpenseList, expenseList);
+    }
+
+    @Test
+    public void setExpenses_nullExpenseList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, ()
+            -> expenseList.setExpenses((ExpenseList) null));
+    }
+
+    @Test
+    public void setExpenses_expenseList_replacesOwnListWithProvidedExpenseList() {
+        expenseList.add(ALICE_EXPENSE);
+        ExpenseList expectedExpenseList = new ExpenseList();
+        expectedExpenseList.add(BOB_EXPENSE);
+        expenseList.setExpenses(expectedExpenseList);
+        assertEquals(expectedExpenseList, expenseList);
+    }
+
+    @Test
+    public void setExpenses_nullList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> expenseList.setExpenses((List<Expense>) null));
+    }
+
+    @Test
+    public void setExpenses_list_replacesOwnListWithProvidedList() {
+        expenseList.add(ALICE_EXPENSE);
+        List<Expense> expenseList = Collections.singletonList(BOB_EXPENSE);
+        this.expenseList.setExpenses(expenseList);
+        ExpenseList expectedExpenseList = new ExpenseList();
+        expectedExpenseList.add(BOB_EXPENSE);
+        assertEquals(expectedExpenseList, this.expenseList);
+    }
+
+    @Test
+    public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, ()
+            -> expenseList.asUnmodifiableObservableList().remove(0));
+    }
+}

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/IncomeListTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/IncomeListTest.java
@@ -1,0 +1,125 @@
+package ay2021s1_cs2103_w16_3.finesse.model.transaction;
+
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_CATEGORY_HUSBAND;
+import static ay2021s1_cs2103_w16_3.finesse.testutil.Assert.assertThrows;
+import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.ALICE;
+import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.BOB;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.exceptions.TransactionNotFoundException;
+import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
+
+public class IncomeListTest {
+
+    private static final Income ALICE_INCOME = new TransactionBuilder(ALICE).buildIncome();
+    private static final Income BOB_INCOME = new TransactionBuilder(BOB).buildIncome();
+
+    private final IncomeList incomeList = new IncomeList();
+
+    @Test
+    public void add_nullIncome_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> incomeList.add(null));
+    }
+
+    @Test
+    public void setIncome_nullTargetIncome_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> incomeList.setIncome(null, ALICE_INCOME));
+    }
+
+    @Test
+    public void setIncome_nullEditedIncome_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> incomeList.setIncome(ALICE_INCOME, null));
+    }
+
+    @Test
+    public void setIncome_targetIncomeNotInList_throwsTransactionNotFoundException() {
+        assertThrows(TransactionNotFoundException.class, () -> incomeList.setIncome(ALICE_INCOME, ALICE_INCOME));
+    }
+
+    @Test
+    public void setIncome_editedIncomeIsSameIncome_success() {
+        incomeList.add(ALICE_INCOME);
+        incomeList.setIncome(ALICE_INCOME, ALICE_INCOME);
+        IncomeList expectedIncomeList = new IncomeList();
+        expectedIncomeList.add(ALICE_INCOME);
+        assertEquals(expectedIncomeList, incomeList);
+    }
+
+    @Test
+    public void setIncome_editedIncomeHasSameIdentity_success() {
+        incomeList.add(ALICE_INCOME);
+        Income editedAlice = new TransactionBuilder(ALICE).withCategories(VALID_CATEGORY_HUSBAND).buildIncome();
+        incomeList.setIncome(ALICE_INCOME, editedAlice);
+        IncomeList expectedIncomeList = new IncomeList();
+        expectedIncomeList.add(editedAlice);
+        assertEquals(expectedIncomeList, incomeList);
+    }
+
+    @Test
+    public void setIncome_editedIncomeHasDifferentIdentity_success() {
+        incomeList.add(ALICE_INCOME);
+        incomeList.setIncome(ALICE_INCOME, BOB_INCOME);
+        IncomeList expectedIncomeList = new IncomeList();
+        expectedIncomeList.add(BOB_INCOME);
+        assertEquals(expectedIncomeList, incomeList);
+    }
+
+    @Test
+    public void remove_nullIncome_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> incomeList.remove(null));
+    }
+
+    @Test
+    public void remove_incomeDoesNotExist_throwsTransactionNotFoundException() {
+        assertThrows(TransactionNotFoundException.class, () -> incomeList.remove(ALICE_INCOME));
+    }
+
+    @Test
+    public void remove_existingIncome_removesIncome() {
+        incomeList.add(ALICE_INCOME);
+        incomeList.remove(ALICE_INCOME);
+        IncomeList expectedIncomeList = new IncomeList();
+        assertEquals(expectedIncomeList, incomeList);
+    }
+
+    @Test
+    public void setIncomes_nullIncomeList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, ()
+            -> incomeList.setIncomes((IncomeList) null));
+    }
+
+    @Test
+    public void setIncomes_incomeList_replacesOwnListWithProvidedIncomeList() {
+        incomeList.add(ALICE_INCOME);
+        IncomeList expectedIncomeList = new IncomeList();
+        expectedIncomeList.add(BOB_INCOME);
+        incomeList.setIncomes(expectedIncomeList);
+        assertEquals(expectedIncomeList, incomeList);
+    }
+
+    @Test
+    public void setIncomes_nullList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> incomeList.setIncomes((List<Income>) null));
+    }
+
+    @Test
+    public void setIncomes_list_replacesOwnListWithProvidedList() {
+        incomeList.add(ALICE_INCOME);
+        List<Income> incomeList = Collections.singletonList(BOB_INCOME);
+        this.incomeList.setIncomes(incomeList);
+        IncomeList expectedIncomeList = new IncomeList();
+        expectedIncomeList.add(BOB_INCOME);
+        assertEquals(expectedIncomeList, this.incomeList);
+    }
+
+    @Test
+    public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, ()
+            -> incomeList.asUnmodifiableObservableList().remove(0));
+    }
+}

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedExpenseTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedExpenseTest.java
@@ -1,0 +1,98 @@
+package ay2021s1_cs2103_w16_3.finesse.storage;
+
+import static ay2021s1_cs2103_w16_3.finesse.storage.JsonAdaptedExpense.MISSING_FIELD_MESSAGE_FORMAT;
+import static ay2021s1_cs2103_w16_3.finesse.testutil.Assert.assertThrows;
+import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.BENSON;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import ay2021s1_cs2103_w16_3.finesse.commons.exceptions.IllegalValueException;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
+import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
+
+public class JsonAdaptedExpenseTest {
+    private static final String INVALID_TITLE = "R@chel";
+    private static final String INVALID_AMOUNT = "+651234";
+    private static final String INVALID_DATE = "example.com";
+    private static final String INVALID_CATEGORY = "#friend";
+
+    private static final String VALID_TITLE = BENSON.getTitle().toString();
+    private static final String VALID_AMOUNT = BENSON.getAmount().toString();
+    private static final String VALID_DATE = BENSON.getDate().toString();
+    private static final List<JsonAdaptedCategory> VALID_CATEGORIES = BENSON.getCategories().stream()
+            .map(JsonAdaptedCategory::new)
+            .collect(Collectors.toList());
+
+    @Test
+    public void toModelType_validExpenseDetails_returnsExpense() throws Exception {
+        Expense expenseBenson = new TransactionBuilder(BENSON).buildExpense();
+        JsonAdaptedExpense expense = new JsonAdaptedExpense(expenseBenson);
+        assertEquals(expenseBenson, expense.toModelType());
+    }
+
+    @Test
+    public void toModelType_invalidTitle_throwsIllegalValueException() {
+        JsonAdaptedExpense expense =
+                new JsonAdaptedExpense(INVALID_TITLE, VALID_AMOUNT, VALID_DATE, VALID_CATEGORIES);
+        String expectedMessage = Title.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, expense::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullTitle_throwsIllegalValueException() {
+        JsonAdaptedExpense expense = new JsonAdaptedExpense(null, VALID_AMOUNT, VALID_DATE,
+                VALID_CATEGORIES);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Title.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, expense::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidAmount_throwsIllegalValueException() {
+        JsonAdaptedExpense expense =
+                new JsonAdaptedExpense(VALID_TITLE, INVALID_AMOUNT, VALID_DATE, VALID_CATEGORIES);
+        String expectedMessage = Amount.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, expense::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullAmount_throwsIllegalValueException() {
+        JsonAdaptedExpense expense = new JsonAdaptedExpense(VALID_TITLE, null, VALID_DATE,
+                VALID_CATEGORIES);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Amount.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, expense::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidDate_throwsIllegalValueException() {
+        JsonAdaptedExpense expense =
+                new JsonAdaptedExpense(VALID_TITLE, VALID_AMOUNT, INVALID_DATE, VALID_CATEGORIES);
+        String expectedMessage = Date.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, expense::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullDate_throwsIllegalValueException() {
+        JsonAdaptedExpense expense = new JsonAdaptedExpense(VALID_TITLE, VALID_AMOUNT, null,
+                VALID_CATEGORIES);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Date.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, expense::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidCategories_throwsIllegalValueException() {
+        List<JsonAdaptedCategory> invalidCategories = new ArrayList<>(VALID_CATEGORIES);
+        invalidCategories.add(new JsonAdaptedCategory(INVALID_CATEGORY));
+        JsonAdaptedExpense expense =
+                new JsonAdaptedExpense(VALID_TITLE, VALID_AMOUNT, VALID_DATE, invalidCategories);
+        assertThrows(IllegalValueException.class, expense::toModelType);
+    }
+
+}

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedIncomeTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedIncomeTest.java
@@ -1,0 +1,98 @@
+package ay2021s1_cs2103_w16_3.finesse.storage;
+
+import static ay2021s1_cs2103_w16_3.finesse.storage.JsonAdaptedIncome.MISSING_FIELD_MESSAGE_FORMAT;
+import static ay2021s1_cs2103_w16_3.finesse.testutil.Assert.assertThrows;
+import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.BENSON;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import ay2021s1_cs2103_w16_3.finesse.commons.exceptions.IllegalValueException;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
+import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
+
+public class JsonAdaptedIncomeTest {
+    private static final String INVALID_TITLE = "R@chel";
+    private static final String INVALID_AMOUNT = "+651234";
+    private static final String INVALID_DATE = "example.com";
+    private static final String INVALID_CATEGORY = "#friend";
+
+    private static final String VALID_TITLE = BENSON.getTitle().toString();
+    private static final String VALID_AMOUNT = BENSON.getAmount().toString();
+    private static final String VALID_DATE = BENSON.getDate().toString();
+    private static final List<JsonAdaptedCategory> VALID_CATEGORIES = BENSON.getCategories().stream()
+            .map(JsonAdaptedCategory::new)
+            .collect(Collectors.toList());
+
+    @Test
+    public void toModelType_validIncomeDetails_returnsIncome() throws Exception {
+        Income bensonIncome = new TransactionBuilder(BENSON).buildIncome();
+        JsonAdaptedIncome income = new JsonAdaptedIncome(bensonIncome);
+        assertEquals(bensonIncome, income.toModelType());
+    }
+
+    @Test
+    public void toModelType_invalidTitle_throwsIllegalValueException() {
+        JsonAdaptedIncome income =
+                new JsonAdaptedIncome(INVALID_TITLE, VALID_AMOUNT, VALID_DATE, VALID_CATEGORIES);
+        String expectedMessage = Title.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, income::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullTitle_throwsIllegalValueException() {
+        JsonAdaptedIncome income = new JsonAdaptedIncome(null, VALID_AMOUNT, VALID_DATE,
+                VALID_CATEGORIES);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Title.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, income::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidAmount_throwsIllegalValueException() {
+        JsonAdaptedIncome income =
+                new JsonAdaptedIncome(VALID_TITLE, INVALID_AMOUNT, VALID_DATE, VALID_CATEGORIES);
+        String expectedMessage = Amount.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, income::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullAmount_throwsIllegalValueException() {
+        JsonAdaptedIncome income = new JsonAdaptedIncome(VALID_TITLE, null, VALID_DATE,
+                VALID_CATEGORIES);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Amount.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, income::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidDate_throwsIllegalValueException() {
+        JsonAdaptedIncome income =
+                new JsonAdaptedIncome(VALID_TITLE, VALID_AMOUNT, INVALID_DATE, VALID_CATEGORIES);
+        String expectedMessage = Date.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, income::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullDate_throwsIllegalValueException() {
+        JsonAdaptedIncome income = new JsonAdaptedIncome(VALID_TITLE, VALID_AMOUNT, null,
+                VALID_CATEGORIES);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Date.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, income::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidCategories_throwsIllegalValueException() {
+        List<JsonAdaptedCategory> invalidCategories = new ArrayList<>(VALID_CATEGORIES);
+        invalidCategories.add(new JsonAdaptedCategory(INVALID_CATEGORY));
+        JsonAdaptedIncome income =
+                new JsonAdaptedIncome(VALID_TITLE, VALID_AMOUNT, VALID_DATE, invalidCategories);
+        assertThrows(IllegalValueException.class, income::toModelType);
+    }
+
+}

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/testutil/TypicalTransactions.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/testutil/TypicalTransactions.java
@@ -79,7 +79,7 @@ public class TypicalTransactions {
                 .map(TransactionBuilder::buildExpense)
                 .collect(Collectors.toList());
     }
-    
+
     public static List<Income> getTypicalIncomes() {
         return getTypicalTransactions().stream()
                 .map(TransactionBuilder::new)

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/testutil/TypicalTransactions.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/testutil/TypicalTransactions.java
@@ -79,6 +79,7 @@ public class TypicalTransactions {
                 .map(TransactionBuilder::buildExpense)
                 .collect(Collectors.toList());
     }
+    
     public static List<Income> getTypicalIncomes() {
         return getTypicalTransactions().stream()
                 .map(TransactionBuilder::new)

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/testutil/TypicalTransactions.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/testutil/TypicalTransactions.java
@@ -12,6 +12,7 @@ import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import ay2021s1_cs2103_w16_3.finesse.model.FinanceTracker;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
@@ -73,18 +74,15 @@ public class TypicalTransactions {
     }
 
     public static List<Expense> getTypicalExpenses() {
-        List<Expense> typicalExpenses = new ArrayList<>();
-        for (Transaction transaction : getTypicalTransactions()) {
-            typicalExpenses.add(new TransactionBuilder(transaction).buildExpense());
-        }
-        return typicalExpenses;
+        return getTypicalTransactions().stream()
+                .map(TransactionBuilder::new)
+                .map(TransactionBuilder::buildExpense)
+                .collect(Collectors.toList());
     }
-
     public static List<Income> getTypicalIncomes() {
-        List<Income> typicalIncomes = new ArrayList<>();
-        for (Transaction transaction : getTypicalTransactions()) {
-            typicalIncomes.add(new TransactionBuilder(transaction).buildIncome());
-        }
-        return typicalIncomes;
+        return getTypicalTransactions().stream()
+                .map(TransactionBuilder::new)
+                .map(TransactionBuilder::buildIncome)
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/testutil/TypicalTransactions.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/testutil/TypicalTransactions.java
@@ -14,6 +14,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import ay2021s1_cs2103_w16_3.finesse.model.FinanceTracker;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 
 /**
@@ -60,11 +62,29 @@ public class TypicalTransactions {
         FinanceTracker ft = new FinanceTracker();
         for (Transaction transaction : getTypicalTransactions()) {
             ft.addTransaction(transaction);
+            ft.addExpense(new TransactionBuilder(transaction).buildExpense());
+            ft.addIncome(new TransactionBuilder(transaction).buildIncome());
         }
         return ft;
     }
 
     public static List<Transaction> getTypicalTransactions() {
         return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
+    }
+
+    public static List<Expense> getTypicalExpenses() {
+        List<Expense> typicalExpenses = new ArrayList<>();
+        for (Transaction transaction : getTypicalTransactions()) {
+            typicalExpenses.add(new TransactionBuilder(transaction).buildExpense());
+        }
+        return typicalExpenses;
+    }
+
+    public static List<Income> getTypicalIncomes() {
+        List<Income> typicalIncomes = new ArrayList<>();
+        for (Transaction transaction : getTypicalTransactions()) {
+            typicalIncomes.add(new TransactionBuilder(transaction).buildIncome());
+        }
+        return typicalIncomes;
     }
 }


### PR DESCRIPTION
Partially addresses #59.

`JSON` data files now require `"transactions"`, `"expenses"` and `"incomes"` fields. `"transactions"` will be removed in a future PR. Loading and saving of current data reflects this structure.

Adding expenses and incomes does not work yet, since they are still added to transaction list, instead of expense and income lists.
