### PR TITLE
Modify Logic and Model to handle expense and income

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/Logic.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/Logic.java
@@ -7,6 +7,8 @@ import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
 import ay2021s1_cs2103_w16_3.finesse.model.ReadOnlyFinanceTracker;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import javafx.collections.ObservableList;
 
@@ -32,6 +34,12 @@ public interface Logic {
 
     /** Returns an unmodifiable view of the filtered list of transactions */
     ObservableList<Transaction> getFilteredTransactionList();
+
+    /** Returns an unmodifiable view of the filtered list of expenses */
+    ObservableList<Expense> getFilteredExpenseList();
+
+    /** Returns an unmodifiable view of the filtered list of incomes */
+    ObservableList<Income> getFilteredIncomeList();
 
     /**
      * Returns the user prefs' finance tracker file path.

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/Logic.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/Logic.java
@@ -13,7 +13,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import javafx.collections.ObservableList;
 
 /**
- * API of the Logic component
+ * API of the Logic component.
  */
 public interface Logic {
     /**
@@ -32,13 +32,13 @@ public interface Logic {
      */
     ReadOnlyFinanceTracker getFinanceTracker();
 
-    /** Returns an unmodifiable view of the filtered list of transactions */
+    /** Returns an unmodifiable view of the filtered list of transactions. */
     ObservableList<Transaction> getFilteredTransactionList();
 
-    /** Returns an unmodifiable view of the filtered list of expenses */
+    /** Returns an unmodifiable view of the filtered list of expenses. */
     ObservableList<Expense> getFilteredExpenseList();
 
-    /** Returns an unmodifiable view of the filtered list of incomes */
+    /** Returns an unmodifiable view of the filtered list of incomes. */
     ObservableList<Income> getFilteredIncomeList();
 
     /**

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/LogicManager.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/LogicManager.java
@@ -13,6 +13,8 @@ import ay2021s1_cs2103_w16_3.finesse.logic.parser.FinanceTrackerParser;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.ReadOnlyFinanceTracker;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import ay2021s1_cs2103_w16_3.finesse.storage.Storage;
 import javafx.collections.ObservableList;
@@ -62,6 +64,16 @@ public class LogicManager implements Logic {
     @Override
     public ObservableList<Transaction> getFilteredTransactionList() {
         return model.getFilteredTransactionList();
+    }
+
+    @Override
+    public ObservableList<Expense> getFilteredExpenseList() {
+        return model.getFilteredExpenseList();
+    }
+
+    @Override
+    public ObservableList<Income> getFilteredIncomeList() {
+        return model.getFilteredIncomeList();
     }
 
     @Override

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddExpenseCommand.java
@@ -45,7 +45,7 @@ public class AddExpenseCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
 
-        model.addTransaction(toAdd);
+        model.addExpense(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddExpenseCommand.java
@@ -34,7 +34,7 @@ public class AddExpenseCommand extends Command {
     private final Expense toAdd;
 
     /**
-     * Creates an AddExpenseCommand to add the specified {@code Expense}
+     * Creates an AddExpenseCommand to add the specified {@code Expense}.
      */
     public AddExpenseCommand(Expense expense) {
         requireNonNull(expense);

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommand.java
@@ -45,7 +45,7 @@ public class AddIncomeCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
 
-        model.addTransaction(toAdd);
+        model.addIncome(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommand.java
@@ -34,7 +34,7 @@ public class AddIncomeCommand extends Command {
     private final Income toAdd;
 
     /**
-     * Creates an AddIncomeCommand to add the specified {@code Income}
+     * Creates an AddIncomeCommand to add the specified {@code Income}.
      */
     public AddIncomeCommand(Income income) {
         requireNonNull(income);

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/Model.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/Model.java
@@ -4,6 +4,8 @@ import java.nio.file.Path;
 import java.util.function.Predicate;
 
 import ay2021s1_cs2103_w16_3.finesse.commons.core.GuiSettings;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import javafx.collections.ObservableList;
 
@@ -59,9 +61,31 @@ public interface Model {
     void deleteTransaction(Transaction target);
 
     /**
+     * Deletes the given expense.
+     * The expense must exist in the finance tracker.
+     */
+    void deleteExpense(Expense target);
+
+    /**
+     * Deletes the given income.
+     * The income must exist in the finance tracker.
+     */
+    void deleteIncome(Income target);
+
+    /**
      * Adds the given transaction.
      */
     void addTransaction(Transaction transaction);
+
+    /**
+     * Adds the given expense.
+     */
+    void addExpense(Expense expense);
+
+    /**
+     * Adds the given income.
+     */
+    void addIncome(Income income);
 
     /**
      * Replaces the given transaction {@code target} with {@code editedTransaction}.
@@ -69,12 +93,42 @@ public interface Model {
      */
     void setTransaction(Transaction target, Transaction editedTransaction);
 
+    /**
+     * Replaces the given expense {@code target} with {@code editedExpense}.
+     * {@code target} must exist in the finance tracker.
+     */
+    void setExpense(Expense target, Expense editedExpense);
+
+    /**
+     * Replaces the given income {@code target} with {@code editedIncome}.
+     * {@code target} must exist in the finance tracker.
+     */
+    void setIncome(Income target, Income editedIncome);
+
     /** Returns an unmodifiable view of the filtered transaction list */
     ObservableList<Transaction> getFilteredTransactionList();
+
+    /** Returns an unmodifiable view of the filtered expense list */
+    ObservableList<Expense> getFilteredExpenseList();
+
+    /** Returns an unmodifiable view of the filtered income list */
+    ObservableList<Income> getFilteredIncomeList();
 
     /**
      * Updates the filter of the filtered transaction list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredTransactionList(Predicate<Transaction> predicate);
+
+    /**
+     * Updates the filter of the filtered expense list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredExpenseList(Predicate<Transaction> predicate);
+
+    /**
+     * Updates the filter of the filtered income list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredIncomeList(Predicate<Transaction> predicate);
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/Model.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/Model.java
@@ -13,7 +13,7 @@ import javafx.collections.ObservableList;
  * The API of the Model component.
  */
 public interface Model {
-    /** {@code Predicate} that always evaluate to true */
+    /** {@code Predicate} that always evaluate to true. */
     Predicate<Transaction> PREDICATE_SHOW_ALL_TRANSACTIONS = unused -> true;
 
     /**
@@ -105,13 +105,13 @@ public interface Model {
      */
     void setIncome(Income target, Income editedIncome);
 
-    /** Returns an unmodifiable view of the filtered transaction list */
+    /** Returns an unmodifiable view of the filtered transaction list. */
     ObservableList<Transaction> getFilteredTransactionList();
 
-    /** Returns an unmodifiable view of the filtered expense list */
+    /** Returns an unmodifiable view of the filtered expense list. */
     ObservableList<Expense> getFilteredExpenseList();
 
-    /** Returns an unmodifiable view of the filtered income list */
+    /** Returns an unmodifiable view of the filtered income list. */
     ObservableList<Income> getFilteredIncomeList();
 
     /**

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/ModelManager.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/ModelManager.java
@@ -9,6 +9,8 @@ import java.util.logging.Logger;
 
 import ay2021s1_cs2103_w16_3.finesse.commons.core.GuiSettings;
 import ay2021s1_cs2103_w16_3.finesse.commons.core.LogsCenter;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
@@ -22,6 +24,8 @@ public class ModelManager implements Model {
     private final FinanceTracker financeTracker;
     private final UserPrefs userPrefs;
     private final FilteredList<Transaction> filteredTransactions;
+    private final FilteredList<Expense> filteredExpenses;
+    private final FilteredList<Income> filteredIncomes;
 
     /**
      * Initializes a ModelManager with the given financeTracker and userPrefs.
@@ -35,6 +39,8 @@ public class ModelManager implements Model {
         this.financeTracker = new FinanceTracker(financeTracker);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredTransactions = new FilteredList<>(this.financeTracker.getTransactionList());
+        filteredExpenses = new FilteredList<>(this.financeTracker.getExpenseList());
+        filteredIncomes = new FilteredList<>(this.financeTracker.getIncomeList());
     }
 
     public ModelManager() {
@@ -94,8 +100,30 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void deleteExpense(Expense target) {
+        financeTracker.removeExpense(target);
+    }
+
+    @Override
+    public void deleteIncome(Income target) {
+        financeTracker.removeIncome(target);
+    }
+
+    @Override
     public void addTransaction(Transaction transaction) {
         financeTracker.addTransaction(transaction);
+        updateFilteredTransactionList(PREDICATE_SHOW_ALL_TRANSACTIONS);
+    }
+
+    @Override
+    public void addExpense(Expense expense) {
+        financeTracker.addExpense(expense);
+        updateFilteredTransactionList(PREDICATE_SHOW_ALL_TRANSACTIONS);
+    }
+
+    @Override
+    public void addIncome(Income income) {
+        financeTracker.addIncome(income);
         updateFilteredTransactionList(PREDICATE_SHOW_ALL_TRANSACTIONS);
     }
 
@@ -104,6 +132,20 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedTransaction);
 
         financeTracker.setTransaction(target, editedTransaction);
+    }
+
+    @Override
+    public void setExpense(Expense target, Expense editedExpense) {
+        requireAllNonNull(target, editedExpense);
+
+        financeTracker.setExpense(target, editedExpense);
+    }
+
+    @Override
+    public void setIncome(Income target, Income editedIncome) {
+        requireAllNonNull(target, editedIncome);
+
+        financeTracker.setIncome(target, editedIncome);
     }
 
     //=========== Filtered Transaction List Accessors =============================================================
@@ -117,10 +159,40 @@ public class ModelManager implements Model {
         return filteredTransactions;
     }
 
+    /**
+     * Returns an unmodifiable view of the list of {@code Expense} backed by the internal list of
+     * {@code versionedFinanceTracker}
+     */
+    @Override
+    public ObservableList<Expense> getFilteredExpenseList() {
+        return filteredExpenses;
+    }
+
+    /**
+     * Returns an unmodifiable view of the list of {@code Income} backed by the internal list of
+     * {@code versionedFinanceTracker}
+     */
+    @Override
+    public ObservableList<Income> getFilteredIncomeList() {
+        return filteredIncomes;
+    }
+
     @Override
     public void updateFilteredTransactionList(Predicate<Transaction> predicate) {
         requireNonNull(predicate);
         filteredTransactions.setPredicate(predicate);
+    }
+
+    @Override
+    public void updateFilteredExpenseList(Predicate<Transaction> predicate) {
+        requireNonNull(predicate);
+        filteredExpenses.setPredicate(predicate);
+    }
+
+    @Override
+    public void updateFilteredIncomeList(Predicate<Transaction> predicate) {
+        requireNonNull(predicate);
+        filteredIncomes.setPredicate(predicate);
     }
 
     @Override
@@ -139,7 +211,9 @@ public class ModelManager implements Model {
         ModelManager other = (ModelManager) obj;
         return financeTracker.equals(other.financeTracker)
                 && userPrefs.equals(other.userPrefs)
-                && filteredTransactions.equals(other.filteredTransactions);
+                && filteredTransactions.equals(other.filteredTransactions)
+                && filteredExpenses.equals(other.filteredExpenses)
+                && filteredIncomes.equals(other.filteredIncomes);
     }
 
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/ModelManager.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/ModelManager.java
@@ -151,8 +151,8 @@ public class ModelManager implements Model {
     //=========== Filtered Transaction List Accessors =============================================================
 
     /**
-     * Returns an unmodifiable view of the list of {@code Transaction} backed by the internal list of
-     * {@code versionedFinanceTracker}
+     * Returns an unmodifiable view of the list of {@code Transaction} backed by the internal transaction list of
+     * {@code versionedFinanceTracker}.
      */
     @Override
     public ObservableList<Transaction> getFilteredTransactionList() {
@@ -160,8 +160,8 @@ public class ModelManager implements Model {
     }
 
     /**
-     * Returns an unmodifiable view of the list of {@code Expense} backed by the internal list of
-     * {@code versionedFinanceTracker}
+     * Returns an unmodifiable view of the list of {@code Expense} backed by the internal expense list of
+     * {@code versionedFinanceTracker}.
      */
     @Override
     public ObservableList<Expense> getFilteredExpenseList() {
@@ -169,8 +169,8 @@ public class ModelManager implements Model {
     }
 
     /**
-     * Returns an unmodifiable view of the list of {@code Income} backed by the internal list of
-     * {@code versionedFinanceTracker}
+     * Returns an unmodifiable view of the list of {@code Income} backed by the internal income list of
+     * {@code versionedFinanceTracker}.
      */
     @Override
     public ObservableList<Income> getFilteredIncomeList() {

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddCommandTest.java
@@ -18,6 +18,8 @@ import ay2021s1_cs2103_w16_3.finesse.model.FinanceTracker;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.ReadOnlyFinanceTracker;
 import ay2021s1_cs2103_w16_3.finesse.model.ReadOnlyUserPrefs;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
 import javafx.collections.ObservableList;
@@ -104,6 +106,16 @@ public class AddCommandTest {
         }
 
         @Override
+        public void addExpense(Expense expense) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addIncome(Income income) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setFinanceTracker(ReadOnlyFinanceTracker newData) {
             throw new AssertionError("This method should not be called.");
         }
@@ -119,7 +131,27 @@ public class AddCommandTest {
         }
 
         @Override
+        public void deleteExpense(Expense target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteIncome(Income target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setTransaction(Transaction target, Transaction editedTransaction) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setExpense(Expense target, Expense editedExpense) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setIncome(Income target, Income editedIncome) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -129,7 +161,27 @@ public class AddCommandTest {
         }
 
         @Override
+        public ObservableList<Expense> getFilteredExpenseList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Income> getFilteredIncomeList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void updateFilteredTransactionList(Predicate<Transaction> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredExpenseList(Predicate<Transaction> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredIncomeList(Predicate<Transaction> predicate) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddExpenseCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddExpenseCommandTest.java
@@ -33,13 +33,13 @@ public class AddExpenseCommandTest {
 
     @Test
     public void execute_transactionAcceptedByModel_addSuccessful() throws Exception {
-        ModelStubAcceptingTransactionAdded modelStub = new ModelStubAcceptingTransactionAdded();
+        ModelStubAcceptingExpenseAdded modelStub = new ModelStubAcceptingExpenseAdded();
         Expense validExpense = new TransactionBuilder().buildExpense();
 
         CommandResult commandResult = new AddExpenseCommand(validExpense).execute(modelStub);
 
         assertEquals(String.format(AddExpenseCommand.MESSAGE_SUCCESS, validExpense), commandResult.getFeedbackToUser());
-        assertEquals(Arrays.asList(validExpense), modelStub.transactionsAdded);
+        assertEquals(Arrays.asList(validExpense), modelStub.expensesAdded);
     }
 
     @Test
@@ -189,13 +189,13 @@ public class AddExpenseCommandTest {
     /**
      * A Model stub that always accept the transaction being added.
      */
-    private class ModelStubAcceptingTransactionAdded extends ModelStub {
-        final ArrayList<Transaction> transactionsAdded = new ArrayList<>();
+    private class ModelStubAcceptingExpenseAdded extends ModelStub {
+        final ArrayList<Expense> expensesAdded = new ArrayList<>();
 
         @Override
-        public void addTransaction(Transaction transaction) {
-            requireNonNull(transaction);
-            transactionsAdded.add(transaction);
+        public void addExpense(Expense expense) {
+            requireNonNull(expense);
+            expensesAdded.add(expense);
         }
 
         @Override

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddExpenseCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddExpenseCommandTest.java
@@ -19,6 +19,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.ReadOnlyFinanceTracker;
 import ay2021s1_cs2103_w16_3.finesse.model.ReadOnlyUserPrefs;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
 import javafx.collections.ObservableList;
@@ -105,6 +106,16 @@ public class AddExpenseCommandTest {
         }
 
         @Override
+        public void addExpense(Expense expense) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addIncome(Income income) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setFinanceTracker(ReadOnlyFinanceTracker newData) {
             throw new AssertionError("This method should not be called.");
         }
@@ -120,7 +131,27 @@ public class AddExpenseCommandTest {
         }
 
         @Override
+        public void deleteExpense(Expense target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteIncome(Income target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setTransaction(Transaction target, Transaction editedTransaction) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setExpense(Expense target, Expense editedExpense) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setIncome(Income target, Income editedIncome) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -130,7 +161,27 @@ public class AddExpenseCommandTest {
         }
 
         @Override
+        public ObservableList<Expense> getFilteredExpenseList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Income> getFilteredIncomeList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void updateFilteredTransactionList(Predicate<Transaction> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredExpenseList(Predicate<Transaction> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredIncomeList(Predicate<Transaction> predicate) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommandTest.java
@@ -33,13 +33,13 @@ public class AddIncomeCommandTest {
 
     @Test
     public void execute_transactionAcceptedByModel_addSuccessful() throws Exception {
-        ModelStubAcceptingTransactionAdded modelStub = new ModelStubAcceptingTransactionAdded();
+        ModelStubAcceptingIncomeAdded modelStub = new ModelStubAcceptingIncomeAdded();
         Income validIncome = new TransactionBuilder().buildIncome();
 
         CommandResult commandResult = new AddIncomeCommand(validIncome).execute(modelStub);
 
         assertEquals(String.format(AddIncomeCommand.MESSAGE_SUCCESS, validIncome), commandResult.getFeedbackToUser());
-        assertEquals(Arrays.asList(validIncome), modelStub.transactionsAdded);
+        assertEquals(Arrays.asList(validIncome), modelStub.incomesAdded);
     }
 
     @Test
@@ -189,13 +189,13 @@ public class AddIncomeCommandTest {
     /**
      * A Model stub that always accept the transaction being added.
      */
-    private class ModelStubAcceptingTransactionAdded extends ModelStub {
-        final ArrayList<Transaction> transactionsAdded = new ArrayList<>();
+    private class ModelStubAcceptingIncomeAdded extends ModelStub {
+        final ArrayList<Income> incomesAdded = new ArrayList<>();
 
         @Override
-        public void addTransaction(Transaction transaction) {
-            requireNonNull(transaction);
-            transactionsAdded.add(transaction);
+        public void addIncome(Income income) {
+            requireNonNull(income);
+            incomesAdded.add(income);
         }
 
         @Override

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommandTest.java
@@ -18,6 +18,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.FinanceTracker;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.ReadOnlyFinanceTracker;
 import ay2021s1_cs2103_w16_3.finesse.model.ReadOnlyUserPrefs;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
@@ -105,6 +106,16 @@ public class AddIncomeCommandTest {
         }
 
         @Override
+        public void addExpense(Expense expense) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addIncome(Income income) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setFinanceTracker(ReadOnlyFinanceTracker newData) {
             throw new AssertionError("This method should not be called.");
         }
@@ -120,7 +131,27 @@ public class AddIncomeCommandTest {
         }
 
         @Override
+        public void deleteExpense(Expense target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteIncome(Income target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setTransaction(Transaction target, Transaction editedTransaction) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setExpense(Expense target, Expense editedExpense) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setIncome(Income target, Income editedIncome) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -130,7 +161,27 @@ public class AddIncomeCommandTest {
         }
 
         @Override
+        public ObservableList<Expense> getFilteredExpenseList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Income> getFilteredIncomeList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void updateFilteredTransactionList(Predicate<Transaction> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredExpenseList(Predicate<Transaction> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredIncomeList(Predicate<Transaction> predicate) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/ModelManagerTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/ModelManagerTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import ay2021s1_cs2103_w16_3.finesse.commons.core.GuiSettings;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.TitleContainsKeywordsPredicate;
 import ay2021s1_cs2103_w16_3.finesse.testutil.FinanceTrackerBuilder;
+import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
 
 public class ModelManagerTest {
 
@@ -78,9 +79,22 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void getFilteredExpenseList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredExpenseList().remove(0));
+    }
+
+    @Test
+    public void getFilteredIncomeList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredIncomeList().remove(0));
+    }
+
+    @Test
     public void equals() {
-        FinanceTracker financeTracker = new FinanceTrackerBuilder().withTransaction(ALICE)
-                .withTransaction(BENSON).build();
+        FinanceTracker financeTracker = new FinanceTrackerBuilder().withTransaction(ALICE).withTransaction(BENSON)
+                .withExpense(new TransactionBuilder(ALICE).buildExpense())
+                .withExpense(new TransactionBuilder(BENSON).buildExpense())
+                .withIncome(new TransactionBuilder(ALICE).buildIncome())
+                .withIncome(new TransactionBuilder(BENSON).buildIncome()).build();
         FinanceTracker differentFinanceTracker = new FinanceTracker();
         UserPrefs userPrefs = new UserPrefs();
 
@@ -101,9 +115,18 @@ public class ModelManagerTest {
         // different financeTracker -> returns false
         assertFalse(modelManager.equals(new ModelManager(differentFinanceTracker, userPrefs)));
 
-        // different filteredList -> returns false
         String[] keywords = ALICE.getTitle().fullTitle.split("\\s+");
+
+        // different filteredTransactionList -> returns false
         modelManager.updateFilteredTransactionList(new TitleContainsKeywordsPredicate(Arrays.asList(keywords)));
+        assertFalse(modelManager.equals(new ModelManager(financeTracker, userPrefs)));
+
+        // different filteredExpenseList -> returns false
+        modelManager.updateFilteredExpenseList(new TitleContainsKeywordsPredicate(Arrays.asList(keywords)));
+        assertFalse(modelManager.equals(new ModelManager(financeTracker, userPrefs)));
+
+        // different filteredIncomeList -> returns false
+        modelManager.updateFilteredIncomeList(new TitleContainsKeywordsPredicate(Arrays.asList(keywords)));
         assertFalse(modelManager.equals(new ModelManager(financeTracker, userPrefs)));
 
         // resets modelManager to initial state for upcoming tests

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/testutil/FinanceTrackerBuilder.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/testutil/FinanceTrackerBuilder.java
@@ -1,6 +1,8 @@
 package ay2021s1_cs2103_w16_3.finesse.testutil;
 
 import ay2021s1_cs2103_w16_3.finesse.model.FinanceTracker;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 
 /**
@@ -23,6 +25,22 @@ public class FinanceTrackerBuilder {
      */
     public FinanceTrackerBuilder withTransaction(Transaction transaction) {
         financeTracker.addTransaction(transaction);
+        return this;
+    }
+
+    /**
+     * Adds a new {@code Transaction} to the {@code FinanceTracker} that we are building.
+     */
+    public FinanceTrackerBuilder withExpense(Expense expense) {
+        financeTracker.addExpense(expense);
+        return this;
+    }
+
+    /**
+     * Adds a new {@code Transaction} to the {@code FinanceTracker} that we are building.
+     */
+    public FinanceTrackerBuilder withIncome(Income income) {
+        financeTracker.addIncome(income);
         return this;
     }
 


### PR DESCRIPTION
Partially addresses #59.

Changes:
* `AddExpenseCommand` and `AddIncomeCommand` adds expense and income to `ExpenseList` and `IncomeList` respectively
* Added `filteredExpenses` and `filteredIncomes` to `ModelManager`. These fields represent the list view on the UI under the tabs `Expenses` and `Incomes` respectively, and thus needs to be linked with the UI in a future PR.
* In `Model`, the methods `updateFilteredExpenseList` and `updateFileredIncomeList` both have `Predicate<Transaction> predicate` as the argument, as opposed to  `Predicate<Expense> predicate` and  `Predicate<Income> predicate`. This is to avoid creating additional classes with the same functionality as`TitleContainsKeywordsPredicate` for expense and income. Due to how Java generics work, the parameters for the aforementioned two methods will work.

Additional notes:
* `ModelManager.filteredTransactions` will not be removed, as it represents the list view in the UI under the tab `Overview`.
* `ListExpenseCommand` and `ListIncomeCommand` are not changed as the intended effect of these commands involves changes in the UI.