### PR TITLE
Fix input validation for 'category'

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/category/Category.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/category/Category.java
@@ -9,8 +9,8 @@ import static java.util.Objects.requireNonNull;
  */
 public class Category {
 
-    public static final String MESSAGE_CONSTRAINTS = "Categories names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String MESSAGE_CONSTRAINTS = "Category names should be printable.";
+    public static final String VALIDATION_REGEX = "\\p{Print}+";
 
     public final String categoryName;
 

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandTestUtil.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandTestUtil.java
@@ -46,8 +46,8 @@ public class CommandTestUtil {
     public static final String INVALID_TITLE_DESC = " " + PREFIX_TITLE + "James&"; // '&' not allowed in titles
     public static final String INVALID_AMOUNT_DESC = " " + PREFIX_AMOUNT + "911a"; // 'a' not allowed in amounts
     public static final String INVALID_DATE_DESC = " " + PREFIX_DATE + "bob!yahoo"; // only numbers and '/' allowed
-    public static final String INVALID_CATEGORY_DESC = " " + PREFIX_CATEGORY + "hubby*";
-    // '*' not allowed in categories
+    public static final String INVALID_CATEGORY_DESC = " " + PREFIX_CATEGORY + "hubby\u2416";
+    // 'SYN' not allowed in categories
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtilTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtilTest.java
@@ -23,7 +23,7 @@ public class ParserUtilTest {
     private static final String INVALID_TITLE = "R@chel";
     private static final String INVALID_AMOUNT = "+651234";
     private static final String INVALID_DATE = "example.com";
-    private static final String INVALID_CATEGORY = "#friend";
+    private static final String INVALID_CATEGORY = "\u2416friend";
 
     private static final String VALID_TITLE = "Rachel Walker";
     private static final String VALID_AMOUNT = "123456";

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedExpenseTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedExpenseTest.java
@@ -22,7 +22,7 @@ public class JsonAdaptedExpenseTest {
     private static final String INVALID_TITLE = "R@chel";
     private static final String INVALID_AMOUNT = "+651234";
     private static final String INVALID_DATE = "example.com";
-    private static final String INVALID_CATEGORY = "#friend";
+    private static final String INVALID_CATEGORY = "\u2416friend";
 
     private static final String VALID_TITLE = BENSON.getTitle().toString();
     private static final String VALID_AMOUNT = BENSON.getAmount().toString();

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedIncomeTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedIncomeTest.java
@@ -22,7 +22,7 @@ public class JsonAdaptedIncomeTest {
     private static final String INVALID_TITLE = "R@chel";
     private static final String INVALID_AMOUNT = "+651234";
     private static final String INVALID_DATE = "example.com";
-    private static final String INVALID_CATEGORY = "#friend";
+    private static final String INVALID_CATEGORY = "\u2416friend";
 
     private static final String VALID_TITLE = BENSON.getTitle().toString();
     private static final String VALID_AMOUNT = BENSON.getAmount().toString();

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedTransactionTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedTransactionTest.java
@@ -20,7 +20,7 @@ public class JsonAdaptedTransactionTest {
     private static final String INVALID_TITLE = "R@chel";
     private static final String INVALID_AMOUNT = "+651234";
     private static final String INVALID_DATE = "example.com";
-    private static final String INVALID_CATEGORY = "#friend";
+    private static final String INVALID_CATEGORY = "\u2416friend";
 
     private static final String VALID_TITLE = BENSON.getTitle().toString();
     private static final String VALID_AMOUNT = BENSON.getAmount().toString();


### PR DESCRIPTION
Changes:
- Allow all printable characters as valid input for category names

Fixes #78.