### PR TITLE
Add 'tab' command

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandResult.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandResult.java
@@ -3,6 +3,9 @@ package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
+import java.util.Optional;
+
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
 /**
  * Represents the result of a command execution.
@@ -17,18 +20,52 @@ public class CommandResult {
     /** The application should exit. */
     private final boolean exit;
 
+    /** An optional {@code Tab} to switch to */
+    private final Optional<Tab> tabToSwitchTo;
+
     /**
      * Constructs a {@code CommandResult} with the specified fields.
+     *
+     * @param feedbackToUser The feedback to be displayed to the user.
+     * @param showHelp Whether the help dialog should be shown to the user.
+     * @param exit Whether the application should exit.
+     * @param tabToSwitchTo The tab the UI should switch to.
      */
-    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, Tab tabToSwitchTo) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
+        this.tabToSwitchTo = Optional.ofNullable(tabToSwitchTo);
+    }
+
+    /**
+     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser}, {@code showHelp},
+     * {@code exit}, and other fields set to their default value.
+     *
+     * @param feedbackToUser The feedback to be displayed to the user.
+     * @param showHelp Whether the help dialog should be shown to the user.
+     * @param exit Whether the application should exit.
+     */
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
+        this(feedbackToUser, showHelp, exit, null);
+    }
+
+    /**
+     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser}, {@code tabToSwitchTo},
+     * and other fields set to their default value.
+     *
+     * @param feedbackToUser The feedback to be displayed to the user.
+     * @param tabToSwitchTo The tab the UI should switch to.
+     */
+    public CommandResult(String feedbackToUser, Tab tabToSwitchTo) {
+        this(feedbackToUser, false, false, tabToSwitchTo);
     }
 
     /**
      * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
      * and other fields set to their default value.
+     *
+     * @param feedbackToUser The feedback to be displayed to the user.
      */
     public CommandResult(String feedbackToUser) {
         this(feedbackToUser, false, false);
@@ -44,6 +81,10 @@ public class CommandResult {
 
     public boolean isExit() {
         return exit;
+    }
+
+    public Optional<Tab> getTabToSwitchTo() {
+        return tabToSwitchTo;
     }
 
     @Override

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandResult.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandResult.java
@@ -101,12 +101,13 @@ public class CommandResult {
         CommandResult otherCommandResult = (CommandResult) other;
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
                 && showHelp == otherCommandResult.showHelp
-                && exit == otherCommandResult.exit;
+                && exit == otherCommandResult.exit
+                && tabToSwitchTo.equals(otherCommandResult.tabToSwitchTo);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showHelp, exit);
+        return Objects.hash(feedbackToUser, showHelp, exit, tabToSwitchTo);
     }
 
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/TabCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/TabCommand.java
@@ -10,13 +10,17 @@ import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
  */
 public class TabCommand extends Command {
 
+    /** The number of tabs in the UI. */
+    public static final int NUM_OF_TABS = 4;
+
     public static final String COMMAND_WORD = "tab";
 
     // TODO: Update this
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Switches to the specified tab by index.\n"
-            + "Parameters: INDEX (must be a positive integer)";
+            + "Parameters: INDEX (must be a positive integer between 1 to " + NUM_OF_TABS + " inclusive)";
 
     public static final String MESSAGE_SWITCH_TABS_SUCCESS = "Switched to %1$s tab.";
+    public static final String MESSAGE_TAB_DOES_NOT_EXIST = "The specified tab does not exist.";
 
     /** The tab to switch to. */
     private final Tab tabToSwitchTo;

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/TabCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/TabCommand.java
@@ -2,6 +2,8 @@ package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
@@ -22,22 +24,28 @@ public class TabCommand extends Command {
     public static final String MESSAGE_SWITCH_TABS_SUCCESS = "Switched to %1$s tab.";
     public static final String MESSAGE_TAB_DOES_NOT_EXIST = "The specified tab does not exist.";
 
-    /** The tab to switch to. */
-    private final Tab tabToSwitchTo;
+    /** The index of the tab to switch to. */
+    private final Index tabIndex;
 
     /**
-     * Constructs a {@code TabCommand} with the specified tab to switch to.
+     * Constructs a {@code TabCommand} with the specified tab index to switch to.
      *
-     * @param tabToSwitchTo The tab to switch to.
+     * @param tabIndex The index of the tab to switch to.
+     * @throws CommandException If the specified tab index does not exist.
      */
-    public TabCommand(Tab tabToSwitchTo) {
-        requireNonNull(tabToSwitchTo);
+    public TabCommand(Index tabIndex) {
+        requireNonNull(tabIndex);
 
-        this.tabToSwitchTo = tabToSwitchTo;
+        this.tabIndex = tabIndex;
     }
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
+        if (tabIndex.getOneBased() > NUM_OF_TABS) {
+            throw new CommandException(TabCommand.MESSAGE_TAB_DOES_NOT_EXIST);
+        }
+
+        Tab tabToSwitchTo = Tab.values()[tabIndex.getZeroBased()];
         String formattedSuccessMessage = String.format(MESSAGE_SWITCH_TABS_SUCCESS, tabToSwitchTo);
         return new CommandResult(formattedSuccessMessage, tabToSwitchTo);
     }
@@ -46,6 +54,6 @@ public class TabCommand extends Command {
     public boolean equals(Object other) {
         return other == this // Short circuit if same object.
                 || (other instanceof TabCommand // instanceof handles nulls.
-                && tabToSwitchTo.equals(((TabCommand) other).tabToSwitchTo)); // State check.
+                && tabIndex.equals(((TabCommand) other).tabIndex)); // State check.
     }
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/TabCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/TabCommand.java
@@ -41,4 +41,11 @@ public class TabCommand extends Command {
         String formattedSuccessMessage = String.format(MESSAGE_SWITCH_TABS_SUCCESS, tabToSwitchTo);
         return new CommandResult(formattedSuccessMessage, tabToSwitchTo);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // Short circuit if same object.
+                || (other instanceof TabCommand // instanceof handles nulls.
+                && tabToSwitchTo.equals(((TabCommand) other).tabToSwitchTo)); // State check.
+    }
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/TabCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/TabCommand.java
@@ -1,0 +1,40 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import ay2021s1_cs2103_w16_3.finesse.model.Model;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
+
+/**
+ * Switches UI tabs.
+ */
+public class TabCommand extends Command {
+
+    public static final String COMMAND_WORD = "tab";
+
+    // TODO: Update this
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Switches to the specified tab by index.\n"
+            + "Parameters: INDEX (must be a positive integer)";
+
+    public static final String MESSAGE_SWITCH_TABS_SUCCESS = "Switched to %1$s tab.";
+
+    /** The tab to switch to. */
+    private final Tab tabToSwitchTo;
+
+    /**
+     * Constructs a {@code TabCommand} with the specified tab to switch to.
+     *
+     * @param tabToSwitchTo The tab to switch to.
+     */
+    public TabCommand(Tab tabToSwitchTo) {
+        requireNonNull(tabToSwitchTo);
+
+        this.tabToSwitchTo = tabToSwitchTo;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        String formattedSuccessMessage = String.format(MESSAGE_SWITCH_TABS_SUCCESS, tabToSwitchTo);
+        return new CommandResult(formattedSuccessMessage, tabToSwitchTo);
+    }
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
@@ -19,6 +19,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.commands.HelpCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListExpenseCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListIncomeCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.TabCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
 import ay2021s1_cs2103_w16_3.finesse.ui.UiState;
 
@@ -89,6 +90,9 @@ public class FinanceTrackerParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case TabCommand.COMMAND_WORD:
+            return new TabCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/TabCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/TabCommandParser.java
@@ -5,7 +5,6 @@ import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALI
 import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.TabCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
-import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
 /**
  * Parses input arguments and creates a new {@code TabCommand} object.
@@ -19,11 +18,7 @@ public class TabCommandParser implements Parser<TabCommand> {
     public TabCommand parse(String args) throws ParseException {
         try {
             Index index = ParserUtil.parseIndex(args);
-            if (index.getOneBased() > TabCommand.NUM_OF_TABS) {
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, TabCommand.MESSAGE_TAB_DOES_NOT_EXIST));
-            }
-            return new TabCommand(Tab.values()[index.getZeroBased()]);
+            return new TabCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, TabCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/TabCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/TabCommandParser.java
@@ -19,6 +19,10 @@ public class TabCommandParser implements Parser<TabCommand> {
     public TabCommand parse(String args) throws ParseException {
         try {
             Index index = ParserUtil.parseIndex(args);
+            if (index.getOneBased() > TabCommand.NUM_OF_TABS) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, TabCommand.MESSAGE_TAB_DOES_NOT_EXIST));
+            }
             return new TabCommand(Tab.values()[index.getZeroBased()]);
         } catch (ParseException pe) {
             throw new ParseException(

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/TabCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/TabCommandParser.java
@@ -1,0 +1,28 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.parser;
+
+import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.TabCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
+
+/**
+ * Parses input arguments and creates a new {@code TabCommand} object.
+ */
+public class TabCommandParser implements Parser<TabCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code TabCommand}
+     * and returns a {@code TabCommand} object for execution.
+     * @throws ParseException If the user input does not conform to the expected format.
+     */
+    public TabCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new TabCommand(Tab.values()[index.getZeroBased()]);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, TabCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
@@ -1,5 +1,6 @@
 package ay2021s1_cs2103_w16_3.finesse.ui;
 
+import java.util.Optional;
 import java.util.logging.Logger;
 
 import ay2021s1_cs2103_w16_3.finesse.commons.core.GuiSettings;
@@ -289,11 +290,39 @@ public class MainWindow extends UiPart<Stage> {
                 handleExit();
             }
 
+            Optional<Tab> tabToSwitchTo = commandResult.getTabToSwitchTo();
+            tabToSwitchTo.ifPresent(this::switchTabs);
+
             return commandResult;
         } catch (CommandException | ParseException e) {
             logger.info("Invalid command: " + commandText);
             resultDisplay.setFeedbackToUser(e.getMessage());
             throw e;
+        }
+    }
+
+    /**
+     * Programmatically switches UI tab based on the specified tab. If the specified tab is {@code null},
+     * do nothing.
+     *
+     * @param tab The tab to switch to.
+     */
+    private void switchTabs(Tab tab) {
+        switch (tab) {
+        case OVERVIEW:
+            handleOverview();
+            break;
+        case INCOME:
+            handleIncome();
+            break;
+        case EXPENSES:
+            handleExpense();
+            break;
+        case ANALYTICS:
+            handleAnalytics();
+            break;
+        default:
+            // Do nothing.
         }
     }
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/UiState.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/UiState.java
@@ -13,7 +13,17 @@ public class UiState {
         OVERVIEW,
         INCOME,
         EXPENSES,
-        ANALYTICS
+        ANALYTICS;
+
+        /**
+         * Returns a string representation of this {@code Tab}.
+         *
+         * @return A string representation of this {@code Tab}.
+         */
+        @Override
+        public String toString() {
+            return super.toString().toLowerCase();
+        }
     }
 
     /**

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandResultTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandResultTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
+
 public class CommandResultTest {
     @Test
     public void equals() {
@@ -14,7 +16,7 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, null)));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -33,6 +35,9 @@ public class CommandResultTest {
 
         // different exit value -> returns false
         assertFalse(commandResult.equals(new CommandResult("feedback", false, true)));
+
+        // different tabToSwitchTo value -> returns false
+        assertFalse(commandResult.equals(new CommandResult("feedback", Tab.ANALYTICS)));
     }
 
     @Test
@@ -50,5 +55,8 @@ public class CommandResultTest {
 
         // different exit value -> returns different hashcode
         assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true).hashCode());
+
+        // different tabToSwitchTo value -> returns different hashcode
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, Tab.INCOME));
     }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandResultTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandResultTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 
 import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
@@ -58,5 +60,19 @@ public class CommandResultTest {
 
         // different tabToSwitchTo value -> returns different hashcode
         assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, Tab.INCOME));
+    }
+
+    @Test
+    public void getters_returnSameValue() {
+        String feedback = "Hello world!";
+        boolean showHelp = true;
+        boolean exit = true;
+        Tab tabToSwitchTo = Tab.ANALYTICS;
+        CommandResult commandResult = new CommandResult(feedback, showHelp, exit, tabToSwitchTo);
+
+        assertEquals(feedback, commandResult.getFeedbackToUser());
+        assertEquals(showHelp, commandResult.isShowHelp());
+        assertEquals(exit, commandResult.isExit());
+        assertEquals(Optional.of(tabToSwitchTo), commandResult.getTabToSwitchTo());
     }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/TabCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/TabCommandTest.java
@@ -7,6 +7,7 @@ import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.getTypi
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.ModelManager;
 import ay2021s1_cs2103_w16_3.finesse.model.UserPrefs;
@@ -27,27 +28,27 @@ public class TabCommandTest {
     public void execute_switchToOverviewTab_success() {
         String formattedSuccessMessage = String.format(MESSAGE_SWITCH_TABS_SUCCESS, Tab.OVERVIEW);
         CommandResult expectedCommandResult = new CommandResult(formattedSuccessMessage, Tab.OVERVIEW);
-        assertCommandSuccess(new TabCommand(Tab.OVERVIEW), model, expectedCommandResult, expectedModel);
+        assertCommandSuccess(new TabCommand(Index.fromOneBased(1)), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_switchToIncomeTab_success() {
         String formattedSuccessMessage = String.format(MESSAGE_SWITCH_TABS_SUCCESS, Tab.INCOME);
         CommandResult expectedCommandResult = new CommandResult(formattedSuccessMessage, Tab.INCOME);
-        assertCommandSuccess(new TabCommand(Tab.INCOME), model, expectedCommandResult, expectedModel);
+        assertCommandSuccess(new TabCommand(Index.fromOneBased(2)), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_switchToExpensesTab_success() {
         String formattedSuccessMessage = String.format(MESSAGE_SWITCH_TABS_SUCCESS, Tab.EXPENSES);
         CommandResult expectedCommandResult = new CommandResult(formattedSuccessMessage, Tab.EXPENSES);
-        assertCommandSuccess(new TabCommand(Tab.EXPENSES), model, expectedCommandResult, expectedModel);
+        assertCommandSuccess(new TabCommand(Index.fromOneBased(3)), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_switchToAnalyticsTab_success() {
         String formattedSuccessMessage = String.format(MESSAGE_SWITCH_TABS_SUCCESS, Tab.ANALYTICS);
         CommandResult expectedCommandResult = new CommandResult(formattedSuccessMessage, Tab.ANALYTICS);
-        assertCommandSuccess(new TabCommand(Tab.ANALYTICS), model, expectedCommandResult, expectedModel);
+        assertCommandSuccess(new TabCommand(Index.fromOneBased(4)), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/TabCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/TabCommandTest.java
@@ -1,0 +1,53 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.commands;
+
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.TabCommand.MESSAGE_SWITCH_TABS_SUCCESS;
+import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.getTypicalFinanceTracker;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import ay2021s1_cs2103_w16_3.finesse.model.Model;
+import ay2021s1_cs2103_w16_3.finesse.model.ModelManager;
+import ay2021s1_cs2103_w16_3.finesse.model.UserPrefs;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
+
+public class TabCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
+        expectedModel = new ModelManager(model.getFinanceTracker(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_switchToOverviewTab_success() {
+        String formattedSuccessMessage = String.format(MESSAGE_SWITCH_TABS_SUCCESS, Tab.OVERVIEW);
+        CommandResult expectedCommandResult = new CommandResult(formattedSuccessMessage, Tab.OVERVIEW);
+        assertCommandSuccess(new TabCommand(Tab.OVERVIEW), model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_switchToIncomeTab_success() {
+        String formattedSuccessMessage = String.format(MESSAGE_SWITCH_TABS_SUCCESS, Tab.INCOME);
+        CommandResult expectedCommandResult = new CommandResult(formattedSuccessMessage, Tab.INCOME);
+        assertCommandSuccess(new TabCommand(Tab.INCOME), model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_switchToExpensesTab_success() {
+        String formattedSuccessMessage = String.format(MESSAGE_SWITCH_TABS_SUCCESS, Tab.EXPENSES);
+        CommandResult expectedCommandResult = new CommandResult(formattedSuccessMessage, Tab.EXPENSES);
+        assertCommandSuccess(new TabCommand(Tab.EXPENSES), model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_switchToAnalyticsTab_success() {
+        String formattedSuccessMessage = String.format(MESSAGE_SWITCH_TABS_SUCCESS, Tab.ANALYTICS);
+        CommandResult expectedCommandResult = new CommandResult(formattedSuccessMessage, Tab.ANALYTICS);
+        assertCommandSuccess(new TabCommand(Tab.ANALYTICS), model, expectedCommandResult, expectedModel);
+    }
+}

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
+import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddExpenseCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddIncomeCommand;
@@ -433,28 +434,28 @@ public class FinanceTrackerParserTest {
     public void parseCommand_tabWhenOverviewTab() throws Exception {
         TabCommand command = (TabCommand) parser.parseCommand(
                 TabCommand.COMMAND_WORD + " 1", overviewUiStateStub);
-        assertEquals(new TabCommand(UiState.Tab.OVERVIEW), command);
+        assertEquals(new TabCommand(Index.fromOneBased(1)), command);
     }
 
     @Test
     public void parseCommand_tabWhenIncomeTab() throws Exception {
         TabCommand command = (TabCommand) parser.parseCommand(
                 TabCommand.COMMAND_WORD + " 1", incomeUiStateStub);
-        assertEquals(new TabCommand(UiState.Tab.OVERVIEW), command);
+        assertEquals(new TabCommand(Index.fromOneBased(1)), command);
     }
 
     @Test
     public void parseCommand_tabWhenExpensesTab() throws Exception {
         TabCommand command = (TabCommand) parser.parseCommand(
                 TabCommand.COMMAND_WORD + " 1", expensesUiStateStub);
-        assertEquals(new TabCommand(UiState.Tab.OVERVIEW), command);
+        assertEquals(new TabCommand(Index.fromOneBased(1)), command);
     }
 
     @Test
     public void parseCommand_tabWhenAnalyticsTab() throws Exception {
         TabCommand command = (TabCommand) parser.parseCommand(
                 TabCommand.COMMAND_WORD + " 1", analyticsUiStateStub);
-        assertEquals(new TabCommand(UiState.Tab.OVERVIEW), command);
+        assertEquals(new TabCommand(Index.fromOneBased(1)), command);
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
@@ -25,6 +25,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.commands.HelpCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListExpenseCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListIncomeCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.TabCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
@@ -426,6 +427,34 @@ public class FinanceTrackerParserTest {
                 instanceof ListIncomeCommand);
         assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD + " 3",
                 analyticsUiStateStub) instanceof ListIncomeCommand);
+    }
+
+    @Test
+    public void parseCommand_tabWhenOverviewTab() throws Exception {
+        TabCommand command = (TabCommand) parser.parseCommand(
+                TabCommand.COMMAND_WORD + " 1", overviewUiStateStub);
+        assertEquals(new TabCommand(UiState.Tab.OVERVIEW), command);
+    }
+
+    @Test
+    public void parseCommand_tabWhenIncomeTab() throws Exception {
+        TabCommand command = (TabCommand) parser.parseCommand(
+                TabCommand.COMMAND_WORD + " 1", incomeUiStateStub);
+        assertEquals(new TabCommand(UiState.Tab.OVERVIEW), command);
+    }
+
+    @Test
+    public void parseCommand_tabWhenExpensesTab() throws Exception {
+        TabCommand command = (TabCommand) parser.parseCommand(
+                TabCommand.COMMAND_WORD + " 1", expensesUiStateStub);
+        assertEquals(new TabCommand(UiState.Tab.OVERVIEW), command);
+    }
+
+    @Test
+    public void parseCommand_tabWhenAnalyticsTab() throws Exception {
+        TabCommand command = (TabCommand) parser.parseCommand(
+                TabCommand.COMMAND_WORD + " 1", analyticsUiStateStub);
+        assertEquals(new TabCommand(UiState.Tab.OVERVIEW), command);
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
@@ -158,21 +158,21 @@ public class FinanceTrackerParserTest {
 
     @Test
     public void parseCommand_clearWhenIncomeTab() throws Exception {
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, overviewUiStateStub) instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, incomeUiStateStub) instanceof ClearCommand);
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3",
                 incomeUiStateStub) instanceof ClearCommand);
     }
 
     @Test
     public void parseCommand_clearWhenExpensesTab() throws Exception {
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, overviewUiStateStub) instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, expensesUiStateStub) instanceof ClearCommand);
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3",
                 expensesUiStateStub) instanceof ClearCommand);
     }
 
     @Test
     public void parseCommand_clearWhenAnalyticsTab() throws Exception {
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, overviewUiStateStub) instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, analyticsUiStateStub) instanceof ClearCommand);
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3",
                 analyticsUiStateStub) instanceof ClearCommand);
     }
@@ -254,21 +254,21 @@ public class FinanceTrackerParserTest {
 
     @Test
     public void parseCommand_exitWhenIncomeTab() throws Exception {
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, overviewUiStateStub) instanceof ExitCommand);
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, incomeUiStateStub) instanceof ExitCommand);
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3",
                 incomeUiStateStub) instanceof ExitCommand);
     }
 
     @Test
     public void parseCommand_exitWhenExpensesTab() throws Exception {
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, overviewUiStateStub) instanceof ExitCommand);
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, expensesUiStateStub) instanceof ExitCommand);
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3",
                 expensesUiStateStub) instanceof ExitCommand);
     }
 
     @Test
     public void parseCommand_exitWhenAnalyticsTab() throws Exception {
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, overviewUiStateStub) instanceof ExitCommand);
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, analyticsUiStateStub) instanceof ExitCommand);
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3",
                 analyticsUiStateStub) instanceof ExitCommand);
     }
@@ -318,21 +318,21 @@ public class FinanceTrackerParserTest {
 
     @Test
     public void parseCommand_helpWhenIncomeTab() throws Exception {
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, overviewUiStateStub) instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, incomeUiStateStub) instanceof HelpCommand);
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3",
                 incomeUiStateStub) instanceof HelpCommand);
     }
 
     @Test
     public void parseCommand_helpWhenExpensesTab() throws Exception {
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, overviewUiStateStub) instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, expensesUiStateStub) instanceof HelpCommand);
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3",
                 expensesUiStateStub) instanceof HelpCommand);
     }
 
     @Test
     public void parseCommand_helpWhenAnalyticsTab() throws Exception {
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, overviewUiStateStub) instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, analyticsUiStateStub) instanceof HelpCommand);
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3",
                 analyticsUiStateStub) instanceof HelpCommand);
     }
@@ -346,21 +346,21 @@ public class FinanceTrackerParserTest {
 
     @Test
     public void parseCommand_listWhenIncomeTab() throws Exception {
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, overviewUiStateStub) instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, incomeUiStateStub) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3",
                 incomeUiStateStub) instanceof ListCommand);
     }
 
     @Test
     public void parseCommand_listWhenExpensesTab() throws Exception {
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, overviewUiStateStub) instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, expensesUiStateStub) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3",
                 expensesUiStateStub) instanceof ListCommand);
     }
 
     @Test
     public void parseCommand_listWhenAnalyticsTab() throws Exception {
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, overviewUiStateStub) instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, analyticsUiStateStub) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3",
                 analyticsUiStateStub) instanceof ListCommand);
     }
@@ -375,7 +375,7 @@ public class FinanceTrackerParserTest {
 
     @Test
     public void parseCommand_listExpenseWhenIncomeTab() throws Exception {
-        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD, overviewUiStateStub)
+        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD, incomeUiStateStub)
                 instanceof ListExpenseCommand);
         assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD + " 3",
                 incomeUiStateStub) instanceof ListExpenseCommand);
@@ -383,7 +383,7 @@ public class FinanceTrackerParserTest {
 
     @Test
     public void parseCommand_listExpenseWhenExpensesTab() throws Exception {
-        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD, overviewUiStateStub)
+        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD, expensesUiStateStub)
                 instanceof ListExpenseCommand);
         assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD + " 3",
                 expensesUiStateStub) instanceof ListExpenseCommand);
@@ -391,7 +391,7 @@ public class FinanceTrackerParserTest {
 
     @Test
     public void parseCommand_listExpenseWhenAnalyticsTab() throws Exception {
-        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD, overviewUiStateStub)
+        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD, analyticsUiStateStub)
                 instanceof ListExpenseCommand);
         assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD + " 3",
                 analyticsUiStateStub) instanceof ListExpenseCommand);
@@ -407,7 +407,7 @@ public class FinanceTrackerParserTest {
 
     @Test
     public void parseCommand_listIncomeWhenIncomeTab() throws Exception {
-        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD, overviewUiStateStub)
+        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD, incomeUiStateStub)
                 instanceof ListIncomeCommand);
         assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD + " 3",
                 incomeUiStateStub) instanceof ListIncomeCommand);
@@ -415,7 +415,7 @@ public class FinanceTrackerParserTest {
 
     @Test
     public void parseCommand_listIncomeWhenExpensesTab() throws Exception {
-        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD, overviewUiStateStub)
+        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD, expensesUiStateStub)
                 instanceof ListIncomeCommand);
         assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD + " 3",
                 expensesUiStateStub) instanceof ListIncomeCommand);
@@ -423,7 +423,7 @@ public class FinanceTrackerParserTest {
 
     @Test
     public void parseCommand_listIncomeWhenAnalyticsTab() throws Exception {
-        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD, overviewUiStateStub)
+        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD, analyticsUiStateStub)
                 instanceof ListIncomeCommand);
         assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD + " 3",
                 analyticsUiStateStub) instanceof ListIncomeCommand);

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/TabCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/TabCommandParserTest.java
@@ -6,8 +6,8 @@ import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CommandParserTestUtil.a
 
 import org.junit.jupiter.api.Test;
 
+import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.TabCommand;
-import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
 public class TabCommandParserTest {
 
@@ -15,17 +15,16 @@ public class TabCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsTabCommand() {
-        assertParseSuccess(parser, "1", new TabCommand(Tab.OVERVIEW));
-        assertParseSuccess(parser, "2", new TabCommand(Tab.INCOME));
-        assertParseSuccess(parser, "3", new TabCommand(Tab.EXPENSES));
-        assertParseSuccess(parser, "4", new TabCommand(Tab.ANALYTICS));
+        assertParseSuccess(parser, "1", new TabCommand(Index.fromOneBased(1)));
+        assertParseSuccess(parser, "2", new TabCommand(Index.fromOneBased(2)));
+        assertParseSuccess(parser, "3", new TabCommand(Index.fromOneBased(3)));
+        assertParseSuccess(parser, "4", new TabCommand(Index.fromOneBased(4)));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, TabCommand.MESSAGE_USAGE));
         assertParseFailure(parser, "0", String.format(MESSAGE_INVALID_COMMAND_FORMAT, TabCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "5", String.format(MESSAGE_INVALID_COMMAND_FORMAT, TabCommand.MESSAGE_USAGE));
         assertParseFailure(parser, "-5", String.format(MESSAGE_INVALID_COMMAND_FORMAT, TabCommand.MESSAGE_USAGE));
         assertParseFailure(parser, "2 hello", String.format(MESSAGE_INVALID_COMMAND_FORMAT, TabCommand.MESSAGE_USAGE));
     }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/TabCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/TabCommandParserTest.java
@@ -1,0 +1,32 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.parser;
+
+import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.TabCommand;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
+
+public class TabCommandParserTest {
+
+    private TabCommandParser parser = new TabCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsTabCommand() {
+        assertParseSuccess(parser, "1", new TabCommand(Tab.OVERVIEW));
+        assertParseSuccess(parser, "2", new TabCommand(Tab.INCOME));
+        assertParseSuccess(parser, "3", new TabCommand(Tab.EXPENSES));
+        assertParseSuccess(parser, "4", new TabCommand(Tab.ANALYTICS));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, TabCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "0", String.format(MESSAGE_INVALID_COMMAND_FORMAT, TabCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "5", String.format(MESSAGE_INVALID_COMMAND_FORMAT, TabCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "-5", String.format(MESSAGE_INVALID_COMMAND_FORMAT, TabCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "2 hello", String.format(MESSAGE_INVALID_COMMAND_FORMAT, TabCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
Changes:
- Add ability to programmatically switch tabs.
- Add `tab` command.
  - Usage: `tab <1-based index of tab>`
- Add respective test classes.
- Fix wrong stubs being used in `FinanceTrackerParserTest`.

Resolves #89.