### PR TITLE
Modify 'delete' command to depend on UI state

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/commons/core/Messages.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/commons/core/Messages.java
@@ -7,6 +7,7 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+    public static final String MESSAGE_INVALID_TAB_FORMAT = "'%s' command can only be used in the following tabs: %s";
     public static final String MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX =
             "The transaction index provided is invalid";
     public static final String MESSAGE_TRANSACTIONS_LISTED_OVERVIEW = "%1$d transactions listed!";

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/DeleteCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/DeleteCommand.java
@@ -30,6 +30,10 @@ public class DeleteCommand extends Command {
         this.targetIndex = targetIndex;
     }
 
+    protected Index getTargetIndex() {
+        return targetIndex;
+    }
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/DeleteExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/DeleteExpenseCommand.java
@@ -1,0 +1,50 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import ay2021s1_cs2103_w16_3.finesse.commons.core.Messages;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
+import ay2021s1_cs2103_w16_3.finesse.model.Model;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
+
+/**
+ * Deletes a transaction identified using its displayed index from the finance tracker.
+ */
+public class DeleteExpenseCommand extends DeleteCommand {
+
+    public static final String COMMAND_WORD = "delete";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the expense identified by the index number used in the displayed transaction list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_DELETE_TRANSACTION_SUCCESS = "Deleted Expense: %1$s";
+
+    public DeleteExpenseCommand(DeleteCommand superCommand) {
+        super(superCommand.getTargetIndex());
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Expense> lastShownList = model.getFilteredExpenseList();
+
+        if (getTargetIndex().getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
+        }
+
+        Expense expenseToDelete = lastShownList.get(getTargetIndex().getZeroBased());
+        model.deleteExpense(expenseToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_TRANSACTION_SUCCESS, expenseToDelete));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeleteExpenseCommand // instanceof handles nulls
+                && getTargetIndex().equals(((DeleteExpenseCommand) other).getTargetIndex())); // state check
+    }
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/DeleteExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/DeleteExpenseCommand.java
@@ -10,14 +10,14 @@ import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
 
 /**
- * Deletes a transaction identified using its displayed index from the finance tracker.
+ * Deletes an expense identified using its displayed index from the finance tracker.
  */
 public class DeleteExpenseCommand extends DeleteCommand {
 
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the expense identified by the index number used in the displayed transaction list.\n"
+            + ": Deletes the expense identified by the index number used in the displayed expense list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/DeleteIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/DeleteIncomeCommand.java
@@ -10,14 +10,14 @@ import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 
 /**
- * Deletes a transaction identified using its displayed index from the finance tracker.
+ * Deletes an income identified using its displayed index from the finance tracker.
  */
 public class DeleteIncomeCommand extends DeleteCommand {
 
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the income identified by the index number used in the displayed transaction list.\n"
+            + ": Deletes the income identified by the index number used in the displayed income list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/DeleteIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/DeleteIncomeCommand.java
@@ -1,0 +1,50 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import ay2021s1_cs2103_w16_3.finesse.commons.core.Messages;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
+import ay2021s1_cs2103_w16_3.finesse.model.Model;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
+
+/**
+ * Deletes a transaction identified using its displayed index from the finance tracker.
+ */
+public class DeleteIncomeCommand extends DeleteCommand {
+
+    public static final String COMMAND_WORD = "delete";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the income identified by the index number used in the displayed transaction list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_DELETE_TRANSACTION_SUCCESS = "Deleted Income: %1$s";
+
+    public DeleteIncomeCommand(DeleteCommand superCommand) {
+        super(superCommand.getTargetIndex());
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Income> lastShownList = model.getFilteredIncomeList();
+
+        if (getTargetIndex().getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
+        }
+
+        Income incomeToDelete = lastShownList.get(getTargetIndex().getZeroBased());
+        model.deleteIncome(incomeToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_TRANSACTION_SUCCESS, incomeToDelete));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeleteIncomeCommand // instanceof handles nulls
+                && getTargetIndex().equals(((DeleteIncomeCommand) other).getTargetIndex())); // state check
+    }
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
@@ -1,10 +1,13 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.parser;
 
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_TAB_FORMAT;
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddExpenseCommand;
@@ -12,6 +15,8 @@ import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddIncomeCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ClearCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.Command;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.DeleteCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.DeleteExpenseCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.DeleteIncomeCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.EditCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ExitCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.FindCommand;
@@ -65,7 +70,16 @@ public class FinanceTrackerParser {
             return new EditCommandParser().parse(arguments);
 
         case DeleteCommand.COMMAND_WORD:
-            return new DeleteCommandParser().parse(arguments);
+            final DeleteCommand baseCommand = new DeleteCommandParser().parse(arguments);
+            switch (uiState.getCurrentTab()) {
+            case EXPENSES:
+                return new DeleteExpenseCommand(baseCommand);
+            case INCOME:
+                return new DeleteIncomeCommand(baseCommand);
+            default:
+                throw new ParseException(commandInvalidTabMessage(commandWord,
+                        UiState.Tab.EXPENSES, UiState.Tab.INCOME));
+            }
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
@@ -93,6 +107,11 @@ public class FinanceTrackerParser {
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }
+    }
+
+    private String commandInvalidTabMessage(String command, UiState.Tab... tabs) {
+        return String.format(MESSAGE_INVALID_TAB_FORMAT, command,
+                Stream.of(tabs).map(UiState.Tab::toString).collect(Collectors.joining(", ")));
     }
 
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
@@ -109,6 +109,12 @@ public class FinanceTrackerParser {
         }
     }
 
+    /**
+     * Error message to be used when a command is not applicable to the user's current tab.
+     * @param command The command word that was used incorrectly.
+     * @param tabs The tabs that the command is applicable to.
+     * @return The error message to be displayed to the user.
+     */
     private String commandInvalidTabMessage(String command, UiState.Tab... tabs) {
         return String.format(MESSAGE_INVALID_TAB_FORMAT, command,
                 Stream.of(tabs).map(UiState.Tab::toString).collect(Collectors.joining(", ")));

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/LogicManagerTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/LogicManagerTest.java
@@ -20,7 +20,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
-import ay2021s1_cs2103_w16_3.finesse.logic.parser.FinanceTrackerParserTest.OverviewUiStateStub;
+import ay2021s1_cs2103_w16_3.finesse.logic.parser.FinanceTrackerParserTest.ExpensesUiStateStub;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.ModelManager;
@@ -40,7 +40,7 @@ public class LogicManagerTest {
 
     private Model model = new ModelManager();
     private Logic logic;
-    private OverviewUiStateStub overviewUiStateStub = new OverviewUiStateStub();
+    private ExpensesUiStateStub expensesUiStateStub = new ExpensesUiStateStub();
 
     @BeforeEach
     public void setUp() {
@@ -103,7 +103,7 @@ public class LogicManagerTest {
      */
     private void assertCommandSuccess(String inputCommand, String expectedMessage,
             Model expectedModel) throws CommandException, ParseException {
-        CommandResult result = logic.execute(inputCommand, overviewUiStateStub);
+        CommandResult result = logic.execute(inputCommand, expensesUiStateStub);
         assertEquals(expectedMessage, result.getFeedbackToUser());
         assertEquals(expectedModel, model);
     }
@@ -143,7 +143,7 @@ public class LogicManagerTest {
      */
     private void assertCommandFailure(String inputCommand, Class<? extends Throwable> expectedException,
             String expectedMessage, Model expectedModel) {
-        assertThrows(expectedException, expectedMessage, () -> logic.execute(inputCommand, overviewUiStateStub));
+        assertThrows(expectedException, expectedMessage, () -> logic.execute(inputCommand, expensesUiStateStub));
         assertEquals(expectedModel, model);
     }
 

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
@@ -178,9 +178,8 @@ public class FinanceTrackerParserTest {
 
     @Test
     public void parseCommand_deleteWhenOverviewTab() throws Exception {
-        DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_TRANSACTION.getOneBased(), overviewUiStateStub);
-        assertEquals(new DeleteCommand(INDEX_FIRST_TRANSACTION), command);
+        assertThrows(ParseException.class, () -> parser.parseCommand(
+                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_TRANSACTION.getOneBased(), overviewUiStateStub));
     }
 
     @Test
@@ -199,9 +198,8 @@ public class FinanceTrackerParserTest {
 
     @Test
     public void parseCommand_deleteWhenAnalyticsTab() throws Exception {
-        DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_TRANSACTION.getOneBased(), analyticsUiStateStub);
-        assertEquals(new DeleteCommand(INDEX_FIRST_TRANSACTION), command);
+        assertThrows(ParseException.class, () -> parser.parseCommand(
+                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_TRANSACTION.getOneBased(), analyticsUiStateStub));
     }
 
     @Test


### PR DESCRIPTION
Resolves #91

The idea is that `FinanceTrackerParser` will take the `DeleteCommand` from `DeleteCommandParser` and wrap it into either `DeleteExpenseCommand` or `DeleteIncomeCommand` depending on the value of `uiState.getCurrentTab()`.

If the user's current tab does not support deletion (such as the analytics tab), a `ParseException` will be thrown. The overview tab should eventually be supported, but perhaps not within this PR.

Note that at the moment documentation (javadoc) and test coverage have been sidelined, pending a review of the implementation. Notably, `DeleteExpenseCommand` and `DeleteIncomeCommand` require test coverage.