### PR TITLE
Modify 'find' command to depend on UI state

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/FindCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/FindCommand.java
@@ -7,15 +7,22 @@ import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.TitleContainsKeywordsPredicate;
 
 /**
- * Finds and lists all transactions in finance tracker whose title contains any of the argument keywords.
+ * Finds and lists all transactions in the finance tracker whose title contains any of the argument keywords
+ * depending on the tab the user is on.
  * Keyword matching is case insensitive.
+ *
+ * Base class for FindExpenseCommand, FindIncomeCommand and FindTransactionCommand.
  */
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all transactions whose titles contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all transactions on the current tab "
+            + "whose titles contain any of the specified keywords (case-insensitive) "
+            + "and displays them as a list with index numbers.\n"
+            + "When on Overview tab: Searches all transactions.\n"
+            + "When on Income tab: Searches all incomes.\n"
+            + "When on Overview tab: Searches all expenses.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
@@ -23,6 +30,10 @@ public class FindCommand extends Command {
 
     public FindCommand(TitleContainsKeywordsPredicate predicate) {
         this.predicate = predicate;
+    }
+
+    protected TitleContainsKeywordsPredicate getPredicate() {
+        return predicate;
     }
 
     @Override

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/FindCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/FindCommand.java
@@ -22,7 +22,7 @@ public class FindCommand extends Command {
             + "and displays them as a list with index numbers.\n"
             + "When on Overview tab: Searches all transactions.\n"
             + "When on Income tab: Searches all incomes.\n"
-            + "When on Overview tab: Searches all expenses.\n"
+            + "When on Expenses tab: Searches all expenses.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/FindExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/FindExpenseCommand.java
@@ -1,0 +1,34 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import ay2021s1_cs2103_w16_3.finesse.commons.core.Messages;
+import ay2021s1_cs2103_w16_3.finesse.model.Model;
+
+/**
+ * Finds and lists all expenses in the finance tracker whose title contains any of the argument keywords.
+ * Used when the user is on the Expenses tab.
+ * Keyword matching is case insensitive.
+ */
+public class FindExpenseCommand extends FindCommand {
+
+    public FindExpenseCommand(FindCommand superCommand) {
+        super(superCommand.getPredicate());
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredExpenseList(getPredicate());
+        return new CommandResult(
+                String.format(Messages.MESSAGE_TRANSACTIONS_LISTED_OVERVIEW,
+                        model.getFilteredExpenseList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindExpenseCommand // instanceof handles nulls
+                && getPredicate().equals(((FindExpenseCommand) other).getPredicate())); // state check
+    }
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/FindIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/FindIncomeCommand.java
@@ -1,0 +1,34 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import ay2021s1_cs2103_w16_3.finesse.commons.core.Messages;
+import ay2021s1_cs2103_w16_3.finesse.model.Model;
+
+/**
+ * Finds and lists all incomes in the finance tracker whose title contains any of the argument keywords.
+ * Used when the user is on the Income tab.
+ * Keyword matching is case insensitive.
+ */
+public class FindIncomeCommand extends FindCommand {
+
+    public FindIncomeCommand(FindCommand superCommand) {
+        super(superCommand.getPredicate());
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredIncomeList(getPredicate());
+        return new CommandResult(
+                String.format(Messages.MESSAGE_TRANSACTIONS_LISTED_OVERVIEW,
+                        model.getFilteredIncomeList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindIncomeCommand // instanceof handles nulls
+                && getPredicate().equals(((FindIncomeCommand) other).getPredicate())); // state check
+    }
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/FindTransactionCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/FindTransactionCommand.java
@@ -1,0 +1,34 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import ay2021s1_cs2103_w16_3.finesse.commons.core.Messages;
+import ay2021s1_cs2103_w16_3.finesse.model.Model;
+
+/**
+ * Finds and lists all transactions in the finance tracker whose title contains any of the argument keywords.
+ * Used when the user is on the Overview tab.
+ * Keyword matching is case insensitive.
+ */
+public class FindTransactionCommand extends FindCommand {
+
+    public FindTransactionCommand(FindCommand superCommand) {
+        super(superCommand.getPredicate());
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredTransactionList(getPredicate());
+        return new CommandResult(
+                String.format(Messages.MESSAGE_TRANSACTIONS_LISTED_OVERVIEW,
+                        model.getFilteredTransactionList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindTransactionCommand // instanceof handles nulls
+                && getPredicate().equals(((FindTransactionCommand) other).getPredicate())); // state check
+    }
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
@@ -20,6 +20,9 @@ import ay2021s1_cs2103_w16_3.finesse.logic.commands.DeleteIncomeCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.EditCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ExitCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.FindCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.FindExpenseCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.FindIncomeCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.FindTransactionCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.HelpCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListExpenseCommand;
@@ -71,12 +74,12 @@ public class FinanceTrackerParser {
             return new EditCommandParser().parse(arguments);
 
         case DeleteCommand.COMMAND_WORD:
-            final DeleteCommand baseCommand = new DeleteCommandParser().parse(arguments);
+            final DeleteCommand baseDeleteCommand = new DeleteCommandParser().parse(arguments);
             switch (uiState.getCurrentTab()) {
             case EXPENSES:
-                return new DeleteExpenseCommand(baseCommand);
+                return new DeleteExpenseCommand(baseDeleteCommand);
             case INCOME:
-                return new DeleteIncomeCommand(baseCommand);
+                return new DeleteIncomeCommand(baseDeleteCommand);
             default:
                 throw new ParseException(commandInvalidTabMessage(commandWord,
                         UiState.Tab.EXPENSES, UiState.Tab.INCOME));
@@ -86,7 +89,18 @@ public class FinanceTrackerParser {
             return new ClearCommand();
 
         case FindCommand.COMMAND_WORD:
-            return new FindCommandParser().parse(arguments);
+            final FindCommand baseFindCommand = new FindCommandParser().parse(arguments);
+            switch (uiState.getCurrentTab()) {
+            case OVERVIEW:
+                return new FindTransactionCommand(baseFindCommand);
+            case EXPENSES:
+                return new FindExpenseCommand(baseFindCommand);
+            case INCOME:
+                return new FindIncomeCommand(baseFindCommand);
+            default:
+                throw new ParseException(commandInvalidTabMessage(commandWord,
+                        UiState.Tab.OVERVIEW, UiState.Tab.EXPENSES, UiState.Tab.INCOME));
+            }
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
@@ -301,11 +301,8 @@ public class FinanceTrackerParserTest {
 
     @Test
     public void parseCommand_findWhenAnalyticsTab() throws Exception {
-        List<String> keywords = Arrays.asList("foo", "bar", "baz");
-        FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream()
-                        .collect(Collectors.joining(" ")), analyticsUiStateStub);
-        assertEquals(new FindCommand(new TitleContainsKeywordsPredicate(keywords)), command);
+        assertThrows(ParseException.class, () -> parser.parseCommand(
+                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_TRANSACTION.getOneBased(), analyticsUiStateStub));
     }
 
     @Test


### PR DESCRIPTION
Resolves #92.

Allows find to find transactions depending on the current UI tab, using a similar logic to that of the `delete` command.

`FindExpenseCommand`, `FindIncomeCommand` and `FindTransactionCommand` currently do not have test coverage.