### PR TITLE
Modify 'list' command to depend on UI state

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListExpenseCommand.java
@@ -4,6 +4,7 @@ import static ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense.PREDICATE_
 import static java.util.Objects.requireNonNull;
 
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
 /**
  * Lists all expenses in the finance tracker to the user.
@@ -20,6 +21,6 @@ public class ListExpenseCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredTransactionList(PREDICATE_SHOW_ALL_EXPENSES);
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(MESSAGE_SUCCESS, Tab.EXPENSES);
     }
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListExpenseCommand.java
@@ -14,7 +14,7 @@ public class ListExpenseCommand extends Command {
     public static final String COMMAND_WORD = "ls-expense";
     public static final String COMMAND_ALIAS = "lse";
 
-    public static final String MESSAGE_SUCCESS = "Listed all expenses";
+    public static final String MESSAGE_SUCCESS = "Listed all expenses.";
 
 
     @Override

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListIncomeCommand.java
@@ -14,7 +14,7 @@ public class ListIncomeCommand extends Command {
     public static final String COMMAND_WORD = "ls-income";
     public static final String COMMAND_ALIAS = "lsi";
 
-    public static final String MESSAGE_SUCCESS = "Listed all income";
+    public static final String MESSAGE_SUCCESS = "Listed all income.";
 
 
     @Override

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListIncomeCommand.java
@@ -4,6 +4,7 @@ import static ay2021s1_cs2103_w16_3.finesse.model.transaction.Income.PREDICATE_S
 import static java.util.Objects.requireNonNull;
 
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
 /**
  * Lists all income in the finance tracker to the user.
@@ -20,6 +21,6 @@ public class ListIncomeCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredTransactionList(PREDICATE_SHOW_ALL_INCOME);
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(MESSAGE_SUCCESS, Tab.INCOME);
     }
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListTransactionCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListTransactionCommand.java
@@ -1,0 +1,26 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.commands;
+
+import static ay2021s1_cs2103_w16_3.finesse.model.Model.PREDICATE_SHOW_ALL_TRANSACTIONS;
+import static java.util.Objects.requireNonNull;
+
+import ay2021s1_cs2103_w16_3.finesse.model.Model;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
+
+/**
+ * Lists all transactions in the finance tracker to the user.
+ */
+public class ListTransactionCommand extends Command {
+
+    public static final String COMMAND_WORD = "ls-overview";
+    public static final String COMMAND_ALIAS = "lso";
+
+    public static final String MESSAGE_SUCCESS = "Listed all transactions.";
+
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredTransactionList(PREDICATE_SHOW_ALL_TRANSACTIONS);
+        return new CommandResult(MESSAGE_SUCCESS, Tab.OVERVIEW);
+    }
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
@@ -149,9 +149,9 @@ public class FinanceTrackerParser {
      * @param tabs The tabs that the command is applicable to.
      * @return The error message to be displayed to the user.
      */
-    private String commandInvalidTabMessage(String command, UiState.Tab... tabs) {
+    private String commandInvalidTabMessage(String command, Tab... tabs) {
         return String.format(MESSAGE_INVALID_TAB_FORMAT, command,
-                Stream.of(tabs).map(UiState.Tab::toString).collect(Collectors.joining(", ")));
+                Stream.of(tabs).map(Tab::toString).collect(Collectors.joining(", ")));
     }
 
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
@@ -105,7 +105,17 @@ public class FinanceTrackerParser {
             }
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+            switch (uiState.getCurrentTab()) {
+            case OVERVIEW:
+                return new ListTransactionCommand();
+            case EXPENSES:
+                return new ListExpenseCommand();
+            case INCOME:
+                return new ListIncomeCommand();
+            default:
+                throw new ParseException(commandInvalidTabMessage(commandWord,
+                        Tab.OVERVIEW, Tab.EXPENSES, Tab.INCOME));
+            }
 
         case ListTransactionCommand.COMMAND_WORD:
         case ListTransactionCommand.COMMAND_ALIAS:

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
@@ -27,9 +27,11 @@ import ay2021s1_cs2103_w16_3.finesse.logic.commands.HelpCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListExpenseCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListIncomeCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListTransactionCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.TabCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
 import ay2021s1_cs2103_w16_3.finesse.ui.UiState;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
 /**
  * Parses user input.
@@ -82,7 +84,7 @@ public class FinanceTrackerParser {
                 return new DeleteIncomeCommand(baseDeleteCommand);
             default:
                 throw new ParseException(commandInvalidTabMessage(commandWord,
-                        UiState.Tab.EXPENSES, UiState.Tab.INCOME));
+                        Tab.EXPENSES, Tab.INCOME));
             }
 
         case ClearCommand.COMMAND_WORD:
@@ -99,11 +101,15 @@ public class FinanceTrackerParser {
                 return new FindIncomeCommand(baseFindCommand);
             default:
                 throw new ParseException(commandInvalidTabMessage(commandWord,
-                        UiState.Tab.OVERVIEW, UiState.Tab.EXPENSES, UiState.Tab.INCOME));
+                        Tab.OVERVIEW, Tab.EXPENSES, Tab.INCOME));
             }
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
+
+        case ListTransactionCommand.COMMAND_WORD:
+        case ListTransactionCommand.COMMAND_ALIAS:
+            return new ListTransactionCommand();
 
         case ListExpenseCommand.COMMAND_WORD:
         case ListExpenseCommand.COMMAND_ALIAS:

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/LogicManagerTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/LogicManagerTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
-import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListIncomeCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.FinanceTrackerParserTest.ExpensesUiStateStub;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
@@ -65,8 +65,8 @@ public class LogicManagerTest {
 
     @Test
     public void execute_validCommand_success() throws Exception {
-        String listCommand = ListCommand.COMMAND_WORD;
-        assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
+        String listIncomeCommand = ListIncomeCommand.COMMAND_WORD;
+        assertCommandSuccess(listIncomeCommand, ListIncomeCommand.MESSAGE_SUCCESS, model);
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListExpenseCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListExpenseCommandTest.java
@@ -1,6 +1,7 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense.PREDICATE_SHOW_ALL_EXPENSES;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.getTypicalFinanceTracker;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -30,7 +31,7 @@ public class ListExpenseCommandTest {
 
     @Test
     public void execute_showsExpenseOnly() {
-        expectedModel.updateFilteredTransactionList(Expense.PREDICATE_SHOW_ALL_EXPENSES);
+        expectedModel.updateFilteredTransactionList(PREDICATE_SHOW_ALL_EXPENSES);
         assertCommandSuccess(new ListExpenseCommand(), model,
                 new CommandResult(ListExpenseCommand.MESSAGE_SUCCESS, Tab.EXPENSES), expectedModel);
     }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListExpenseCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListExpenseCommandTest.java
@@ -12,6 +12,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.ModelManager;
 import ay2021s1_cs2103_w16_3.finesse.model.UserPrefs;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
 import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListExpenseCommand.
@@ -30,7 +31,8 @@ public class ListExpenseCommandTest {
     @Test
     public void execute_showsExpenseOnly() {
         expectedModel.updateFilteredTransactionList(Expense.PREDICATE_SHOW_ALL_EXPENSES);
-        assertCommandSuccess(new ListExpenseCommand(), model, ListExpenseCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListExpenseCommand(), model,
+                new CommandResult(ListExpenseCommand.MESSAGE_SUCCESS, Tab.EXPENSES), expectedModel);
     }
 
     @Test
@@ -38,7 +40,8 @@ public class ListExpenseCommandTest {
         model.addTransaction(new TransactionBuilder().buildExpense());
         expectedModel = new ModelManager(model.getFinanceTracker(), new UserPrefs());
         expectedModel.updateFilteredTransactionList(transaction -> transaction instanceof Expense);
-        assertCommandSuccess(new ListExpenseCommand(), model, ListExpenseCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListExpenseCommand(), model,
+                new CommandResult(ListExpenseCommand.MESSAGE_SUCCESS, Tab.EXPENSES), expectedModel);
         assertEquals(model.getFilteredTransactionList().size(), 1);
     }
 
@@ -47,7 +50,8 @@ public class ListExpenseCommandTest {
         model.addTransaction(new TransactionBuilder().buildIncome());
         expectedModel = new ModelManager(model.getFinanceTracker(), new UserPrefs());
         expectedModel.updateFilteredTransactionList(transaction -> transaction instanceof Expense);
-        assertCommandSuccess(new ListExpenseCommand(), model, ListExpenseCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListExpenseCommand(), model,
+                new CommandResult(ListExpenseCommand.MESSAGE_SUCCESS, Tab.EXPENSES), expectedModel);
         assertEquals(model.getFilteredTransactionList().size(), 0);
     }
 

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListIncomeCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListIncomeCommandTest.java
@@ -12,6 +12,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.ModelManager;
 import ay2021s1_cs2103_w16_3.finesse.model.UserPrefs;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListIncomeCommand.
@@ -30,7 +31,8 @@ public class ListIncomeCommandTest {
     @Test
     public void execute_showsIncomeOnly() {
         expectedModel.updateFilteredTransactionList(Income.PREDICATE_SHOW_ALL_INCOME);
-        assertCommandSuccess(new ListIncomeCommand(), model, ListIncomeCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListIncomeCommand(), model,
+                new CommandResult(ListIncomeCommand.MESSAGE_SUCCESS, Tab.INCOME), expectedModel);
     }
 
     @Test
@@ -38,7 +40,8 @@ public class ListIncomeCommandTest {
         model.addTransaction(new TransactionBuilder().buildIncome());
         expectedModel = new ModelManager(model.getFinanceTracker(), new UserPrefs());
         expectedModel.updateFilteredTransactionList(transaction -> transaction instanceof Income);
-        assertCommandSuccess(new ListIncomeCommand(), model, ListIncomeCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListIncomeCommand(), model,
+                new CommandResult(ListIncomeCommand.MESSAGE_SUCCESS, Tab.INCOME), expectedModel);
         assertEquals(model.getFilteredTransactionList().size(), 1);
     }
 
@@ -47,7 +50,8 @@ public class ListIncomeCommandTest {
         model.addTransaction(new TransactionBuilder().buildExpense());
         expectedModel = new ModelManager(model.getFinanceTracker(), new UserPrefs());
         expectedModel.updateFilteredTransactionList(transaction -> transaction instanceof Income);
-        assertCommandSuccess(new ListIncomeCommand(), model, ListIncomeCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListIncomeCommand(), model,
+                new CommandResult(ListIncomeCommand.MESSAGE_SUCCESS, Tab.INCOME), expectedModel);
         assertEquals(model.getFilteredTransactionList().size(), 0);
     }
 

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListTransactionCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListTransactionCommandTest.java
@@ -1,7 +1,7 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static ay2021s1_cs2103_w16_3.finesse.model.transaction.Income.PREDICATE_SHOW_ALL_INCOME;
+import static ay2021s1_cs2103_w16_3.finesse.model.Model.PREDICATE_SHOW_ALL_TRANSACTIONS;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.getTypicalFinanceTracker;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -11,14 +11,13 @@ import org.junit.jupiter.api.Test;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.ModelManager;
 import ay2021s1_cs2103_w16_3.finesse.model.UserPrefs;
-import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
 import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
 /**
- * Contains integration tests (interaction with the Model) and unit tests for ListIncomeCommand.
+ * Contains integration tests (interaction with the Model) and unit tests for ListTransactionCommand.
  */
-public class ListIncomeCommandTest {
+public class ListTransactionCommandTest {
 
     private Model model;
     private Model expectedModel;
@@ -30,30 +29,30 @@ public class ListIncomeCommandTest {
     }
 
     @Test
-    public void execute_showsIncomeOnly() {
-        expectedModel.updateFilteredTransactionList(PREDICATE_SHOW_ALL_INCOME);
-        assertCommandSuccess(new ListIncomeCommand(), model,
-                new CommandResult(ListIncomeCommand.MESSAGE_SUCCESS, Tab.INCOME), expectedModel);
+    public void execute_showsAllTransactions() {
+        expectedModel.updateFilteredTransactionList(PREDICATE_SHOW_ALL_TRANSACTIONS);
+        assertCommandSuccess(new ListTransactionCommand(), model,
+                new CommandResult(ListTransactionCommand.MESSAGE_SUCCESS, Tab.OVERVIEW), expectedModel);
     }
 
     @Test
     public void execute_hasSomeIncome() {
         model.addTransaction(new TransactionBuilder().buildIncome());
         expectedModel = new ModelManager(model.getFinanceTracker(), new UserPrefs());
-        expectedModel.updateFilteredTransactionList(transaction -> transaction instanceof Income);
-        assertCommandSuccess(new ListIncomeCommand(), model,
-                new CommandResult(ListIncomeCommand.MESSAGE_SUCCESS, Tab.INCOME), expectedModel);
-        assertEquals(model.getFilteredTransactionList().size(), 1);
+        expectedModel.updateFilteredTransactionList(transaction -> true);
+        assertCommandSuccess(new ListTransactionCommand(), model,
+                new CommandResult(ListTransactionCommand.MESSAGE_SUCCESS, Tab.OVERVIEW), expectedModel);
+        assertEquals(model.getFilteredTransactionList().size(), 8);
     }
 
     @Test
-    public void execute_hasSomeNonIncome() {
+    public void execute_hasSomeExpense() {
         model.addTransaction(new TransactionBuilder().buildExpense());
         expectedModel = new ModelManager(model.getFinanceTracker(), new UserPrefs());
-        expectedModel.updateFilteredTransactionList(transaction -> transaction instanceof Income);
-        assertCommandSuccess(new ListIncomeCommand(), model,
-                new CommandResult(ListIncomeCommand.MESSAGE_SUCCESS, Tab.INCOME), expectedModel);
-        assertEquals(model.getFilteredTransactionList().size(), 0);
+        expectedModel.updateFilteredTransactionList(transaction -> true);
+        assertCommandSuccess(new ListTransactionCommand(), model,
+                new CommandResult(ListTransactionCommand.MESSAGE_SUCCESS, Tab.OVERVIEW), expectedModel);
+        assertEquals(model.getFilteredTransactionList().size(), 8);
     }
 
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
@@ -335,30 +335,31 @@ public class FinanceTrackerParserTest {
 
     @Test
     public void parseCommand_listWhenOverviewTab() throws Exception {
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, overviewUiStateStub) instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, overviewUiStateStub)
+                instanceof ListTransactionCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3",
-                overviewUiStateStub) instanceof ListCommand);
+                overviewUiStateStub) instanceof ListTransactionCommand);
     }
 
     @Test
     public void parseCommand_listWhenIncomeTab() throws Exception {
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, incomeUiStateStub) instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, incomeUiStateStub)
+                instanceof ListIncomeCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3",
-                incomeUiStateStub) instanceof ListCommand);
+                incomeUiStateStub) instanceof ListIncomeCommand);
     }
 
     @Test
     public void parseCommand_listWhenExpensesTab() throws Exception {
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, expensesUiStateStub) instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, expensesUiStateStub)
+                instanceof ListExpenseCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3",
-                expensesUiStateStub) instanceof ListCommand);
+                expensesUiStateStub) instanceof ListExpenseCommand);
     }
 
     @Test
     public void parseCommand_listWhenAnalyticsTab() throws Exception {
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, analyticsUiStateStub) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3",
-                analyticsUiStateStub) instanceof ListCommand);
+        assertThrows(ParseException.class, () -> parser.parseCommand(ListCommand.COMMAND_WORD, analyticsUiStateStub));
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
@@ -26,6 +26,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.commands.HelpCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListExpenseCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListIncomeCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListTransactionCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.TabCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
@@ -40,7 +41,6 @@ import ay2021s1_cs2103_w16_3.finesse.ui.UiState;
 public class FinanceTrackerParserTest {
 
     private final FinanceTrackerParser parser = new FinanceTrackerParser();
-    // TODO: Once the UI-dependent command behavior is added, the corresponding tests should be updated too.
     private final OverviewUiStateStub overviewUiStateStub = new OverviewUiStateStub();
     private final IncomeUiStateStub incomeUiStateStub = new IncomeUiStateStub();
     private final ExpensesUiStateStub expensesUiStateStub = new ExpensesUiStateStub();
@@ -359,6 +359,38 @@ public class FinanceTrackerParserTest {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, analyticsUiStateStub) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3",
                 analyticsUiStateStub) instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_listTransactionWhenOverviewTab() throws Exception {
+        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD, overviewUiStateStub)
+                instanceof ListTransactionCommand);
+        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD + " 3",
+                overviewUiStateStub) instanceof ListTransactionCommand);
+    }
+
+    @Test
+    public void parseCommand_listTransactionWhenIncomeTab() throws Exception {
+        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD, incomeUiStateStub)
+                instanceof ListTransactionCommand);
+        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD + " 3",
+                incomeUiStateStub) instanceof ListTransactionCommand);
+    }
+
+    @Test
+    public void parseCommand_listTransactionWhenExpensesTab() throws Exception {
+        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD, expensesUiStateStub)
+                instanceof ListTransactionCommand);
+        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD + " 3",
+                expensesUiStateStub) instanceof ListTransactionCommand);
+    }
+
+    @Test
+    public void parseCommand_listTransactionWhenAnalyticsTab() throws Exception {
+        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD, analyticsUiStateStub)
+                instanceof ListTransactionCommand);
+        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD + " 3",
+                analyticsUiStateStub) instanceof ListTransactionCommand);
     }
 
     @Test


### PR DESCRIPTION
Changes:
- Add `list-overview` command to be consistent with `find` in supporting the overview tab.
- Programmatically switch to the respective tabs when executing `list-overview`, `list-expense`, and `list-income`.
- Add generic `list` command that returns one of the 3 specialised list commands depending on UI state.
- Add full stop where needed.
- Add full import for `UiState.Tab`.
- Update test cases accordingly.

Resolves #98.