### PR TITLE
Modify TypicalTransactions.getTypicalFinanceTracker

### DIFF
--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/testutil/TypicalTransactions.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/testutil/TypicalTransactions.java
@@ -61,11 +61,9 @@ public class TypicalTransactions {
      */
     public static FinanceTracker getTypicalFinanceTracker() {
         FinanceTracker ft = new FinanceTracker();
-        for (Transaction transaction : getTypicalTransactions()) {
-            ft.addTransaction(transaction);
-            ft.addExpense(new TransactionBuilder(transaction).buildExpense());
-            ft.addIncome(new TransactionBuilder(transaction).buildIncome());
-        }
+        getTypicalTransactions().forEach(ft::addTransaction);
+        getTypicalExpenses().forEach(ft::addExpense);
+        getTypicalIncomes().forEach(ft::addIncome);
         return ft;
     }
 


### PR DESCRIPTION
Modified `TypicalTransactions.getTypicalFinanceTracker` to call the methods `getTypicalExpenses` and `getTypicalIncomes`, in addition to `getTypicalTransactions`.

This is to allow tests that use `getTypicalFinanceTracker` to easily access its components if required.