### PR TITLE
Modify 'add' command to depend on UI state

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddCommand.java
@@ -11,23 +11,26 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 
 /**
  * Adds a transaction to the finance tracker.
+ * Depending on the current tab, either an Expense or an Income will be created.
  */
 public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a transaction to the finance tracker. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a transaction to the finance tracker, "
+            + " based on the current tab."
+            + "When on Income tab: Adds an income.\n"
+            + "When on Expenses tab: Adds an expense.\n"
             + "Parameters: "
             + PREFIX_TITLE + "TITLE "
             + PREFIX_AMOUNT + "AMOUNT "
             + PREFIX_DATE + "DATE "
             + "[" + PREFIX_CATEGORY + "CATEGORY]...\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_TITLE + "John Doe "
-            + PREFIX_AMOUNT + "98765432 "
-            + PREFIX_DATE + "johnd@example.com "
-            + PREFIX_CATEGORY + "friends "
-            + PREFIX_CATEGORY + "owesMoney";
+            + PREFIX_TITLE + "Lunch "
+            + PREFIX_AMOUNT + "$5 "
+            + PREFIX_DATE + "13/10/2020 "
+            + PREFIX_CATEGORY + "Food & Beverage";
 
     public static final String MESSAGE_SUCCESS = "New transaction added: %1$s";
 
@@ -39,6 +42,10 @@ public class AddCommand extends Command {
     public AddCommand(Transaction transaction) {
         requireNonNull(transaction);
         toAdd = transaction;
+    }
+
+    public Transaction getToAdd() {
+        return toAdd;
     }
 
     @Override

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddCommand.java
@@ -17,8 +17,8 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a transaction to the finance tracker, "
-            + " based on the current tab."
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a transaction to the finance tracker "
+            + "based on the current tab.\n"
             + "When on Income tab: Adds an income.\n"
             + "When on Expenses tab: Adds an expense.\n"
             + "Parameters: "

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
@@ -30,6 +30,9 @@ import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListIncomeCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListTransactionCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.TabCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import ay2021s1_cs2103_w16_3.finesse.ui.UiState;
 import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
@@ -62,7 +65,27 @@ public class FinanceTrackerParser {
         switch (commandWord) {
 
         case AddCommand.COMMAND_WORD:
-            return new AddCommandParser().parse(arguments);
+            final AddCommand baseAddCommand = new AddCommandParser().parse(arguments);
+            final Transaction addCommandToAdd = baseAddCommand.getToAdd();
+            switch (uiState.getCurrentTab()) {
+            case EXPENSES:
+                return new AddExpenseCommand(new Expense(
+                        addCommandToAdd.getTitle(),
+                        addCommandToAdd.getAmount(),
+                        addCommandToAdd.getDate(),
+                        addCommandToAdd.getCategories()
+                ));
+            case INCOME:
+                return new AddIncomeCommand(new Income(
+                        addCommandToAdd.getTitle(),
+                        addCommandToAdd.getAmount(),
+                        addCommandToAdd.getDate(),
+                        addCommandToAdd.getCategories()
+                ));
+            default:
+                throw new ParseException(commandInvalidTabMessage(commandWord,
+                        Tab.EXPENSES, Tab.INCOME));
+            }
 
         case AddExpenseCommand.COMMAND_WORD:
         case AddExpenseCommand.COMMAND_ALIAS:

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/LogicManagerTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/LogicManagerTest.java
@@ -26,7 +26,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.ModelManager;
 import ay2021s1_cs2103_w16_3.finesse.model.ReadOnlyFinanceTracker;
 import ay2021s1_cs2103_w16_3.finesse.model.UserPrefs;
-import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
 import ay2021s1_cs2103_w16_3.finesse.storage.JsonFinanceTrackerStorage;
 import ay2021s1_cs2103_w16_3.finesse.storage.JsonUserPrefsStorage;
 import ay2021s1_cs2103_w16_3.finesse.storage.StorageManager;
@@ -80,11 +80,11 @@ public class LogicManagerTest {
         StorageManager storage = new StorageManager(financeTrackerStorage, userPrefsStorage);
         logic = new LogicManager(model, storage);
 
-        // Execute add command
+        // Execute add command - adds an Expense as assertCommandFailure uses the expensesUiStateStub
         String addCommand = AddCommand.COMMAND_WORD + TITLE_DESC_AMY + AMOUNT_DESC_AMY + DATE_DESC_AMY;
-        Transaction expectedTransaction = new TransactionBuilder(AMY).withCategories().build();
+        Expense expectedExpense = new TransactionBuilder(AMY).withCategories().buildExpense();
         ModelManager expectedModel = new ModelManager();
-        expectedModel.addTransaction(expectedTransaction);
+        expectedModel.addExpense(expectedExpense);
         String expectedMessage = LogicManager.FILE_OPS_ERROR_MESSAGE + DUMMY_IO_EXCEPTION;
         assertCommandFailure(addCommand, CommandException.class, expectedMessage, expectedModel);
     }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
@@ -176,7 +176,7 @@ public class FinanceTrackerParserTest {
     }
 
     @Test
-    public void parseCommand_deleteWhenOverviewTab() throws Exception {
+    public void parseCommand_deleteWhenOverviewTab() {
         assertThrows(ParseException.class, () -> parser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_TRANSACTION.getOneBased(), overviewUiStateStub));
     }
@@ -196,7 +196,7 @@ public class FinanceTrackerParserTest {
     }
 
     @Test
-    public void parseCommand_deleteWhenAnalyticsTab() throws Exception {
+    public void parseCommand_deleteWhenAnalyticsTab() {
         assertThrows(ParseException.class, () -> parser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_TRANSACTION.getOneBased(), analyticsUiStateStub));
     }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
@@ -14,7 +14,6 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
-import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddExpenseCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddIncomeCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ClearCommand;
@@ -47,35 +46,33 @@ public class FinanceTrackerParserTest {
     private final AnalyticsUiStateStub analyticsUiStateStub = new AnalyticsUiStateStub();
 
     @Test
-    public void parseCommand_addWhenOverviewTab() throws Exception {
+    public void parseCommand_addWhenOverviewTab() {
         Transaction transaction = new TransactionBuilder().build();
-        AddCommand command =
-                (AddCommand) parser.parseCommand(TransactionUtil.getAddCommand(transaction), overviewUiStateStub);
-        assertEquals(new AddCommand(transaction), command);
+        assertThrows(ParseException.class, () -> parser.parseCommand(
+                TransactionUtil.getAddCommand(transaction), overviewUiStateStub));
     }
 
     @Test
     public void parseCommand_addWhenIncomeTab() throws Exception {
-        Transaction transaction = new TransactionBuilder().build();
-        AddCommand command =
-                (AddCommand) parser.parseCommand(TransactionUtil.getAddCommand(transaction), incomeUiStateStub);
-        assertEquals(new AddCommand(transaction), command);
+        Income income = new TransactionBuilder().buildIncome();
+        AddIncomeCommand command =
+                (AddIncomeCommand) parser.parseCommand(TransactionUtil.getAddCommand(income), incomeUiStateStub);
+        assertEquals(new AddIncomeCommand(income), command);
     }
 
     @Test
     public void parseCommand_addWhenExpensesTab() throws Exception {
-        Transaction transaction = new TransactionBuilder().build();
-        AddCommand command =
-                (AddCommand) parser.parseCommand(TransactionUtil.getAddCommand(transaction), expensesUiStateStub);
-        assertEquals(new AddCommand(transaction), command);
+        Expense expense = new TransactionBuilder().buildExpense();
+        AddExpenseCommand command =
+                (AddExpenseCommand) parser.parseCommand(TransactionUtil.getAddCommand(expense), expensesUiStateStub);
+        assertEquals(new AddExpenseCommand(expense), command);
     }
 
     @Test
-    public void parseCommand_addWhenAnalyticsTab() throws Exception {
+    public void parseCommand_addWhenAnalyticsTab() {
         Transaction transaction = new TransactionBuilder().build();
-        AddCommand command =
-                (AddCommand) parser.parseCommand(TransactionUtil.getAddCommand(transaction), analyticsUiStateStub);
-        assertEquals(new AddCommand(transaction), command);
+        assertThrows(ParseException.class, () -> parser.parseCommand(
+                TransactionUtil.getAddCommand(transaction), analyticsUiStateStub));
     }
 
     @Test


### PR DESCRIPTION
Resolves #88 

Note that the behavior inside `FinanceTrackerParser` may be a bit different compared to other commands, as we already have the commands `AddIncomeCommand` and `AddExpenseCommand`. Once the input has been parsed via `AddCommand`, it is repackaged into either `AddIncomeCommand` or `AddExpenseCommand` depending on the current tab.