### PR TITLE
Modify 'edit' command to depend on UI state

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/commons/core/Messages.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/commons/core/Messages.java
@@ -9,7 +9,11 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_TAB_FORMAT = "'%s' command can only be used in the following tabs: %s";
     public static final String MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX =
-            "The transaction index provided is invalid";
+            "The transaction index provided is invalid.";
+    public static final String MESSAGE_INVALID_EXPENSE_DISPLAYED_INDEX =
+            "The expense index provided is invalid.";
+    public static final String MESSAGE_INVALID_INCOME_DISPLAYED_INDEX =
+            "The income index provided is invalid.";
     public static final String MESSAGE_TRANSACTIONS_LISTED_OVERVIEW = "%1$d transactions listed!";
 
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditCommand.java
@@ -45,8 +45,8 @@ public class EditCommand extends Command {
             + "[" + PREFIX_DATE + "DATE] "
             + "[" + PREFIX_CATEGORY + "CATEGORY]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_AMOUNT + "91234567 "
-            + PREFIX_DATE + "johndoe@example.com";
+            + PREFIX_AMOUNT + "5 "
+            + PREFIX_DATE + "22/09/2020";
 
     public static final String MESSAGE_EDIT_TRANSACTION_SUCCESS = "Edited Transaction: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditCommand.java
@@ -25,15 +25,20 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 
 /**
- * Edits the details of an existing transaction in the finance tracker.
+ * Edits the details of an existing transaction using its displayed index from the finance tracker
+ * depending on the tab the user is on.
+ *
+ * Base class for EditExpenseCommand and EditIncomeCommand.
  */
 public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the transaction identified "
-            + "by the index number used in the displayed transaction list. "
+            + "by the index number used in the displayed transaction list on the current tab. "
             + "Existing values will be overwritten by the input values.\n"
+            + "When on Income tab: Edits from the currently displayed income list.\n"
+            + "When on Expenses tab: Edits from the currently displayed expenses list.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_TITLE + "TITLE] "
             + "[" + PREFIX_AMOUNT + "AMOUNT] "
@@ -46,19 +51,27 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_TRANSACTION_SUCCESS = "Edited Transaction: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
 
-    private final Index index;
+    private final Index targetIndex;
     private final EditTransactionDescriptor editTransactionDescriptor;
 
     /**
-     * @param index of the transaction in the filtered transaction list to edit
-     * @param editTransactionDescriptor details to edit the transaction with
+     * @param targetIndex Index of the transaction in the filtered transaction list to edit.
+     * @param editTransactionDescriptor Details to edit the transaction with.
      */
-    public EditCommand(Index index, EditTransactionDescriptor editTransactionDescriptor) {
-        requireNonNull(index);
+    public EditCommand(Index targetIndex, EditTransactionDescriptor editTransactionDescriptor) {
+        requireNonNull(targetIndex);
         requireNonNull(editTransactionDescriptor);
 
-        this.index = index;
+        this.targetIndex = targetIndex;
         this.editTransactionDescriptor = new EditTransactionDescriptor(editTransactionDescriptor);
+    }
+
+    protected Index getTargetIndex() {
+        return targetIndex;
+    }
+
+    protected EditTransactionDescriptor getEditTransactionDescriptor() {
+        return editTransactionDescriptor;
     }
 
     @Override
@@ -66,11 +79,11 @@ public class EditCommand extends Command {
         requireNonNull(model);
         List<Transaction> lastShownList = model.getFilteredTransactionList();
 
-        if (index.getZeroBased() >= lastShownList.size()) {
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
         }
 
-        Transaction transactionToEdit = lastShownList.get(index.getZeroBased());
+        Transaction transactionToEdit = lastShownList.get(targetIndex.getZeroBased());
         Transaction editedTransaction = createEditedTransaction(transactionToEdit, editTransactionDescriptor);
 
         model.setTransaction(transactionToEdit, editedTransaction);
@@ -109,7 +122,7 @@ public class EditCommand extends Command {
 
         // state check
         EditCommand e = (EditCommand) other;
-        return index.equals(e.index)
+        return targetIndex.equals(e.targetIndex)
                 && editTransactionDescriptor.equals(e.editTransactionDescriptor);
     }
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditCommand.java
@@ -1,5 +1,6 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 
+import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_DATE;
@@ -13,7 +14,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import ay2021s1_cs2103_w16_3.finesse.commons.core.Messages;
 import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
 import ay2021s1_cs2103_w16_3.finesse.commons.util.CollectionUtil;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
@@ -80,7 +80,7 @@ public class EditCommand extends Command {
         List<Transaction> lastShownList = model.getFilteredTransactionList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
+            throw new CommandException(MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
         }
 
         Transaction transactionToEdit = lastShownList.get(targetIndex.getZeroBased());

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditExpenseCommand.java
@@ -1,0 +1,80 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.commands;
+
+import static ay2021s1_cs2103_w16_3.finesse.model.Model.PREDICATE_SHOW_ALL_TRANSACTIONS;
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Set;
+
+import ay2021s1_cs2103_w16_3.finesse.commons.core.Messages;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
+import ay2021s1_cs2103_w16_3.finesse.model.Model;
+import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
+
+/**
+ * Edits an expense identified using its displayed index from the finance tracker.
+ */
+public class EditExpenseCommand extends EditCommand {
+
+    public static final String MESSAGE_EDIT_TRANSACTION_SUCCESS = "Edited Expense: %1$s";
+
+    public EditExpenseCommand(EditCommand superCommand) {
+        super(superCommand.getTargetIndex(), superCommand.getEditTransactionDescriptor());
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Expense> lastShownList = model.getFilteredExpenseList();
+
+        if (getTargetIndex().getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_EXPENSE_DISPLAYED_INDEX);
+        }
+
+        Expense expenseToEdit = lastShownList.get(getTargetIndex().getZeroBased());
+        Expense editedExpense = createEditedExpense(expenseToEdit, getEditTransactionDescriptor());
+
+        model.setExpense(expenseToEdit, editedExpense);
+        model.updateFilteredTransactionList(PREDICATE_SHOW_ALL_TRANSACTIONS);
+        return new CommandResult(String.format(MESSAGE_EDIT_TRANSACTION_SUCCESS, editedExpense));
+    }
+
+    /**
+     * Creates and returns an {@code Expense} with the details of {@code expenseToEdit}
+     * edited with {@code editExpenseDescriptor}.
+     */
+    private static Expense createEditedExpense(Expense expenseToEdit,
+                                               EditTransactionDescriptor editExpenseDescriptor) {
+        assert expenseToEdit != null;
+
+        Title updatedTitle = editExpenseDescriptor.getTitle().orElse(expenseToEdit.getTitle());
+        Amount updatedAmount = editExpenseDescriptor.getAmount().orElse(expenseToEdit.getAmount());
+        Date updatedDate = editExpenseDescriptor.getDate().orElse(expenseToEdit.getDate());
+        Set<Category> updatedCategories = editExpenseDescriptor.getCategories()
+                .orElse(expenseToEdit.getCategories());
+
+        return new Expense(updatedTitle, updatedAmount, updatedDate, updatedCategories);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditExpenseCommand)) {
+            return false;
+        }
+
+        // state check
+        EditExpenseCommand e = (EditExpenseCommand) other;
+        return getTargetIndex().equals(e.getTargetIndex())
+                && getEditTransactionDescriptor().equals(e.getEditTransactionDescriptor());
+    }
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditExpenseCommand.java
@@ -1,12 +1,12 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 
+import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_EXPENSE_DISPLAYED_INDEX;
 import static ay2021s1_cs2103_w16_3.finesse.model.Model.PREDICATE_SHOW_ALL_TRANSACTIONS;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 import java.util.Set;
 
-import ay2021s1_cs2103_w16_3.finesse.commons.core.Messages;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
@@ -32,7 +32,7 @@ public class EditExpenseCommand extends EditCommand {
         List<Expense> lastShownList = model.getFilteredExpenseList();
 
         if (getTargetIndex().getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_EXPENSE_DISPLAYED_INDEX);
+            throw new CommandException(MESSAGE_INVALID_EXPENSE_DISPLAYED_INDEX);
         }
 
         Expense expenseToEdit = lastShownList.get(getTargetIndex().getZeroBased());

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditExpenseCommand.java
@@ -39,7 +39,7 @@ public class EditExpenseCommand extends EditCommand {
         Expense editedExpense = createEditedExpense(expenseToEdit, getEditTransactionDescriptor());
 
         model.setExpense(expenseToEdit, editedExpense);
-        model.updateFilteredTransactionList(PREDICATE_SHOW_ALL_TRANSACTIONS);
+        model.updateFilteredExpenseList(PREDICATE_SHOW_ALL_TRANSACTIONS);
         return new CommandResult(String.format(MESSAGE_EDIT_TRANSACTION_SUCCESS, editedExpense));
     }
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditIncomeCommand.java
@@ -1,0 +1,80 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.commands;
+
+import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_INCOME_DISPLAYED_INDEX;
+import static ay2021s1_cs2103_w16_3.finesse.model.Model.PREDICATE_SHOW_ALL_TRANSACTIONS;
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Set;
+
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
+import ay2021s1_cs2103_w16_3.finesse.model.Model;
+import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
+
+/**
+ * Edits an income identified using its displayed index from the finance tracker.
+ */
+public class EditIncomeCommand extends EditCommand {
+
+    public static final String MESSAGE_EDIT_TRANSACTION_SUCCESS = "Edited Income: %1$s";
+
+    public EditIncomeCommand(EditCommand superCommand) {
+        super(superCommand.getTargetIndex(), superCommand.getEditTransactionDescriptor());
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Income> lastShownList = model.getFilteredIncomeList();
+
+        if (getTargetIndex().getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(MESSAGE_INVALID_INCOME_DISPLAYED_INDEX);
+        }
+
+        Income incomeToEdit = lastShownList.get(getTargetIndex().getZeroBased());
+        Income editedIncome = createEditedIncome(incomeToEdit, getEditTransactionDescriptor());
+
+        model.setIncome(incomeToEdit, editedIncome);
+        model.updateFilteredIncomeList(PREDICATE_SHOW_ALL_TRANSACTIONS);
+        return new CommandResult(String.format(MESSAGE_EDIT_TRANSACTION_SUCCESS, editedIncome));
+    }
+
+    /**
+     * Creates and returns an {@code Income} with the details of {@code incomeToEdit}
+     * edited with {@code editIncomeDescriptor}.
+     */
+    private static Income createEditedIncome(Income incomeToEdit,
+                                               EditTransactionDescriptor editIncomeDescriptor) {
+        assert incomeToEdit != null;
+
+        Title updatedTitle = editIncomeDescriptor.getTitle().orElse(incomeToEdit.getTitle());
+        Amount updatedAmount = editIncomeDescriptor.getAmount().orElse(incomeToEdit.getAmount());
+        Date updatedDate = editIncomeDescriptor.getDate().orElse(incomeToEdit.getDate());
+        Set<Category> updatedCategories = editIncomeDescriptor.getCategories()
+                .orElse(incomeToEdit.getCategories());
+
+        return new Income(updatedTitle, updatedAmount, updatedDate, updatedCategories);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditIncomeCommand)) {
+            return false;
+        }
+
+        // state check
+        EditIncomeCommand e = (EditIncomeCommand) other;
+        return getTargetIndex().equals(e.getTargetIndex())
+                && getEditTransactionDescriptor().equals(e.getEditTransactionDescriptor());
+    }
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
@@ -18,6 +18,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.commands.DeleteCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.DeleteExpenseCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.DeleteIncomeCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.EditCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.EditExpenseCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ExitCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.FindCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.FindExpenseCommand;
@@ -73,7 +74,14 @@ public class FinanceTrackerParser {
             return new AddIncomeCommandParser().parse(arguments);
 
         case EditCommand.COMMAND_WORD:
-            return new EditCommandParser().parse(arguments);
+            final EditCommand baseEditCommand = new EditCommandParser().parse(arguments);
+            switch (uiState.getCurrentTab()) {
+            case EXPENSES:
+                return new EditExpenseCommand(baseEditCommand);
+            default:
+                throw new ParseException(commandInvalidTabMessage(commandWord,
+                        Tab.EXPENSES, Tab.INCOME));
+            }
 
         case DeleteCommand.COMMAND_WORD:
             final DeleteCommand baseDeleteCommand = new DeleteCommandParser().parse(arguments);

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
@@ -19,6 +19,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.commands.DeleteExpenseCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.DeleteIncomeCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.EditCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.EditExpenseCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.EditIncomeCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.ExitCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.FindCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.FindExpenseCommand;
@@ -78,6 +79,8 @@ public class FinanceTrackerParser {
             switch (uiState.getCurrentTab()) {
             case EXPENSES:
                 return new EditExpenseCommand(baseEditCommand);
+            case INCOME:
+                return new EditIncomeCommand(baseEditCommand);
             default:
                 throw new ParseException(commandInvalidTabMessage(commandWord,
                         Tab.EXPENSES, Tab.INCOME));

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/FinanceTracker.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/FinanceTracker.java
@@ -3,6 +3,7 @@ package ay2021s1_cs2103_w16_3.finesse.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Objects;
 
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.ExpenseList;
@@ -189,6 +190,6 @@ public class FinanceTracker implements ReadOnlyFinanceTracker {
 
     @Override
     public int hashCode() {
-        return transactions.hashCode();
+        return Objects.hash(transactions, expenses, incomes);
     }
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/ModelManager.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/ModelManager.java
@@ -118,13 +118,13 @@ public class ModelManager implements Model {
     @Override
     public void addExpense(Expense expense) {
         financeTracker.addExpense(expense);
-        updateFilteredTransactionList(PREDICATE_SHOW_ALL_TRANSACTIONS);
+        updateFilteredExpenseList(PREDICATE_SHOW_ALL_TRANSACTIONS);
     }
 
     @Override
     public void addIncome(Income income) {
         financeTracker.addIncome(income);
-        updateFilteredTransactionList(PREDICATE_SHOW_ALL_TRANSACTIONS);
+        updateFilteredIncomeList(PREDICATE_SHOW_ALL_TRANSACTIONS);
     }
 
     @Override

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandTestUtil.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandTestUtil.java
@@ -16,6 +16,7 @@ import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.model.FinanceTracker;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.TitleContainsKeywordsPredicate;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import ay2021s1_cs2103_w16_3.finesse.testutil.EditTransactionDescriptorBuilder;
@@ -120,4 +121,17 @@ public class CommandTestUtil {
         assertEquals(1, model.getFilteredTransactionList().size());
     }
 
+    /**
+     * Updates {@code model}'s filtered list to show only the expense at the given {@code targetIndex} in the
+     * {@code model}'s finance tracker.
+     */
+    public static void showExpenseAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredExpenseList().size());
+
+        Expense expense = model.getFilteredExpenseList().get(targetIndex.getZeroBased());
+        final String[] splitTitle = expense.getTitle().fullTitle.split("\\s+");
+        model.updateFilteredExpenseList(new TitleContainsKeywordsPredicate(Arrays.asList(splitTitle[0])));
+
+        assertEquals(1, model.getFilteredExpenseList().size());
+    }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandTestUtil.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandTestUtil.java
@@ -17,6 +17,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.model.FinanceTracker;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.TitleContainsKeywordsPredicate;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import ay2021s1_cs2103_w16_3.finesse.testutil.EditTransactionDescriptorBuilder;
@@ -133,5 +134,19 @@ public class CommandTestUtil {
         model.updateFilteredExpenseList(new TitleContainsKeywordsPredicate(Arrays.asList(splitTitle[0])));
 
         assertEquals(1, model.getFilteredExpenseList().size());
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show only the income at the given {@code targetIndex} in the
+     * {@code model}'s finance tracker.
+     */
+    public static void showIncomeAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredIncomeList().size());
+
+        Income income = model.getFilteredIncomeList().get(targetIndex.getZeroBased());
+        final String[] splitTitle = income.getTitle().fullTitle.split("\\s+");
+        model.updateFilteredIncomeList(new TitleContainsKeywordsPredicate(Arrays.asList(splitTitle[0])));
+
+        assertEquals(1, model.getFilteredIncomeList().size());
     }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditExpenseCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditExpenseCommandTest.java
@@ -29,9 +29,9 @@ import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
 
 /**
  * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests
- * for EditExpensesCommand.
+ * for EditExpenseCommand.
  */
-public class EditExpensesCommandTest {
+public class EditExpenseCommandTest {
 
     private Model model = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
 
@@ -86,7 +86,6 @@ public class EditExpensesCommandTest {
         assertCommandSuccess(editExpenseCommand, model, expectedMessage, expectedModel);
     }
 
-    /* TODO: Test fails after substituting all the transaction commands for expense commands.
     @Test
     public void execute_filteredList_success() {
         showExpenseAtIndex(model, INDEX_FIRST_TRANSACTION);
@@ -105,7 +104,6 @@ public class EditExpensesCommandTest {
 
         assertCommandSuccess(editExpenseCommand, model, expectedMessage, expectedModel);
     }
-     */
 
     @Test
     public void execute_invalidExpenseIndexUnfilteredList_failure() {

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditExpensesCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditExpensesCommandTest.java
@@ -1,0 +1,165 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.commands;
+
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DESC_AMY;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DESC_BOB;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_AMOUNT_BOB;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_CATEGORY_HUSBAND;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_TITLE_BOB;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandFailure;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.showExpenseAtIndex;
+import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalIndexes.INDEX_FIRST_TRANSACTION;
+import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalIndexes.INDEX_SECOND_TRANSACTION;
+import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.getTypicalFinanceTracker;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import ay2021s1_cs2103_w16_3.finesse.commons.core.Messages;
+import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.EditCommand.EditTransactionDescriptor;
+import ay2021s1_cs2103_w16_3.finesse.model.FinanceTracker;
+import ay2021s1_cs2103_w16_3.finesse.model.Model;
+import ay2021s1_cs2103_w16_3.finesse.model.ModelManager;
+import ay2021s1_cs2103_w16_3.finesse.model.UserPrefs;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
+import ay2021s1_cs2103_w16_3.finesse.testutil.EditTransactionDescriptorBuilder;
+import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests
+ * for EditExpensesCommand.
+ */
+public class EditExpensesCommandTest {
+
+    private Model model = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
+
+    @Test
+    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+        Expense editedExpense = new TransactionBuilder().buildExpense();
+        EditTransactionDescriptor descriptor =
+                new EditTransactionDescriptorBuilder(editedExpense).build();
+        EditExpenseCommand editExpenseCommand = new EditExpenseCommand(
+                new EditCommand(INDEX_FIRST_TRANSACTION, descriptor));
+
+        String expectedMessage = String.format(EditExpenseCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS, editedExpense);
+
+        Model expectedModel = new ModelManager(new FinanceTracker(model.getFinanceTracker()), new UserPrefs());
+        expectedModel.setExpense(model.getFilteredExpenseList().get(0), editedExpense);
+
+        assertCommandSuccess(editExpenseCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_someFieldsSpecifiedUnfilteredList_success() {
+        Index indexLastExpense = Index.fromOneBased(model.getFilteredExpenseList().size());
+        Expense lastExpense = model.getFilteredExpenseList().get(indexLastExpense.getZeroBased());
+
+        TransactionBuilder expenseInList = new TransactionBuilder(lastExpense);
+        Expense editedExpense = expenseInList.withTitle(VALID_TITLE_BOB).withAmount(VALID_AMOUNT_BOB)
+                .withCategories(VALID_CATEGORY_HUSBAND).buildExpense();
+
+        EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder()
+                .withTitle(VALID_TITLE_BOB).withAmount(VALID_AMOUNT_BOB).withCategories(VALID_CATEGORY_HUSBAND).build();
+        EditExpenseCommand editExpenseCommand = new EditExpenseCommand(
+                new EditCommand(indexLastExpense, descriptor));
+
+        String expectedMessage = String.format(EditExpenseCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS, editedExpense);
+
+        Model expectedModel = new ModelManager(new FinanceTracker(model.getFinanceTracker()), new UserPrefs());
+        expectedModel.setExpense(lastExpense, editedExpense);
+
+        assertCommandSuccess(editExpenseCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_noFieldSpecifiedUnfilteredList_success() {
+        EditExpenseCommand editExpenseCommand = new EditExpenseCommand(
+                new EditCommand(INDEX_FIRST_TRANSACTION, new EditTransactionDescriptor()));
+        Expense editedExpense = model.getFilteredExpenseList().get(INDEX_FIRST_TRANSACTION.getZeroBased());
+
+        String expectedMessage = String.format(EditExpenseCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS, editedExpense);
+
+        Model expectedModel = new ModelManager(new FinanceTracker(model.getFinanceTracker()), new UserPrefs());
+
+        assertCommandSuccess(editExpenseCommand, model, expectedMessage, expectedModel);
+    }
+
+    /* TODO: Test fails after substituting all the transaction commands for expense commands.
+    @Test
+    public void execute_filteredList_success() {
+        showExpenseAtIndex(model, INDEX_FIRST_TRANSACTION);
+
+        Expense expenseInFilteredList = model.getFilteredExpenseList()
+                .get(INDEX_FIRST_TRANSACTION.getZeroBased());
+        Expense editedExpense =
+                new TransactionBuilder(expenseInFilteredList).withTitle(VALID_TITLE_BOB).buildExpense();
+        EditExpenseCommand editExpenseCommand = new EditExpenseCommand(new EditCommand(INDEX_FIRST_TRANSACTION,
+                new EditTransactionDescriptorBuilder().withTitle(VALID_TITLE_BOB).build()));
+
+        String expectedMessage = String.format(EditExpenseCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS, editedExpense);
+
+        Model expectedModel = new ModelManager(new FinanceTracker(model.getFinanceTracker()), new UserPrefs());
+        expectedModel.setExpense(model.getFilteredExpenseList().get(0), editedExpense);
+
+        assertCommandSuccess(editExpenseCommand, model, expectedMessage, expectedModel);
+    }
+     */
+
+    @Test
+    public void execute_invalidExpenseIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredExpenseList().size() + 1);
+        EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder()
+                .withTitle(VALID_TITLE_BOB).build();
+        EditExpenseCommand editExpenseCommand = new EditExpenseCommand(
+                new EditCommand(outOfBoundIndex, descriptor));
+
+        assertCommandFailure(editExpenseCommand, model, Messages.MESSAGE_INVALID_EXPENSE_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Edit filtered list where index is larger than size of filtered list,
+     * but smaller than size of finance tracker
+     */
+    @Test
+    public void execute_invalidExpenseIndexFilteredList_failure() {
+        showExpenseAtIndex(model, INDEX_FIRST_TRANSACTION);
+        Index outOfBoundIndex = INDEX_SECOND_TRANSACTION;
+        // ensures that outOfBoundIndex is still in bounds of finance tracker list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getFinanceTracker().getExpenseList().size());
+
+        EditExpenseCommand editExpenseCommand = new EditExpenseCommand(new EditCommand(outOfBoundIndex,
+                new EditTransactionDescriptorBuilder().withTitle(VALID_TITLE_BOB).build()));
+
+        assertCommandFailure(editExpenseCommand, model, Messages.MESSAGE_INVALID_EXPENSE_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final EditExpenseCommand standardCommand = new EditExpenseCommand(
+                new EditCommand(INDEX_FIRST_TRANSACTION, DESC_AMY));
+
+        // same values -> returns true
+        EditTransactionDescriptor copyDescriptor = new EditTransactionDescriptor(DESC_AMY);
+        EditExpenseCommand commandWithSameValues = new EditExpenseCommand(
+                new EditCommand(INDEX_FIRST_TRANSACTION, copyDescriptor));
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_TRANSACTION, DESC_AMY)));
+
+        // different descriptor -> returns false
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_TRANSACTION, DESC_BOB)));
+    }
+
+}

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditIncomeCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditIncomeCommandTest.java
@@ -1,0 +1,163 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.commands;
+
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DESC_AMY;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DESC_BOB;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_AMOUNT_BOB;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_CATEGORY_HUSBAND;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_TITLE_BOB;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandFailure;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.showIncomeAtIndex;
+import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalIndexes.INDEX_FIRST_TRANSACTION;
+import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalIndexes.INDEX_SECOND_TRANSACTION;
+import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.getTypicalFinanceTracker;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import ay2021s1_cs2103_w16_3.finesse.commons.core.Messages;
+import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.EditCommand.EditTransactionDescriptor;
+import ay2021s1_cs2103_w16_3.finesse.model.FinanceTracker;
+import ay2021s1_cs2103_w16_3.finesse.model.Model;
+import ay2021s1_cs2103_w16_3.finesse.model.ModelManager;
+import ay2021s1_cs2103_w16_3.finesse.model.UserPrefs;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
+import ay2021s1_cs2103_w16_3.finesse.testutil.EditTransactionDescriptorBuilder;
+import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests
+ * for EditIncomeCommand.
+ */
+public class EditIncomeCommandTest {
+
+    private Model model = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
+
+    @Test
+    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+        Income editedIncome = new TransactionBuilder().buildIncome();
+        EditTransactionDescriptor descriptor =
+                new EditTransactionDescriptorBuilder(editedIncome).build();
+        EditIncomeCommand editIncomeCommand = new EditIncomeCommand(
+                new EditCommand(INDEX_FIRST_TRANSACTION, descriptor));
+
+        String expectedMessage = String.format(EditIncomeCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS, editedIncome);
+
+        Model expectedModel = new ModelManager(new FinanceTracker(model.getFinanceTracker()), new UserPrefs());
+        expectedModel.setIncome(model.getFilteredIncomeList().get(0), editedIncome);
+
+        assertCommandSuccess(editIncomeCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_someFieldsSpecifiedUnfilteredList_success() {
+        Index indexLastIncome = Index.fromOneBased(model.getFilteredIncomeList().size());
+        Income lastIncome = model.getFilteredIncomeList().get(indexLastIncome.getZeroBased());
+
+        TransactionBuilder incomeInList = new TransactionBuilder(lastIncome);
+        Income editedIncome = incomeInList.withTitle(VALID_TITLE_BOB).withAmount(VALID_AMOUNT_BOB)
+                .withCategories(VALID_CATEGORY_HUSBAND).buildIncome();
+
+        EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder()
+                .withTitle(VALID_TITLE_BOB).withAmount(VALID_AMOUNT_BOB).withCategories(VALID_CATEGORY_HUSBAND).build();
+        EditIncomeCommand editIncomeCommand = new EditIncomeCommand(
+                new EditCommand(indexLastIncome, descriptor));
+
+        String expectedMessage = String.format(EditIncomeCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS, editedIncome);
+
+        Model expectedModel = new ModelManager(new FinanceTracker(model.getFinanceTracker()), new UserPrefs());
+        expectedModel.setIncome(lastIncome, editedIncome);
+
+        assertCommandSuccess(editIncomeCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_noFieldSpecifiedUnfilteredList_success() {
+        EditIncomeCommand editIncomeCommand = new EditIncomeCommand(
+                new EditCommand(INDEX_FIRST_TRANSACTION, new EditTransactionDescriptor()));
+        Income editedIncome = model.getFilteredIncomeList().get(INDEX_FIRST_TRANSACTION.getZeroBased());
+
+        String expectedMessage = String.format(EditIncomeCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS, editedIncome);
+
+        Model expectedModel = new ModelManager(new FinanceTracker(model.getFinanceTracker()), new UserPrefs());
+
+        assertCommandSuccess(editIncomeCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_filteredList_success() {
+        showIncomeAtIndex(model, INDEX_FIRST_TRANSACTION);
+
+        Income incomeInFilteredList = model.getFilteredIncomeList()
+                .get(INDEX_FIRST_TRANSACTION.getZeroBased());
+        Income editedIncome =
+                new TransactionBuilder(incomeInFilteredList).withTitle(VALID_TITLE_BOB).buildIncome();
+        EditIncomeCommand editIncomeCommand = new EditIncomeCommand(new EditCommand(INDEX_FIRST_TRANSACTION,
+                new EditTransactionDescriptorBuilder().withTitle(VALID_TITLE_BOB).build()));
+
+        String expectedMessage = String.format(EditIncomeCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS, editedIncome);
+
+        Model expectedModel = new ModelManager(new FinanceTracker(model.getFinanceTracker()), new UserPrefs());
+        expectedModel.setIncome(model.getFilteredIncomeList().get(0), editedIncome);
+
+        assertCommandSuccess(editIncomeCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIncomeIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredIncomeList().size() + 1);
+        EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder()
+                .withTitle(VALID_TITLE_BOB).build();
+        EditIncomeCommand editIncomeCommand = new EditIncomeCommand(
+                new EditCommand(outOfBoundIndex, descriptor));
+
+        assertCommandFailure(editIncomeCommand, model, Messages.MESSAGE_INVALID_INCOME_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Edit filtered list where index is larger than size of filtered list,
+     * but smaller than size of finance tracker
+     */
+    @Test
+    public void execute_invalidIncomeIndexFilteredList_failure() {
+        showIncomeAtIndex(model, INDEX_FIRST_TRANSACTION);
+        Index outOfBoundIndex = INDEX_SECOND_TRANSACTION;
+        // ensures that outOfBoundIndex is still in bounds of finance tracker list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getFinanceTracker().getIncomeList().size());
+
+        EditIncomeCommand editIncomeCommand = new EditIncomeCommand(new EditCommand(outOfBoundIndex,
+                new EditTransactionDescriptorBuilder().withTitle(VALID_TITLE_BOB).build()));
+
+        assertCommandFailure(editIncomeCommand, model, Messages.MESSAGE_INVALID_INCOME_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final EditIncomeCommand standardCommand = new EditIncomeCommand(
+                new EditCommand(INDEX_FIRST_TRANSACTION, DESC_AMY));
+
+        // same values -> returns true
+        EditTransactionDescriptor copyDescriptor = new EditTransactionDescriptor(DESC_AMY);
+        EditIncomeCommand commandWithSameValues = new EditIncomeCommand(
+                new EditCommand(INDEX_FIRST_TRANSACTION, copyDescriptor));
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_TRANSACTION, DESC_AMY)));
+
+        // different descriptor -> returns false
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_TRANSACTION, DESC_BOB)));
+    }
+
+}

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
@@ -206,22 +206,13 @@ public class FinanceTrackerParserTest {
 
     @Test
     public void parseCommand_editWhenOverviewTab() throws Exception {
-        Transaction transaction = new TransactionBuilder().build();
-        EditCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder(transaction).build();
-        EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_TRANSACTION.getOneBased() + " "
-                + TransactionUtil.getEditTransactionDescriptorDetails(descriptor), overviewUiStateStub);
-        assertEquals(new EditCommand(INDEX_FIRST_TRANSACTION, descriptor), command);
+        assertThrows(ParseException.class, () -> parser.parseCommand(EditCommand.COMMAND_WORD, overviewUiStateStub));
     }
 
+    // TODO: Update once EditIncomeCommand is implemented.
     @Test
     public void parseCommand_editWhenIncomeTab() throws Exception {
-        Transaction transaction = new TransactionBuilder().build();
-        EditCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder(transaction).build();
-        EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_TRANSACTION.getOneBased() + " "
-                + TransactionUtil.getEditTransactionDescriptorDetails(descriptor), incomeUiStateStub);
-        assertEquals(new EditCommand(INDEX_FIRST_TRANSACTION, descriptor), command);
+        assertThrows(ParseException.class, () -> parser.parseCommand(EditCommand.COMMAND_WORD, incomeUiStateStub));
     }
 
     @Test
@@ -236,12 +227,7 @@ public class FinanceTrackerParserTest {
 
     @Test
     public void parseCommand_editWhenAnalyticsTab() throws Exception {
-        Transaction transaction = new TransactionBuilder().build();
-        EditCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder(transaction).build();
-        EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_TRANSACTION.getOneBased() + " "
-                + TransactionUtil.getEditTransactionDescriptorDetails(descriptor), analyticsUiStateStub);
-        assertEquals(new EditCommand(INDEX_FIRST_TRANSACTION, descriptor), command);
+        assertThrows(ParseException.class, () -> parser.parseCommand(EditCommand.COMMAND_WORD, analyticsUiStateStub));
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
@@ -209,16 +209,20 @@ public class FinanceTrackerParserTest {
         assertThrows(ParseException.class, () -> parser.parseCommand(EditCommand.COMMAND_WORD, overviewUiStateStub));
     }
 
-    // TODO: Update once EditIncomeCommand is implemented.
     @Test
     public void parseCommand_editWhenIncomeTab() throws Exception {
-        assertThrows(ParseException.class, () -> parser.parseCommand(EditCommand.COMMAND_WORD, incomeUiStateStub));
+        Income income = new TransactionBuilder().buildIncome();
+        EditCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder(income).build();
+        EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
+                + INDEX_FIRST_TRANSACTION.getOneBased() + " "
+                + TransactionUtil.getEditTransactionDescriptorDetails(descriptor), incomeUiStateStub);
+        assertEquals(new EditCommand(INDEX_FIRST_TRANSACTION, descriptor), command);
     }
 
     @Test
     public void parseCommand_editWhenExpensesTab() throws Exception {
-        Transaction transaction = new TransactionBuilder().build();
-        EditCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder(transaction).build();
+        Expense expense = new TransactionBuilder().buildExpense();
+        EditCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder(expense).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_TRANSACTION.getOneBased() + " "
                 + TransactionUtil.getEditTransactionDescriptorDetails(descriptor), expensesUiStateStub);


### PR DESCRIPTION
Changes:
- Add generic `edit` command that returns one of the 2 specialised `edit` commands depending on UI state.
- Update test cases accordingly.
- Fix hash code for `FinanceTracker`.
- Fix `addExpense` and `addIncome` methods of `ModelManager` updating the wrong list.

Resolves #86.