### PR TITLE
Fix 'tab' command not working with TabPane

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
@@ -1,5 +1,7 @@
 package ay2021s1_cs2103_w16_3.finesse.ui;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -294,28 +296,14 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
-     * Programmatically switches UI tab based on the specified tab. If the specified tab is {@code null},
-     * do nothing.
+     * Programmatically switches UI tab based on the specified tab.
      *
      * @param tab The tab to switch to.
+     * @throws NullPointerException If the tab is {@code null}.
      */
     private void switchTabs(UiState.Tab tab) {
-        switch (tab) {
-        case OVERVIEW:
-            handleOverview();
-            break;
-        case INCOME:
-            handleIncome();
-            break;
-        case EXPENSES:
-            handleExpense();
-            break;
-        case ANALYTICS:
-            handleAnalytics();
-            break;
-        default:
-            // Do nothing.
-        }
+        requireNonNull(tab);
+        tabPane.getSelectionModel().select(tab.getTabIndex());
     }
 
     /**

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/UiState.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/UiState.java
@@ -23,7 +23,7 @@ public class UiState {
          *
          * @param tabIndex The index of the tab in the {@code TabPane}.
          */
-        private Tab(int tabIndex) {
+        Tab(int tabIndex) {
             this.tabIndex = tabIndex;
         }
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/UiState.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/UiState.java
@@ -10,10 +10,31 @@ public class UiState {
      * Tabs present in the UI.
      */
     public enum Tab {
-        OVERVIEW,
-        INCOME,
-        EXPENSES,
-        ANALYTICS;
+        OVERVIEW(1),
+        INCOME(2),
+        EXPENSES(3),
+        ANALYTICS(4);
+
+        /** The index of the tab in the {@code TabPane}. */
+        private final int tabIndex;
+
+        /**
+         * Constructs a new {@code Tab} enum with the specified tab index.
+         *
+         * @param tabIndex The index of the tab in the {@code TabPane}.
+         */
+        private Tab(int tabIndex) {
+            this.tabIndex = tabIndex;
+        }
+
+        /**
+         * Returns the index of the tab in the {@code TabPane}.
+         *
+         * @return The index of the tab in the {@code TabPane}.
+         */
+        public int getTabIndex() {
+            return tabIndex;
+        }
 
         /**
          * Returns a string representation of this {@code Tab}.

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/ui/UiStateTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/ui/UiStateTest.java
@@ -9,6 +9,14 @@ import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
 public class UiStateTest {
     @Test
+    public void getTabEnumIndex_returnsCorrectIndex() {
+        assertEquals(1, Tab.OVERVIEW.getTabIndex());
+        assertEquals(2, Tab.INCOME.getTabIndex());
+        assertEquals(3, Tab.EXPENSES.getTabIndex());
+        assertEquals(4, Tab.ANALYTICS.getTabIndex());
+    }
+
+    @Test
     public void constructor_nullCurrentTab_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new UiState((Tab) null));
     }


### PR DESCRIPTION
Changes:
- Update the 'tab' command to change the tab via the `TabPane`.
- Add tab index information to the `UiState.Tab` enum.
- Update corresponding tests.

Fixes #112.