### PR TITLE
Use LocalDate for Date model and add validation

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedExpense.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedExpense.java
@@ -49,7 +49,7 @@ class JsonAdaptedExpense {
     public JsonAdaptedExpense(Expense source) {
         title = source.getTitle().fullTitle;
         amount = source.getAmount().value;
-        date = source.getDate().value;
+        date = source.getDate().toString();
         categories.addAll(source.getCategories().stream()
                 .map(JsonAdaptedCategory::new)
                 .collect(Collectors.toList()));

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedIncome.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedIncome.java
@@ -49,7 +49,7 @@ class JsonAdaptedIncome {
     public JsonAdaptedIncome(Income source) {
         title = source.getTitle().fullTitle;
         amount = source.getAmount().value;
-        date = source.getDate().value;
+        date = source.getDate().toString();
         categories.addAll(source.getCategories().stream()
                 .map(JsonAdaptedCategory::new)
                 .collect(Collectors.toList()));

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedTransaction.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedTransaction.java
@@ -49,7 +49,7 @@ class JsonAdaptedTransaction {
     public JsonAdaptedTransaction(Transaction source) {
         title = source.getTitle().fullTitle;
         amount = source.getAmount().value;
-        date = source.getDate().value;
+        date = source.getDate().toString();
         categories.addAll(source.getCategories().stream()
                 .map(JsonAdaptedCategory::new)
                 .collect(Collectors.toList()));

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandTestUtil.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandTestUtil.java
@@ -31,8 +31,8 @@ public class CommandTestUtil {
     public static final String VALID_TITLE_BOB = "Bob Choo";
     public static final String VALID_AMOUNT_AMY = "11111111";
     public static final String VALID_AMOUNT_BOB = "22222222";
-    public static final String VALID_DATE_AMY = "31/10/2020";
-    public static final String VALID_DATE_BOB = "25/12/2020";
+    public static final String VALID_DATE_AMY = "31/10/2019";
+    public static final String VALID_DATE_BOB = "25/12/2019";
     public static final String VALID_CATEGORY_HUSBAND = "husband";
     public static final String VALID_CATEGORY_FRIEND = "friend";
 

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/DateTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/DateTest.java
@@ -4,6 +4,10 @@ import static ay2021s1_cs2103_w16_3.finesse.testutil.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
 import org.junit.jupiter.api.Test;
 
 public class DateTest {
@@ -41,6 +45,11 @@ public class DateTest {
         assertFalse(Date.isValidDate("32/09/2020")); // day is not valid
         assertFalse(Date.isValidDate("03/13/2020")); // month is not valid
         assertFalse(Date.isValidDate("01/01/0000")); // year is not valid
+
+        // date from the future is not allowed
+        LocalDate pastDate = LocalDate.of(2020, 10, 16);
+        assertFalse(Date.isValidDate("17/10/2020", Clock.fixed(
+                pastDate.atStartOfDay(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault())));
 
         // valid date
         assertTrue(Date.isValidDate("06/10/2020")); // 6 October 2020

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/testutil/TransactionUtil.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/testutil/TransactionUtil.java
@@ -49,7 +49,7 @@ public class TransactionUtil {
         StringBuilder sb = new StringBuilder();
         sb.append(PREFIX_TITLE + transaction.getTitle().fullTitle + " ");
         sb.append(PREFIX_AMOUNT + transaction.getAmount().value + " ");
-        sb.append(PREFIX_DATE + transaction.getDate().value + " ");
+        sb.append(PREFIX_DATE + transaction.getDate().toString() + " ");
         transaction.getCategories().stream().forEach(
             s -> sb.append(PREFIX_CATEGORY + s.categoryName + " ")
         );
@@ -63,7 +63,7 @@ public class TransactionUtil {
         StringBuilder sb = new StringBuilder();
         descriptor.getTitle().ifPresent(title -> sb.append(PREFIX_TITLE).append(title.fullTitle).append(" "));
         descriptor.getAmount().ifPresent(amount -> sb.append(PREFIX_AMOUNT).append(amount.value).append(" "));
-        descriptor.getDate().ifPresent(date -> sb.append(PREFIX_DATE).append(date.value).append(" "));
+        descriptor.getDate().ifPresent(date -> sb.append(PREFIX_DATE).append(date.toString()).append(" "));
         if (descriptor.getCategories().isPresent()) {
             Set<Category> categories = descriptor.getCategories().get();
             if (categories.isEmpty()) {


### PR DESCRIPTION
Resolves #117 

- The `Date` constructor still takes in a String, and further parsing into a `LocalDate` takes place inside the constructor. This allows the existing functionalities from command parsers and storage to remain largely unchanged.
- The `toString()` method is used to generate commands and write to storage (previously, the raw string value was used directly). This means that the output of `toString()`, once turned into a command or storage, can be used to regenerate an identical `Date` object. Javadoc has been updated accordingly.
- The field `value` was originally `public`. It is now `private` as the dependencies on it have been removed and replaced with `toString()`.
- Switched the validation from `SimpleDateFormat` to `DateTimeFormatter` as `DateTimeFormatter` is used to help create the `LocalDate` object. Enabling "strict mode" and regex validation are now obsolete and have been removed.
- The new data validation rules specify that the input date cannot be later than the current date. However this is not trivial to implement in unit tests, as the notion of "current date" by definition changes over time.
  - Thus, `isValidDate` was overloaded to take in a `Clock` that specifies the current date, for test code to call using a `Clock` stub with a fixed date.
  - As of now, functional code should not need to use this new method - the old method is still supported using `Clock.systemDefaultZone()`.

Pitest: https://ay2021s1-cs2103t-w16-3.github.io/reports/pitest/202010172058/index.html (codecov is lying 😠)