### PR TITLE
Use BigDecimal for Amount model

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Amount.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Amount.java
@@ -3,6 +3,8 @@ package ay2021s1_cs2103_w16_3.finesse.model.transaction;
 import static ay2021s1_cs2103_w16_3.finesse.commons.util.AppUtil.checkArgument;
 import static java.util.Objects.requireNonNull;
 
+import java.math.BigDecimal;
+
 /**
  * Represents a Transaction's amount in the finance tracker.
  * Guarantees: immutable; is valid as declared in {@link #isValidAmount(String)}
@@ -13,7 +15,7 @@ public class Amount {
     public static final String MESSAGE_CONSTRAINTS =
             "Amounts should only contain numbers, with an optional 2 decimal places or '$' prefix";
     public static final String VALIDATION_REGEX = "^\\$?\\d+(\\.\\d{2})?$";
-    public final String value;
+    private final BigDecimal value;
 
     /**
      * Constructs a {@code Amount}.
@@ -23,26 +25,31 @@ public class Amount {
     public Amount(String amount) {
         requireNonNull(amount);
         checkArgument(isValidAmount(amount), MESSAGE_CONSTRAINTS);
-        value = amount;
+        value = new BigDecimal(amount.replaceFirst("^\\$", ""));
     }
 
     /**
      * Returns true if a given string is a valid amount.
+     * A valid amount must only contain numbers, with an optional 2 decimal places or '$' prefix.
      */
     public static boolean isValidAmount(String test) {
         return test.matches(VALIDATION_REGEX);
     }
 
+    /**
+     * Returns a String representation of this Amount that can be used to construct an identical Amount.
+     * @return A String representation of this Amount.
+     */
     @Override
     public String toString() {
-        return value;
+        return String.format("$%.2f", value);
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Amount // instanceof handles nulls
-                && value.equals(((Amount) other).value)); // state check
+                && (value.compareTo(((Amount) other).value)) == 0); // state check
     }
 
     @Override

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedExpense.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedExpense.java
@@ -48,7 +48,7 @@ class JsonAdaptedExpense {
      */
     public JsonAdaptedExpense(Expense source) {
         title = source.getTitle().fullTitle;
-        amount = source.getAmount().value;
+        amount = source.getAmount().toString();
         date = source.getDate().toString();
         categories.addAll(source.getCategories().stream()
                 .map(JsonAdaptedCategory::new)

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedIncome.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedIncome.java
@@ -48,7 +48,7 @@ class JsonAdaptedIncome {
      */
     public JsonAdaptedIncome(Income source) {
         title = source.getTitle().fullTitle;
-        amount = source.getAmount().value;
+        amount = source.getAmount().toString();
         date = source.getDate().toString();
         categories.addAll(source.getCategories().stream()
                 .map(JsonAdaptedCategory::new)

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedTransaction.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedTransaction.java
@@ -48,7 +48,7 @@ class JsonAdaptedTransaction {
      */
     public JsonAdaptedTransaction(Transaction source) {
         title = source.getTitle().fullTitle;
-        amount = source.getAmount().value;
+        amount = source.getAmount().toString();
         date = source.getDate().toString();
         categories.addAll(source.getCategories().stream()
                 .map(JsonAdaptedCategory::new)

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/TransactionCard.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/TransactionCard.java
@@ -50,7 +50,7 @@ public class TransactionCard extends UiPart<Region> {
         cardPane.setPrefHeight(PREFFERED_CARD_HEIGHT);
         id.setText(displayedIndex + ". ");
         title.setText(transaction.getTitle().fullTitle);
-        amount.setText(transaction.getAmount().value);
+        amount.setText(transaction.getAmount().toString());
         transaction.getCategories().stream()
                 .sorted(Comparator.comparing(category -> category.categoryName))
                 .forEach(category -> {

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/AmountTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/AmountTest.java
@@ -17,6 +17,7 @@ public class AmountTest {
     public void constructor_invalidAmount_throwsIllegalArgumentException() {
         String invalidAmount = "";
         assertThrows(IllegalArgumentException.class, () -> new Amount(invalidAmount));
+        assertThrows(IllegalArgumentException.class, () -> new Amount("40.404"));
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/testutil/TransactionUtil.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/testutil/TransactionUtil.java
@@ -48,7 +48,7 @@ public class TransactionUtil {
     public static String getTransactionDetails(Transaction transaction) {
         StringBuilder sb = new StringBuilder();
         sb.append(PREFIX_TITLE + transaction.getTitle().fullTitle + " ");
-        sb.append(PREFIX_AMOUNT + transaction.getAmount().value + " ");
+        sb.append(PREFIX_AMOUNT + transaction.getAmount().toString() + " ");
         sb.append(PREFIX_DATE + transaction.getDate().toString() + " ");
         transaction.getCategories().stream().forEach(
             s -> sb.append(PREFIX_CATEGORY + s.categoryName + " ")
@@ -62,7 +62,7 @@ public class TransactionUtil {
     public static String getEditTransactionDescriptorDetails(EditCommand.EditTransactionDescriptor descriptor) {
         StringBuilder sb = new StringBuilder();
         descriptor.getTitle().ifPresent(title -> sb.append(PREFIX_TITLE).append(title.fullTitle).append(" "));
-        descriptor.getAmount().ifPresent(amount -> sb.append(PREFIX_AMOUNT).append(amount.value).append(" "));
+        descriptor.getAmount().ifPresent(amount -> sb.append(PREFIX_AMOUNT).append(amount.toString()).append(" "));
         descriptor.getDate().ifPresent(date -> sb.append(PREFIX_DATE).append(date.toString()).append(" "));
         if (descriptor.getCategories().isPresent()) {
             Set<Category> categories = descriptor.getCategories().get();


### PR DESCRIPTION
Resolves #116 

- The `Amount` constructor still takes in a String, and further parsing into a `BigDecimal` takes place inside the constructor. This allows the existing functionalities from command parsers and storage to remain largely unchanged.
- The `toString()` method is used to generate commands and write to storage (previously, the raw string value was used directly). This means that the output of `toString()`, once turned into a command or storage, can be used to regenerate an identical `Amount` object. Javadoc has been updated accordingly.
  - Note that although the `Amount` constructor is quite flexible with formats (optional '$' and 2 decimal places), the `toString()` will always give a standardized format (2 decimal places, with '$'). It will be displayed like this in the UI as well.
- The field `value` was originally `public`. It is now `private` as the dependencies on it have been removed and replaced with `toString()`.
  - Now that both `Amount` and `Date` have been changed, we should try and follow suit for `Title` (and perhaps `Category` as well) in a future issue.
- The original plan was to explore using `java.util.Currency`, but it only appears to support formatting and not arithmetic. We need to use `BigDecimal` instead. `BigDecimal` is preferred over other number types due to its robustness against range and precision issues.
  - Equality with `BigDecimal` works a bit differently. It checks the precision as well. For example `2` is not equal to `2.00`. This should not affect the user but it upsets some unit tests, so the equality for `Amount` was changed to use `compareTo`, which ignores precision.

Pitest: https://ay2021s1-cs2103t-w16-3.github.io/reports/pitest/202010180019/