### PR TITLE
Update 'title' and 'category' validation

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/category/Category.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/category/Category.java
@@ -10,7 +10,7 @@ import static java.util.Objects.requireNonNull;
 public class Category {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Category names should be printable and contain at least one graphical character.";
+            "Category names should contain at least one non-whitespace printable ASCII character.";
     public static final String VALIDATION_REGEX = "\\p{Graph}\\p{Print}*";
 
     public final String categoryName;

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/category/Category.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/category/Category.java
@@ -9,8 +9,9 @@ import static java.util.Objects.requireNonNull;
  */
 public class Category {
 
-    public static final String MESSAGE_CONSTRAINTS = "Category names should be printable.";
-    public static final String VALIDATION_REGEX = "\\p{Print}+";
+    public static final String MESSAGE_CONSTRAINTS =
+            "Category names should be printable and contain at least one graphical character.";
+    public static final String VALIDATION_REGEX = "\\p{Graph}\\p{Print}*";
 
     public final String categoryName;
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Title.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Title.java
@@ -10,13 +10,8 @@ import static java.util.Objects.requireNonNull;
 public class Title implements Comparable<Title> {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Titles should only contain alphanumeric characters and spaces, and it should not be blank";
-
-    /*
-     * The first character of the title must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
-     */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+            "Titles should be printable and contain at least one graphical character.";
+    public static final String VALIDATION_REGEX = "\\p{Graph}\\p{Print}*";
 
     public final String fullTitle;
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Title.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Title.java
@@ -10,7 +10,7 @@ import static java.util.Objects.requireNonNull;
 public class Title implements Comparable<Title> {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Titles should be printable and contain at least one graphical character.";
+            "Titles should contain at least one non-whitespace printable ASCII character.";
     public static final String VALIDATION_REGEX = "\\p{Graph}\\p{Print}*";
 
     public final String fullTitle;

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandTestUtil.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandTestUtil.java
@@ -43,7 +43,7 @@ public class CommandTestUtil {
     public static final String CATEGORY_DESC_FRIEND = " " + PREFIX_CATEGORY + VALID_CATEGORY_FRIEND;
     public static final String CATEGORY_DESC_HUSBAND = " " + PREFIX_CATEGORY + VALID_CATEGORY_HUSBAND;
 
-    public static final String INVALID_TITLE_DESC = " " + PREFIX_TITLE + "James&"; // '&' not allowed in titles
+    public static final String INVALID_TITLE_DESC = " " + PREFIX_TITLE + "James\u2416"; // 'SYN' not allowed in titles
     public static final String INVALID_AMOUNT_DESC = " " + PREFIX_AMOUNT + "911a"; // 'a' not allowed in amounts
     public static final String INVALID_DATE_DESC = " " + PREFIX_DATE + "bob!yahoo"; // only numbers and '/' allowed
     public static final String INVALID_CATEGORY_DESC = " " + PREFIX_CATEGORY + "hubby\u2416";

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtilTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtilTest.java
@@ -20,7 +20,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
 
 public class ParserUtilTest {
-    private static final String INVALID_TITLE = "R@chel";
+    private static final String INVALID_TITLE = "R\u2416chel";
     private static final String INVALID_AMOUNT = "+651234";
     private static final String INVALID_DATE = "example.com";
     private static final String INVALID_CATEGORY = "\u2416friend";

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/category/CategoryTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/category/CategoryTest.java
@@ -1,6 +1,8 @@
 package ay2021s1_cs2103_w16_3.finesse.model.category;
 
 import static ay2021s1_cs2103_w16_3.finesse.testutil.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -21,6 +23,20 @@ public class CategoryTest {
     public void isValidCategoryName() {
         // null category name
         assertThrows(NullPointerException.class, () -> Category.isValidCategoryName(null));
+
+        // invalid category name
+        assertFalse(Category.isValidCategoryName("")); // empty string
+        assertFalse(Category.isValidCategoryName("   ")); // spaces only
+        assertFalse(Category.isValidCategoryName("\u0000world")); // non-graphical character
+
+        // valid category name
+        assertTrue(Category.isValidCategoryName("peter jack")); // alphabets only
+        assertTrue(Category.isValidCategoryName("12345")); // numbers only
+        assertTrue(Category.isValidCategoryName("peter the 2nd")); // alphanumeric characters
+        assertTrue(Category.isValidCategoryName("Capital Tan")); // with capital letters
+        assertTrue(Category.isValidCategoryName("David Roger Jackson Ray Jr 2nd")); // long category name
+        assertTrue(Category.isValidCategoryName("^")); // only non-alphanumeric characters
+        assertTrue(Category.isValidCategoryName("peter*")); // contains non-alphanumeric characters
     }
 
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/TitleTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/TitleTest.java
@@ -26,15 +26,16 @@ public class TitleTest {
 
         // invalid title
         assertFalse(Title.isValidTitle("")); // empty string
-        assertFalse(Title.isValidTitle(" ")); // spaces only
-        assertFalse(Title.isValidTitle("^")); // only non-alphanumeric characters
-        assertFalse(Title.isValidTitle("peter*")); // contains non-alphanumeric characters
+        assertFalse(Title.isValidTitle("   ")); // spaces only
+        assertFalse(Title.isValidTitle("\u0000world")); // non-graphical character
 
         // valid title
         assertTrue(Title.isValidTitle("peter jack")); // alphabets only
         assertTrue(Title.isValidTitle("12345")); // numbers only
         assertTrue(Title.isValidTitle("peter the 2nd")); // alphanumeric characters
         assertTrue(Title.isValidTitle("Capital Tan")); // with capital letters
-        assertTrue(Title.isValidTitle("David Roger Jackson Ray Jr 2nd")); // long titles
+        assertTrue(Title.isValidTitle("David Roger Jackson Ray Jr 2nd")); // long title
+        assertTrue(Title.isValidTitle("^")); // only non-alphanumeric characters
+        assertTrue(Title.isValidTitle("peter*")); // contains non-alphanumeric characters
     }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedExpenseTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedExpenseTest.java
@@ -19,7 +19,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
 import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
 
 public class JsonAdaptedExpenseTest {
-    private static final String INVALID_TITLE = "R@chel";
+    private static final String INVALID_TITLE = "R\u2416chel";
     private static final String INVALID_AMOUNT = "+651234";
     private static final String INVALID_DATE = "example.com";
     private static final String INVALID_CATEGORY = "\u2416friend";

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedIncomeTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonAdaptedIncomeTest.java
@@ -19,7 +19,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
 import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
 
 public class JsonAdaptedIncomeTest {
-    private static final String INVALID_TITLE = "R@chel";
+    private static final String INVALID_TITLE = "R\u2416chel";
     private static final String INVALID_AMOUNT = "+651234";
     private static final String INVALID_DATE = "example.com";
     private static final String INVALID_CATEGORY = "\u2416friend";


### PR DESCRIPTION
Changes:
- Update validation for `Title` to allow only printable characters (with at least one graphical character).
  - The set of printable characters is the union of the set of graphical characters and the set of whitespace characters.
- Update validation for `Category` to match that of `Title`.
- Update corresponding tests.

Resolves #129.