### PR TITLE
Siddarth/fix ui bug

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
@@ -13,6 +13,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
 import ay2021s1_cs2103_w16_3.finesse.ui.expense.ExpensePanel;
 import ay2021s1_cs2103_w16_3.finesse.ui.frequent.FrequentExpensePanel;
+import ay2021s1_cs2103_w16_3.finesse.ui.frequent.FrequentIncomePanel;
 import ay2021s1_cs2103_w16_3.finesse.ui.income.IncomePanel;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
@@ -46,6 +47,7 @@ public class MainWindow extends UiPart<Stage> {
     // Independent Ui parts residing in this Ui container
     private TransactionListPanel transactionListPanel;
     private FrequentExpensePanel frequentExpensePanel;
+    private FrequentIncomePanel frequentIncomePanel;
     private IncomePanel incomePanel;
     private ExpensePanel expensePanel;
     private ResultDisplay resultDisplay;
@@ -115,6 +117,9 @@ public class MainWindow extends UiPart<Stage> {
 
         frequentExpensePanel = new FrequentExpensePanel(logic.getFilteredFrequentExpenseList());
         savingsGoalPlaceholder.getChildren().add(frequentExpensePanel.getRoot());
+
+        frequentIncomePanel = new FrequentIncomePanel(logic.getFilteredFrequentExpenseList());
+        savingsGoalPlaceholder.getChildren().add(frequentIncomePanel.getRoot());
 
         transactionListPanel = new TransactionListPanel(logic.getFilteredTransactionList());
         transactionListPanelPlaceholder.getChildren().add(transactionListPanel.getRoot());
@@ -195,14 +200,15 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     private void handleIncome() {
         if (menuIncomeTab.isSelected()) {
-            panelLabel.setText("Income");
-
-            savingsGoalPanel = new SavingsGoalPanel();
-            savingsGoalPlaceholder.getChildren().add(savingsGoalPanel.getRoot());
+            panelLabel.setText("Incomes");
+            rightPanelLabel.setText("Frequent Incomes");
 
             incomePanel = new IncomePanel(logic.getFilteredIncomeList());
             transactionListPanelPlaceholder.getChildren().add(incomePanel.getRoot());
             incomePanel.getRoot().toFront();
+
+            frequentIncomePanel = new FrequentIncomePanel(logic.getFilteredFrequentExpenseList());
+            savingsGoalPlaceholder.getChildren().add(frequentIncomePanel.getRoot());
         }
         onIncome();
         uiState.setCurrentTab(UiState.Tab.INCOME);
@@ -235,9 +241,14 @@ public class MainWindow extends UiPart<Stage> {
     private void handleAnalytics() {
         if (menuAnalyticsTab.isSelected()) {
             panelLabel.setText("Analytics");
+            rightPanelLabel.setText("Savings Summary");
+
             transactionListPanel = new TransactionListPanel(logic.getFilteredTransactionList());
             transactionListPanelPlaceholder.getChildren().add(transactionListPanel.getRoot());
             transactionListPanel.getRoot().toFront();
+
+            savingsGoalPanel = new SavingsGoalPanel();
+            savingsGoalPlaceholder.getChildren().add(savingsGoalPanel.getRoot());
         }
         onAnalytics();
         uiState.setCurrentTab(UiState.Tab.ANALYTICS);

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/frequent/FrequentIncomePanel.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/frequent/FrequentIncomePanel.java
@@ -17,15 +17,15 @@ public class FrequentIncomePanel extends UiPart<Region> {
     private ListView<FrequentExpense> frequentTransactionList;
 
     /**
-     * Creates a {@code FrequentExpensePanel} with the given {@code ObservableList}.
+     * Creates a {@code FrequentIncomePanel} with the given {@code ObservableList}.
      */
-    public FrequentIncomePanel(ObservableList<FrequentExpense> frequentExpensesList) {
+    public FrequentIncomePanel(ObservableList<FrequentExpense> frequentIncomesList) {
         super(FXML);
-        frequentTransactionList.setItems(frequentExpensesList);
-        frequentTransactionList.setCellFactory(listView -> new FrequentExpenseListViewCell());
+        frequentTransactionList.setItems(frequentIncomesList);
+        frequentTransactionList.setCellFactory(listView -> new FrequentIncomeListViewCell());
     }
 
-    class FrequentExpenseListViewCell extends ListCell<FrequentExpense> {
+    class FrequentIncomeListViewCell extends ListCell<FrequentExpense> {
         @Override
         protected void updateItem(FrequentExpense frequentExpense, boolean empty) {
             super.updateItem(frequentExpense, empty);

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/frequent/FrequentIncomePanel.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/frequent/FrequentIncomePanel.java
@@ -1,8 +1,5 @@
 package ay2021s1_cs2103_w16_3.finesse.ui.frequent;
 
-import java.util.logging.Logger;
-
-import ay2021s1_cs2103_w16_3.finesse.commons.core.LogsCenter;
 import ay2021s1_cs2103_w16_3.finesse.model.frequent.FrequentExpense;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
 import ay2021s1_cs2103_w16_3.finesse.ui.UiPart;
@@ -13,9 +10,8 @@ import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 
-public class FrequentExpensePanel extends UiPart<Region> {
+public class FrequentIncomePanel extends UiPart<Region> {
     private static final String FXML = "FrequentTransactionPanel.fxml";
-    private final Logger logger = LogsCenter.getLogger(FrequentExpensePanel.class);
 
     @FXML
     private ListView<FrequentExpense> frequentTransactionList;
@@ -23,7 +19,7 @@ public class FrequentExpensePanel extends UiPart<Region> {
     /**
      * Creates a {@code FrequentExpensePanel} with the given {@code ObservableList}.
      */
-    public FrequentExpensePanel(ObservableList<FrequentExpense> frequentExpensesList) {
+    public FrequentIncomePanel(ObservableList<FrequentExpense> frequentExpensesList) {
         super(FXML);
         frequentTransactionList.setItems(frequentExpensesList);
         frequentTransactionList.setCellFactory(listView -> new FrequentExpenseListViewCell());

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -132,18 +132,18 @@
 
 .cell_big_label {
     -fx-font-family: "Eczar";
-    -fx-font-size: 16px;
+    -fx-font-size: 14px;
     -fx-text-fill: #010504;
 }
 
 .cell_categories {
-    -fx-font-size: 16px;
+    -fx-font-size: 14px;
     -fx-text-fill: #010504;
 }
 
 .cell_small_label {
     -fx-font-family: "Eczar";
-    -fx-font-size: 16px;
+    -fx-font-size: 14px;
     -fx-text-fill: #010504;
 }
 

--- a/src/main/resources/view/FrequentTransactionPanel.fxml
+++ b/src/main/resources/view/FrequentTransactionPanel.fxml
@@ -4,5 +4,5 @@
 <?import javafx.scene.layout.VBox?>
 
 <VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-    <ListView fx:id="frequentExpenseList" styleClass="list-view" VBox.vgrow="ALWAYS"/>
+    <ListView fx:id="frequentTransactionList" styleClass="list-view" VBox.vgrow="ALWAYS"/>
 </VBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -23,7 +23,7 @@
         <TabPane fx:id="tabPane" VBox.vgrow="NEVER" styleClass="tab-pane" tabMinHeight="30">
           <Tab fx:id="menuHelpTab" text="Help" closable="false" />
           <Tab fx:id="menuOverviewTab" text="Overview" closable="false" />
-          <Tab fx:id="menuIncomeTab" text="Income" closable="false" />
+          <Tab fx:id="menuIncomeTab" text="Incomes" closable="false" />
           <Tab fx:id="menuExpenseTab" text="Expenses" closable="false" />
           <Tab fx:id="menuAnalyticsTab" text="Analytics" closable="false" />
         </TabPane>

--- a/src/main/resources/view/TransactionListCard.fxml
+++ b/src/main/resources/view/TransactionListCard.fxml
@@ -12,7 +12,7 @@
 <VBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" alignment="CENTER">
       <GridPane fx:id="transactionDetails" alignment="CENTER_LEFT">
           <columnConstraints>
-              <ColumnConstraints hgrow="ALWAYS" minWidth="30" prefWidth="100" />
+              <ColumnConstraints hgrow="ALWAYS" minWidth="30" prefWidth="130" />
           </columnConstraints>
           <padding>
               <Insets top="5" right="10" bottom="5" left="10" />


### PR DESCRIPTION
Fixed the incorrect behaviour of the header being displayed on the right panel under the `Income` tab. The items being displayed are still `FrequentExpenses` from the `FrequentExpenseList` as the `FrequentIncome` has not been implemented yet. The list displayed will be updated appropriately once `FrequentIncome` has been implemented.