### PR TITLE
Update trailing whitespace check

### DIFF
--- a/config/travis/check-trailing-whitespace.sh
+++ b/config/travis/check-trailing-whitespace.sh
@@ -9,16 +9,8 @@ awk '
         ret = 0
     }
     {
-        # Only warn for markdown files (*.md) to accomodate text editors
-        # which do not properly handle trailing whitespace.
-        # (e.g. GitHub web editor)
-        if ($1 ~ /\.md$/) {
-            severity = "WARN"
-        } else {
-            severity = "ERROR"
-            ret = 1
-        }
-        print severity, $1, $2, " trailing whitespace."
+        ret = 1
+        print "ERROR", $1, $2, " trailing whitespace."
     }
     END {
         exit ret

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -136,7 +136,7 @@ The `Predicate` fields in the three `FilteredList` fields are set such that:
 * `filteredExpenses` shows a view of all `Transaction` objects of type `Expense`
 * `filteredIncomes` shows a view of all `Transaction` objects of type `Income`
 
-The motivation behind having three lists is due to the fact that there are three tabs in the user interface, each having its own list while at the same time retrieving data from the same transaction list. 
+The motivation behind having three lists is due to the fact that there are three tabs in the user interface, each having its own list while at the same time retrieving data from the same transaction list.
 
 ### Storage component
 


### PR DESCRIPTION
Changes:
- Update trailing whitespace check to always fail whenever a trailing whitespace is encountered.
  - This is in contrast to the previous behaviour where trailing whitespace in Markdown files only result in a warning, and not an error.
- Remove trailing whitespace in `DeveloperGuide.md`.

Resolves #151.