### PR TITLE
Refactor tabs

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
@@ -20,6 +20,7 @@ import javafx.scene.control.Button;
 import javafx.scene.control.SelectionModel;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
+import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.StackPane;
 import javafx.scene.text.Text;
 import javafx.stage.Stage;
@@ -52,11 +53,11 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     private Button commandBoxButton;
     @FXML
+    private Button helpButton;
+    @FXML
     private StackPane resultDisplayPlaceholder;
     @FXML
     private StackPane statusbarPlaceholder;
-    @FXML
-    private Tab helpTab;
     @FXML
     private Tab overviewTab;
     @FXML
@@ -129,6 +130,9 @@ public class MainWindow extends UiPart<Stage> {
 
         SelectionModel<Tab> selectionModel = tabPane.getSelectionModel();
         selectionModel.select(overviewTab);
+
+        // Set the bottom anchor after the tabs have been initialized.
+        AnchorPane.setBottomAnchor(tabPane, 0.0);
     }
 
     /**
@@ -137,10 +141,6 @@ public class MainWindow extends UiPart<Stage> {
     public void setActionHandlers() {
         overviewTab.setOnSelectionChanged(event -> {
             handleOverview();
-        });
-
-        helpTab.setOnSelectionChanged(event -> {
-            handleTabHelp();
         });
 
         incomeTab.setOnSelectionChanged(event -> {
@@ -169,16 +169,10 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
-     * Opens the help window or focuses on it if it's already opened.
+     * Displays the help message in the result display.
      */
     @FXML
-    public void handleTabHelp() {
-        if (helpTab.isSelected()) {
-            resultDisplay.setFeedbackToUser(HELP_MESSAGE);
-        }
-    }
-
-    @FXML void handleCommandHelp() {
+    public void handleHelp() {
         resultDisplay.setFeedbackToUser(HELP_MESSAGE);
     }
 
@@ -241,7 +235,7 @@ public class MainWindow extends UiPart<Stage> {
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 
             if (commandResult.isShowHelp()) {
-                handleCommandHelp();
+                handleHelp();
             }
 
             if (commandResult.isExit()) {

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
@@ -11,13 +11,12 @@ import ay2021s1_cs2103_w16_3.finesse.logic.Logic;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
-import ay2021s1_cs2103_w16_3.finesse.ui.expense.ExpensePanel;
-import ay2021s1_cs2103_w16_3.finesse.ui.frequent.FrequentExpensePanel;
-import ay2021s1_cs2103_w16_3.finesse.ui.frequent.FrequentIncomePanel;
-import ay2021s1_cs2103_w16_3.finesse.ui.income.IncomePanel;
+import ay2021s1_cs2103_w16_3.finesse.ui.tabs.AnalyticsTabPane;
+import ay2021s1_cs2103_w16_3.finesse.ui.tabs.ExpenseTabPane;
+import ay2021s1_cs2103_w16_3.finesse.ui.tabs.IncomeTabPane;
+import ay2021s1_cs2103_w16_3.finesse.ui.tabs.OverviewTabPane;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
-import javafx.scene.control.Label;
 import javafx.scene.control.SelectionModel;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
@@ -46,40 +45,26 @@ public class MainWindow extends UiPart<Stage> {
     private final UiState uiState;
 
     // Independent Ui parts residing in this Ui container
-    private TransactionListPanel transactionListPanel;
-    private FrequentExpensePanel frequentExpensePanel;
-    private FrequentIncomePanel frequentIncomePanel;
-    private IncomePanel incomePanel;
-    private ExpensePanel expensePanel;
     private ResultDisplay resultDisplay;
-    private SavingsGoalPanel savingsGoalPanel;
 
     @FXML
     private StackPane commandBoxPlaceholder;
     @FXML
     private Button commandBoxButton;
     @FXML
-    private StackPane transactionListPanelPlaceholder;
-    @FXML
     private StackPane resultDisplayPlaceholder;
-    @FXML
-    private StackPane savingsGoalPlaceholder;
     @FXML
     private StackPane statusbarPlaceholder;
     @FXML
-    private Label panelLabel;
+    private Tab helpTab;
     @FXML
-    private Label rightPanelLabel;
+    private Tab overviewTab;
     @FXML
-    private Tab menuHelpTab;
+    private Tab incomeTab;
     @FXML
-    private Tab menuOverviewTab;
+    private Tab expenseTab;
     @FXML
-    private Tab menuIncomeTab;
-    @FXML
-    private Tab menuExpenseTab;
-    @FXML
-    private Tab menuAnalyticsTab;
+    private Tab analyticsTab;
     @FXML
     private TabPane tabPane;
     @FXML
@@ -112,24 +97,6 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     public void fillInnerParts() {
-        incomePanel = new IncomePanel(logic.getFilteredIncomeList());
-        transactionListPanelPlaceholder.getChildren().add(incomePanel.getRoot());
-
-        expensePanel = new ExpensePanel(logic.getFilteredExpenseList());
-        transactionListPanelPlaceholder.getChildren().add(expensePanel.getRoot());
-
-        frequentExpensePanel = new FrequentExpensePanel(logic.getFilteredFrequentExpenseList());
-        savingsGoalPlaceholder.getChildren().add(frequentExpensePanel.getRoot());
-
-        frequentIncomePanel = new FrequentIncomePanel(logic.getFilteredFrequentIncomeList());
-        savingsGoalPlaceholder.getChildren().add(frequentIncomePanel.getRoot());
-
-        transactionListPanel = new TransactionListPanel(logic.getFilteredTransactionList());
-        transactionListPanelPlaceholder.getChildren().add(transactionListPanel.getRoot());
-
-        savingsGoalPanel = new SavingsGoalPanel(logic.getMonthlyBudget());
-        savingsGoalPlaceholder.getChildren().add(savingsGoalPanel.getRoot());
-
         resultDisplay = new ResultDisplay();
         resultDisplay.setFeedbackToUser(WELCOME_MESSAGE);
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
@@ -141,32 +108,52 @@ public class MainWindow extends UiPart<Stage> {
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
 
         SelectionModel<Tab> selectionModel = tabPane.getSelectionModel();
-        selectionModel.select(menuOverviewTab);
+        selectionModel.select(overviewTab);
 
         onOverview();
+    }
+
+    /**
+     * Initialize the contents of each tab.
+     */
+    public void initializeTabs() {
+        OverviewTabPane overviewTabPane =
+                new OverviewTabPane(logic.getFilteredTransactionList(), logic.getMonthlyBudget());
+        overviewTab.setContent(overviewTabPane.getRoot());
+
+        IncomeTabPane incomeTabPane =
+                new IncomeTabPane(logic.getFilteredIncomeList(), logic.getFilteredFrequentIncomeList());
+        incomeTab.setContent(incomeTabPane.getRoot());
+
+        ExpenseTabPane expenseTabPane =
+                new ExpenseTabPane(logic.getFilteredExpenseList(), logic.getFilteredFrequentExpenseList());
+        expenseTab.setContent(expenseTabPane.getRoot());
+
+        AnalyticsTabPane analyticsTabPane = new AnalyticsTabPane();
+        analyticsTab.setContent(analyticsTabPane.getRoot());
     }
 
     /**
      * Sets up all the action handlers for the tabs on the tab pane.
      */
     public void setActionHandlers() {
-        menuOverviewTab.setOnSelectionChanged(event -> {
+        overviewTab.setOnSelectionChanged(event -> {
             handleOverview();
         });
 
-        menuHelpTab.setOnSelectionChanged(event -> {
+        helpTab.setOnSelectionChanged(event -> {
             handleTabHelp();
         });
 
-        menuIncomeTab.setOnSelectionChanged(event -> {
+        incomeTab.setOnSelectionChanged(event -> {
             handleIncome();
         });
 
-        menuExpenseTab.setOnSelectionChanged(event -> {
+        expenseTab.setOnSelectionChanged(event -> {
             handleExpense();
         });
 
-        menuAnalyticsTab.setOnSelectionChanged(event -> {
+        analyticsTab.setOnSelectionChanged(event -> {
             handleAnalytics();
         });
     }
@@ -188,7 +175,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     public void handleTabHelp() {
-        if (menuHelpTab.isSelected()) {
+        if (helpTab.isSelected()) {
             resultDisplay.setFeedbackToUser(HELP_MESSAGE);
         }
     }
@@ -202,17 +189,6 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleIncome() {
-        if (menuIncomeTab.isSelected()) {
-            panelLabel.setText("Incomes");
-            rightPanelLabel.setText("Frequent Incomes");
-
-            incomePanel = new IncomePanel(logic.getFilteredIncomeList());
-            transactionListPanelPlaceholder.getChildren().add(incomePanel.getRoot());
-            incomePanel.getRoot().toFront();
-
-            frequentIncomePanel = new FrequentIncomePanel(logic.getFilteredFrequentIncomeList());
-            savingsGoalPlaceholder.getChildren().add(frequentIncomePanel.getRoot());
-        }
         onIncome();
         uiState.setCurrentTab(UiState.Tab.INCOME);
     }
@@ -222,17 +198,6 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleOverview() {
-        if (menuOverviewTab.isSelected()) {
-            panelLabel.setText("Overview");
-            rightPanelLabel.setText("Savings Summary");
-
-            transactionListPanel = new TransactionListPanel(logic.getFilteredTransactionList());
-            transactionListPanelPlaceholder.getChildren().add(transactionListPanel.getRoot());
-            transactionListPanel.getRoot().toFront();
-
-            savingsGoalPanel = new SavingsGoalPanel(logic.getMonthlyBudget());
-            savingsGoalPlaceholder.getChildren().add(savingsGoalPanel.getRoot());
-        }
         onOverview();
         uiState.setCurrentTab(UiState.Tab.OVERVIEW);
     }
@@ -242,17 +207,6 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleAnalytics() {
-        if (menuAnalyticsTab.isSelected()) {
-            panelLabel.setText("Analytics");
-            rightPanelLabel.setText("Savings Summary");
-
-            transactionListPanel = new TransactionListPanel(logic.getFilteredTransactionList());
-            transactionListPanelPlaceholder.getChildren().add(transactionListPanel.getRoot());
-            transactionListPanel.getRoot().toFront();
-
-            savingsGoalPanel = new SavingsGoalPanel(logic.getMonthlyBudget());
-            savingsGoalPlaceholder.getChildren().add(savingsGoalPanel.getRoot());
-        }
         onAnalytics();
         uiState.setCurrentTab(UiState.Tab.ANALYTICS);
     }
@@ -262,17 +216,6 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleExpense() {
-        if (menuExpenseTab.isSelected()) {
-            panelLabel.setText("Expense");
-            rightPanelLabel.setText("Frequent Expenses");
-
-            expensePanel = new ExpensePanel(logic.getFilteredExpenseList());
-            transactionListPanelPlaceholder.getChildren().add(expensePanel.getRoot());
-            expensePanel.getRoot().toFront();
-
-            frequentExpensePanel = new FrequentExpensePanel((logic.getFilteredFrequentExpenseList()));
-            savingsGoalPlaceholder.getChildren().add(frequentExpensePanel.getRoot());
-        }
         onExpense();
         uiState.setCurrentTab(UiState.Tab.EXPENSES);
     }
@@ -290,10 +233,6 @@ public class MainWindow extends UiPart<Stage> {
                 (int) primaryStage.getX(), (int) primaryStage.getY());
         logic.setGuiSettings(guiSettings);
         primaryStage.hide();
-    }
-
-    public TransactionListPanel getTransactionListPanel() {
-        return transactionListPanel;
     }
 
     /**
@@ -341,43 +280,43 @@ public class MainWindow extends UiPart<Stage> {
      * Changes the text color of the overview tab to white while the rest remains grey
      */
     private void onOverview() {
-        menuOverviewTab.setStyle("-tab-text-color: white");
-        menuIncomeTab.setStyle("-tab-text-color: #888888");
-        menuExpenseTab.setStyle("-tab-text-color: #888888");
-        menuAnalyticsTab.setStyle("-tab-text-color: #888888");
-        menuHelpTab.setStyle("-tab-text-color: #888888");
+        overviewTab.setStyle("-tab-text-color: white");
+        incomeTab.setStyle("-tab-text-color: #888888");
+        expenseTab.setStyle("-tab-text-color: #888888");
+        analyticsTab.setStyle("-tab-text-color: #888888");
+        helpTab.setStyle("-tab-text-color: #888888");
     }
 
     /**
      * Changes the text color of the income tab to white while the rest remains grey.
      */
     private void onIncome() {
-        menuOverviewTab.setStyle("-tab-text-color: #888888");
-        menuIncomeTab.setStyle("-tab-text-color: white");
-        menuExpenseTab.setStyle("-tab-text-color: #888888");
-        menuAnalyticsTab.setStyle("-tab-text-color: #888888");
-        menuHelpTab.setStyle("-tab-text-color: #888888");
+        overviewTab.setStyle("-tab-text-color: #888888");
+        incomeTab.setStyle("-tab-text-color: white");
+        expenseTab.setStyle("-tab-text-color: #888888");
+        analyticsTab.setStyle("-tab-text-color: #888888");
+        helpTab.setStyle("-tab-text-color: #888888");
     }
 
     /**
      * Changes the text color of the expense tab to white while the rest remains grey.
      */
     private void onExpense() {
-        menuOverviewTab.setStyle("-tab-text-color: #888888");
-        menuIncomeTab.setStyle("-tab-text-color: #888888");
-        menuExpenseTab.setStyle("-tab-text-color: white");
-        menuAnalyticsTab.setStyle("-tab-text-color: #888888");
-        menuHelpTab.setStyle("-tab-text-color: #888888");
+        overviewTab.setStyle("-tab-text-color: #888888");
+        incomeTab.setStyle("-tab-text-color: #888888");
+        expenseTab.setStyle("-tab-text-color: white");
+        analyticsTab.setStyle("-tab-text-color: #888888");
+        helpTab.setStyle("-tab-text-color: #888888");
     }
 
     /**
      * Changes the text color of the analytics tab to white while the rest remains grey.
      */
     private void onAnalytics() {
-        menuOverviewTab.setStyle("-tab-text-color: #888888");
-        menuIncomeTab.setStyle("-tab-text-color: #888888");
-        menuExpenseTab.setStyle("-tab-text-color: #888888");
-        menuAnalyticsTab.setStyle("-tab-text-color: white");
-        menuHelpTab.setStyle("-tab-text-color: #888888");
+        overviewTab.setStyle("-tab-text-color: #888888");
+        incomeTab.setStyle("-tab-text-color: #888888");
+        expenseTab.setStyle("-tab-text-color: #888888");
+        analyticsTab.setStyle("-tab-text-color: white");
+        helpTab.setStyle("-tab-text-color: #888888");
     }
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
@@ -133,27 +133,10 @@ public class MainWindow extends UiPart<Stage> {
 
         // Set the bottom anchor after the tabs have been initialized.
         AnchorPane.setBottomAnchor(tabPane, 0.0);
-    }
 
-    /**
-     * Sets up all the action handlers for the tabs on the tab pane.
-     */
-    public void setActionHandlers() {
-        overviewTab.setOnSelectionChanged(event -> {
-            handleOverview();
-        });
-
-        incomeTab.setOnSelectionChanged(event -> {
-            handleIncome();
-        });
-
-        expenseTab.setOnSelectionChanged(event -> {
-            handleExpense();
-        });
-
-        analyticsTab.setOnSelectionChanged(event -> {
-            handleAnalytics();
-        });
+        // Update UI state on tab change.
+        tabPane.getSelectionModel().selectedIndexProperty().addListener((observable, oldTabIndex, newTabIndex) ->
+                uiState.setCurrentTab(UiState.Tab.values()[newTabIndex.intValue()]));
     }
 
     /**
@@ -174,38 +157,6 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     public void handleHelp() {
         resultDisplay.setFeedbackToUser(HELP_MESSAGE);
-    }
-
-    /**
-     * Opens the income window.
-     */
-    @FXML
-    private void handleIncome() {
-        uiState.setCurrentTab(UiState.Tab.INCOME);
-    }
-
-    /**
-     * Opens the overview window.
-     */
-    @FXML
-    private void handleOverview() {
-        uiState.setCurrentTab(UiState.Tab.OVERVIEW);
-    }
-
-    /**
-     * Opens the analytics window.
-     */
-    @FXML
-    private void handleAnalytics() {
-        uiState.setCurrentTab(UiState.Tab.ANALYTICS);
-    }
-
-    /**
-     * Opens the expense window.
-     */
-    @FXML
-    private void handleExpense() {
-        uiState.setCurrentTab(UiState.Tab.EXPENSES);
     }
 
     void show() {
@@ -261,6 +212,6 @@ public class MainWindow extends UiPart<Stage> {
      */
     private void switchTabs(UiState.Tab tab) {
         requireNonNull(tab);
-        tabPane.getSelectionModel().select(tab.getTabIndex());
+        tabPane.getSelectionModel().select(tab.getTabIndex().getZeroBased());
     }
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
@@ -109,8 +109,6 @@ public class MainWindow extends UiPart<Stage> {
 
         SelectionModel<Tab> selectionModel = tabPane.getSelectionModel();
         selectionModel.select(overviewTab);
-
-        onOverview();
     }
 
     /**
@@ -189,7 +187,6 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleIncome() {
-        onIncome();
         uiState.setCurrentTab(UiState.Tab.INCOME);
     }
 
@@ -198,7 +195,6 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleOverview() {
-        onOverview();
         uiState.setCurrentTab(UiState.Tab.OVERVIEW);
     }
 
@@ -207,7 +203,6 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleAnalytics() {
-        onAnalytics();
         uiState.setCurrentTab(UiState.Tab.ANALYTICS);
     }
 
@@ -216,7 +211,6 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleExpense() {
-        onExpense();
         uiState.setCurrentTab(UiState.Tab.EXPENSES);
     }
 
@@ -274,49 +268,5 @@ public class MainWindow extends UiPart<Stage> {
     private void switchTabs(UiState.Tab tab) {
         requireNonNull(tab);
         tabPane.getSelectionModel().select(tab.getTabIndex());
-    }
-
-    /**
-     * Changes the text color of the overview tab to white while the rest remains grey
-     */
-    private void onOverview() {
-        overviewTab.setStyle("-tab-text-color: white");
-        incomeTab.setStyle("-tab-text-color: #888888");
-        expenseTab.setStyle("-tab-text-color: #888888");
-        analyticsTab.setStyle("-tab-text-color: #888888");
-        helpTab.setStyle("-tab-text-color: #888888");
-    }
-
-    /**
-     * Changes the text color of the income tab to white while the rest remains grey.
-     */
-    private void onIncome() {
-        overviewTab.setStyle("-tab-text-color: #888888");
-        incomeTab.setStyle("-tab-text-color: white");
-        expenseTab.setStyle("-tab-text-color: #888888");
-        analyticsTab.setStyle("-tab-text-color: #888888");
-        helpTab.setStyle("-tab-text-color: #888888");
-    }
-
-    /**
-     * Changes the text color of the expense tab to white while the rest remains grey.
-     */
-    private void onExpense() {
-        overviewTab.setStyle("-tab-text-color: #888888");
-        incomeTab.setStyle("-tab-text-color: #888888");
-        expenseTab.setStyle("-tab-text-color: white");
-        analyticsTab.setStyle("-tab-text-color: #888888");
-        helpTab.setStyle("-tab-text-color: #888888");
-    }
-
-    /**
-     * Changes the text color of the analytics tab to white while the rest remains grey.
-     */
-    private void onAnalytics() {
-        overviewTab.setStyle("-tab-text-color: #888888");
-        incomeTab.setStyle("-tab-text-color: #888888");
-        expenseTab.setStyle("-tab-text-color: #888888");
-        analyticsTab.setStyle("-tab-text-color: white");
-        helpTab.setStyle("-tab-text-color: #888888");
     }
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
@@ -106,9 +106,6 @@ public class MainWindow extends UiPart<Stage> {
 
         CommandBox commandBox = new CommandBox(this::executeCommand);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
-
-        SelectionModel<Tab> selectionModel = tabPane.getSelectionModel();
-        selectionModel.select(overviewTab);
     }
 
     /**
@@ -129,6 +126,9 @@ public class MainWindow extends UiPart<Stage> {
 
         AnalyticsTabPane analyticsTabPane = new AnalyticsTabPane();
         analyticsTab.setContent(analyticsTabPane.getRoot());
+
+        SelectionModel<Tab> selectionModel = tabPane.getSelectionModel();
+        selectionModel.select(overviewTab);
     }
 
     /**

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/TransactionListPanel.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/TransactionListPanel.java
@@ -1,8 +1,5 @@
 package ay2021s1_cs2103_w16_3.finesse.ui;
 
-import java.util.logging.Logger;
-
-import ay2021s1_cs2103_w16_3.finesse.commons.core.LogsCenter;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
@@ -15,7 +12,6 @@ import javafx.scene.layout.Region;
  */
 public class TransactionListPanel extends UiPart<Region> {
     private static final String FXML = "TransactionListPanel.fxml";
-    private final Logger logger = LogsCenter.getLogger(TransactionListPanel.class);
 
     @FXML
     private ListView<Transaction> transactionListView;

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/UiManager.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/UiManager.java
@@ -46,8 +46,6 @@ public class UiManager implements Ui {
             mainWindow.disableStageResizing();
             mainWindow.fillInnerParts();
             mainWindow.initializeTabs();
-            mainWindow.setActionHandlers();
-
         } catch (Throwable e) {
             logger.severe(StringUtil.getDetails(e));
             showFatalErrorDialogAndShutdown("Fatal error during initializing", e);

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/UiManager.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/UiManager.java
@@ -45,6 +45,7 @@ public class UiManager implements Ui {
             mainWindow.show(); //This should be called before creating other UI parts
             mainWindow.disableStageResizing();
             mainWindow.fillInnerParts();
+            mainWindow.initializeTabs();
             mainWindow.setActionHandlers();
 
         } catch (Throwable e) {

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/UiState.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/UiState.java
@@ -2,6 +2,8 @@ package ay2021s1_cs2103_w16_3.finesse.ui;
 
 import static java.util.Objects.requireNonNull;
 
+import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
+
 /**
  * Represents the state of the current UI.
  */
@@ -16,7 +18,7 @@ public class UiState {
         ANALYTICS(4);
 
         /** The index of the tab in the {@code TabPane}. */
-        private final int tabIndex;
+        private final Index tabIndex;
 
         /**
          * Constructs a new {@code Tab} enum with the specified tab index.
@@ -24,7 +26,7 @@ public class UiState {
          * @param tabIndex The index of the tab in the {@code TabPane}.
          */
         Tab(int tabIndex) {
-            this.tabIndex = tabIndex;
+            this.tabIndex = Index.fromOneBased(tabIndex);
         }
 
         /**
@@ -32,7 +34,7 @@ public class UiState {
          *
          * @return The index of the tab in the {@code TabPane}.
          */
-        public int getTabIndex() {
+        public Index getTabIndex() {
             return tabIndex;
         }
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/AnalyticsTabPane.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/AnalyticsTabPane.java
@@ -1,0 +1,20 @@
+package ay2021s1_cs2103_w16_3.finesse.ui.tabs;
+
+import ay2021s1_cs2103_w16_3.finesse.ui.UiPart;
+import javafx.scene.canvas.Canvas;
+
+/**
+ * Tab pane that displays analytics.
+ */
+public class AnalyticsTabPane extends UiPart<Canvas> {
+    private static final String FXML = "AnalyticsTabPane.fxml";
+
+    /**
+     * Creates an {@code AnalyticsTabPane}.
+     */
+    public AnalyticsTabPane() {
+        super(FXML);
+    }
+
+    // TODO: Add visualizations.
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/ExpenseTabPane.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/ExpenseTabPane.java
@@ -1,0 +1,27 @@
+package ay2021s1_cs2103_w16_3.finesse.ui.tabs;
+
+import ay2021s1_cs2103_w16_3.finesse.model.frequent.FrequentExpense;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
+import ay2021s1_cs2103_w16_3.finesse.ui.expense.ExpensePanel;
+import ay2021s1_cs2103_w16_3.finesse.ui.frequent.FrequentExpensePanel;
+import javafx.collections.ObservableList;
+
+/**
+ * Tab pane that displays expenses.
+ */
+public class ExpenseTabPane extends TwoColumnTabPane {
+    private static final String MAIN_PANEL_LABEL = "Expenses";
+    private static final String SIDE_PANEL_LABEL = "Bookmarked Expenses";
+
+    /**
+     * Constructs an {@code ExpenseTabPane} that displays the specified list of expenses
+     * and bookmarked expenses.
+     *
+     * @param expenseList The list of expenses to be displayed.
+     * @param frequentExpenseList The list of frequent expenses to be displayed.
+     */
+    public ExpenseTabPane(ObservableList<Expense> expenseList, ObservableList<FrequentExpense> frequentExpenseList) {
+        super(MAIN_PANEL_LABEL, SIDE_PANEL_LABEL,
+                new ExpensePanel(expenseList), new FrequentExpensePanel(frequentExpenseList));
+    }
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/IncomeTabPane.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/IncomeTabPane.java
@@ -1,0 +1,27 @@
+package ay2021s1_cs2103_w16_3.finesse.ui.tabs;
+
+import ay2021s1_cs2103_w16_3.finesse.model.frequent.FrequentIncome;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
+import ay2021s1_cs2103_w16_3.finesse.ui.frequent.FrequentIncomePanel;
+import ay2021s1_cs2103_w16_3.finesse.ui.income.IncomePanel;
+import javafx.collections.ObservableList;
+
+/**
+ * Tab pane that displays incomes.
+ */
+public class IncomeTabPane extends TwoColumnTabPane {
+    private static final String MAIN_PANEL_LABEL = "Incomes";
+    private static final String SIDE_PANEL_LABEL = "Bookmarked Incomes";
+
+    /**
+     * Constructs an {@code IncomeTabPane} that displays the specified list of incomes
+     * and bookmarked incomes.
+     *
+     * @param incomeList The list of incomes to be displayed.
+     * @param frequentIncomeList The list of frequent incomes to be displayed.
+     */
+    public IncomeTabPane(ObservableList<Income> incomeList, ObservableList<FrequentIncome> frequentIncomeList) {
+        super(MAIN_PANEL_LABEL, SIDE_PANEL_LABEL,
+                new IncomePanel(incomeList), new FrequentIncomePanel(frequentIncomeList));
+    }
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/OverviewTabPane.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/OverviewTabPane.java
@@ -1,0 +1,27 @@
+package ay2021s1_cs2103_w16_3.finesse.ui.tabs;
+
+import ay2021s1_cs2103_w16_3.finesse.model.budget.MonthlyBudget;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
+import ay2021s1_cs2103_w16_3.finesse.ui.SavingsGoalPanel;
+import ay2021s1_cs2103_w16_3.finesse.ui.TransactionListPanel;
+import javafx.collections.ObservableList;
+
+/**
+ * Tab pane that displays an overview of transactions.
+ */
+public class OverviewTabPane extends TwoColumnTabPane {
+    private static final String MAIN_PANEL_LABEL = "Overview";
+    private static final String SIDE_PANEL_LABEL = "Savings Summary";
+
+    /**
+     * Constructs an {@code OverviewTabPane} that displays the specified list of transactions
+     * and savings goal.
+     *
+     * @param transactionList The list of transactions to be displayed.
+     * @param monthlyBudget The monthly budget in the finance tracker.
+     */
+    public OverviewTabPane(ObservableList<Transaction> transactionList, MonthlyBudget monthlyBudget) {
+        super(MAIN_PANEL_LABEL, SIDE_PANEL_LABEL, new TransactionListPanel(transactionList),
+                new SavingsGoalPanel(monthlyBudget));
+    }
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/TwoColumnTabPane.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/TwoColumnTabPane.java
@@ -1,0 +1,40 @@
+package ay2021s1_cs2103_w16_3.finesse.ui.tabs;
+
+import ay2021s1_cs2103_w16_3.finesse.ui.UiPart;
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+
+/**
+ * An abstract tab pane with two panels arranged in columns.
+ */
+public abstract class TwoColumnTabPane extends UiPart<Region> {
+    private static final String FXML = "TwoColumnTabPane.fxml";
+
+    @FXML
+    private Label mainPanelLabel;
+    @FXML
+    private Label sidePanelLabel;
+    @FXML
+    private StackPane mainPanelPlaceholder;
+    @FXML
+    private StackPane sidePanelPlaceholder;
+
+    /**
+     * Creates a {@code TwoColumnTabPane} with the specified attributes.
+     *
+     * @param mainPanelLabelStr The label of the main panel.
+     * @param sidePanelLabelStr The label of the side panel.
+     * @param mainPanel The main panel to be displayed.
+     * @param sidePanel The side panel to be displayed.
+     */
+    public TwoColumnTabPane(String mainPanelLabelStr, String sidePanelLabelStr, UiPart<Region> mainPanel,
+                            UiPart<Region> sidePanel) {
+        super(FXML);
+        mainPanelLabel.setText(mainPanelLabelStr);
+        sidePanelLabel.setText(sidePanelLabelStr);
+        mainPanelPlaceholder.getChildren().add(mainPanel.getRoot());
+        sidePanelPlaceholder.getChildren().add(sidePanel.getRoot());
+    }
+}

--- a/src/main/resources/view/AnalyticsTabPane.fxml
+++ b/src/main/resources/view/AnalyticsTabPane.fxml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.canvas.Canvas?>
+
+<Canvas xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+
+</Canvas>

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -268,6 +268,19 @@
     -fx-text-fill: white;
 }
 
+#helpButton {
+    -fx-background-color: transparent;
+    -fx-font-family: "Roboto Condensed";
+    -fx-font-size: 24px;
+    -fx-text-fill: #888888;
+    -fx-padding: 20, 0, 0, 0;
+}
+
+#helpButton:hover {
+    -fx-background-color: transparent;
+    -fx-text-fill: white;
+}
+
 .tab-pane .label {
     -fx-font-size: 18pt;
     -fx-font-family: "Roboto Condensed";

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -264,6 +264,10 @@
     -fx-text-fill: white;
 }
 
+.tab:hover .tab-label {
+    -fx-text-fill: white;
+}
+
 .tab-pane .label {
     -fx-font-size: 18pt;
     -fx-font-family: "Roboto Condensed";

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -256,6 +256,11 @@
 .tab {
     -fx-background-color: #2E2E36;
     -fx-border-color: #2E2E36;
+    -fx-text-fill: #888888;
+    -fx-padding: 20, 0, 0, 0;
+}
+
+.tab:selected .tab-label {
     -fx-text-fill: white;
 }
 
@@ -263,11 +268,6 @@
     -fx-font-size: 18pt;
     -fx-font-family: "Roboto Condensed";
     -fx-text-fill: white;
-}
-
-.tab {
-    -fx-padding: 20, 0, 0, 0;
-    -fx-border-color: #2E2E36;
 }
 
 .command-box-label {

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -5,7 +5,6 @@
 <?import javafx.scene.Scene?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
-<?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.control.TabPane?>
 <?import javafx.scene.control.Tab?>
@@ -21,31 +20,12 @@
 
       <VBox>
         <TabPane fx:id="tabPane" VBox.vgrow="NEVER" styleClass="tab-pane" tabMinHeight="30">
-          <Tab fx:id="menuHelpTab" text="Help" closable="false" />
-          <Tab fx:id="menuOverviewTab" text="Overview" closable="false" />
-          <Tab fx:id="menuIncomeTab" text="Incomes" closable="false" />
-          <Tab fx:id="menuExpenseTab" text="Expenses" closable="false" />
-          <Tab fx:id="menuAnalyticsTab" text="Analytics" closable="false" />
+          <Tab fx:id="helpTab" text="Help" closable="false" />
+          <Tab fx:id="overviewTab" text="Overview" closable="false" />
+          <Tab fx:id="incomeTab" text="Incomes" closable="false" />
+          <Tab fx:id="expenseTab" text="Expenses" closable="false" />
+          <Tab fx:id="analyticsTab" text="Analytics" closable="false" />
         </TabPane>
-
-        <HBox VBox.vgrow="ALWAYS">
-            <VBox styleClass="pane-with-border" HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS" alignment="CENTER">
-              <Label fx:id="panelLabel" text="Overview" styleClass="panel-label"/>
-              <padding>
-                <Insets top="10" right="10" bottom="10" left="10" />
-              </padding>
-              <StackPane fx:id="transactionListPanelPlaceholder" maxWidth="Infinity" minWidth="400"
-                         HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS"/>
-            </VBox>
-            <VBox styleClass="pane-with-border" HBox.hgrow="ALWAYS" alignment="CENTER">
-              <Label fx:id="rightPanelLabel" text="Savings Summary" styleClass="panel-label"/>
-              <padding>
-                <Insets bottom="10" left="10" right="10" top="10" />
-              </padding>
-              <StackPane fx:id="savingsGoalPlaceholder" maxWidth="Infinity" minWidth="100" prefWidth="150"
-                         HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS"/>
-            </VBox>
-        </HBox>
 
         <StackPane VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS" fx:id="resultDisplayPlaceholder"
                    styleClass="pane-with-border" minHeight="100" prefHeight="100" maxHeight="100">

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -3,9 +3,11 @@
 <?import java.net.URL?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.Scene?>
+<?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.control.Button?>
 <?import javafx.scene.control.TabPane?>
 <?import javafx.scene.control.Tab?>
 
@@ -19,13 +21,17 @@
       </stylesheets>
 
       <VBox>
-        <TabPane fx:id="tabPane" VBox.vgrow="NEVER" styleClass="tab-pane" tabMinHeight="30">
-          <Tab fx:id="helpTab" text="Help" closable="false" />
-          <Tab fx:id="overviewTab" text="Overview" closable="false" />
-          <Tab fx:id="incomeTab" text="Incomes" closable="false" />
-          <Tab fx:id="expenseTab" text="Expenses" closable="false" />
-          <Tab fx:id="analyticsTab" text="Analytics" closable="false" />
-        </TabPane>
+        <AnchorPane>
+          <!-- Bottom anchor of AnchorPane has to be set programmatically after tabs are initialized. -->
+          <TabPane fx:id="tabPane" VBox.vgrow="NEVER" styleClass="tab-pane" tabMinHeight="30" AnchorPane.topAnchor="0.0"
+                   AnchorPane.rightAnchor="0.0" AnchorPane.leftAnchor="0.0">
+            <Tab fx:id="overviewTab" text="Overview" closable="false" />
+            <Tab fx:id="incomeTab" text="Incomes" closable="false" />
+            <Tab fx:id="expenseTab" text="Expenses" closable="false" />
+            <Tab fx:id="analyticsTab" text="Analytics" closable="false" />
+          </TabPane>
+          <Button fx:id="helpButton" text="Help" onMouseClicked="#handleHelp" AnchorPane.rightAnchor="0.0" />
+        </AnchorPane>
 
         <StackPane VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS" fx:id="resultDisplayPlaceholder"
                    styleClass="pane-with-border" minHeight="100" prefHeight="100" maxHeight="100">

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -3,13 +3,13 @@
 <?import java.net.URL?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.Scene?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Tab?>
+<?import javafx.scene.control.TabPane?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.layout.HBox?>
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.TabPane?>
-<?import javafx.scene.control.Tab?>
 
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
          title="Fine$$e" minWidth="450" minHeight="600" onCloseRequest="#handleExit">

--- a/src/main/resources/view/TwoColumnTabPane.fxml
+++ b/src/main/resources/view/TwoColumnTabPane.fxml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.VBox?>
-<?import javafx.scene.control.Label?>
 <?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.VBox?>
 
 <HBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <VBox styleClass="pane-with-border" HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS" alignment="CENTER">

--- a/src/main/resources/view/TwoColumnTabPane.fxml
+++ b/src/main/resources/view/TwoColumnTabPane.fxml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.control.Label?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.layout.StackPane?>
+
+<HBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+  <VBox styleClass="pane-with-border" HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS" alignment="CENTER">
+    <Label fx:id="mainPanelLabel" text="Overview" styleClass="panel-label" />
+    <padding>
+      <Insets top="10" right="10" bottom="10" left="10" />
+    </padding>
+    <StackPane fx:id="mainPanelPlaceholder" maxWidth="Infinity" minWidth="400"
+               HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS" />
+  </VBox>
+  <VBox styleClass="pane-with-border" HBox.hgrow="ALWAYS" alignment="CENTER">
+    <Label fx:id="sidePanelLabel" text="Savings Summary" styleClass="panel-label" />
+    <padding>
+      <Insets bottom="10" left="10" right="10" top="10" />
+    </padding>
+    <StackPane fx:id="sidePanelPlaceholder" maxWidth="Infinity" minWidth="100" prefWidth="150"
+               HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS" />
+  </VBox>
+</HBox>

--- a/src/main/resources/view/TwoColumnTabPane.fxml
+++ b/src/main/resources/view/TwoColumnTabPane.fxml
@@ -8,7 +8,7 @@
 
 <HBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <VBox styleClass="pane-with-border" HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS" alignment="CENTER">
-    <Label fx:id="mainPanelLabel" text="Overview" styleClass="panel-label" />
+    <Label fx:id="mainPanelLabel" styleClass="panel-label" />
     <padding>
       <Insets top="10" right="10" bottom="10" left="10" />
     </padding>
@@ -16,7 +16,7 @@
                HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS" />
   </VBox>
   <VBox styleClass="pane-with-border" HBox.hgrow="ALWAYS" alignment="CENTER">
-    <Label fx:id="sidePanelLabel" text="Savings Summary" styleClass="panel-label" />
+    <Label fx:id="sidePanelLabel" styleClass="panel-label" />
     <padding>
       <Insets bottom="10" left="10" right="10" top="10" />
     </padding>

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/ui/UiStateTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/ui/UiStateTest.java
@@ -10,10 +10,10 @@ import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 public class UiStateTest {
     @Test
     public void getTabEnumIndex_returnsCorrectIndex() {
-        assertEquals(1, Tab.OVERVIEW.getTabIndex());
-        assertEquals(2, Tab.INCOME.getTabIndex());
-        assertEquals(3, Tab.EXPENSES.getTabIndex());
-        assertEquals(4, Tab.ANALYTICS.getTabIndex());
+        assertEquals(1, Tab.OVERVIEW.getTabIndex().getOneBased());
+        assertEquals(2, Tab.INCOME.getTabIndex().getOneBased());
+        assertEquals(3, Tab.EXPENSES.getTabIndex().getOneBased());
+        assertEquals(4, Tab.ANALYTICS.getTabIndex().getOneBased());
     }
 
     @Test


### PR DESCRIPTION
Changes:
- Refactor tabs.
  - Previously, the tabs were implemented by intercepting click events and manually updating the various UI components.
  - Currently, the tabs have their own content panes that get loaded on selecting the respective tab.
    - `OverviewTabPane`
    - `IncomeTabPane`
    - `ExpenseTabPane`
    - `AnalyticsTabPane`
- Remove hard-coded programmatic updating of tab label CSS.
  - Add `.tab:hover` style instead.
- Add highlighting of tabs on hover.
  - To provide feedback to the user for better UX.
- Convert `Help` tab to a button.
  - Previously, it functioned as a button even though the underlying JavaFX element was `Tab`. This only worked because the tabs were not implemented correctly.
  - Add the `Help` button to the right of the tabs so as to distinguish it from the tabs.
    - This was achieved through the use of an `AnchorPane`.
- Update `uiState` whenever the selected tab changes through a listener instead.
- Merge `handleTabHelp` and `handleCommandHelp` into `handleHelp`.
  - Two functions providing the same functionality is useless.
- Add blank `Canvas` for `Analytics` tab.

Resolves #153.