### PR TITLE
Fix expense and income lists to update automatically

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/ModelManager.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/ModelManager.java
@@ -255,6 +255,7 @@ public class ModelManager implements Model {
      * Casts a FilteredList into a List of the filtered subtype.
      * Precondition: The given FilteredList must be either the expense list or income list.
      * This guarantees that the elements of the FilteredList can successfully be cast to the target type.
+     *
      * @param list The FilteredList to be cast.
      * @param toCast The class of the target type to be cast. Required as casting to generic types is not allowed.
      * @param <T> The type of transaction. Can be either Expense or Income, but not Transaction itself.
@@ -263,6 +264,7 @@ public class ModelManager implements Model {
     private <T extends Transaction> List<T> castFilteredList(FilteredList<Transaction> list, Class<T> toCast) {
         assert list == filteredExpenses || list == filteredIncomes
                 : "Casting can only be performed on expense or income list";
+        assert toCast != Transaction.class : "Casting can only be to Expense or Income, not Transaction";
         return list.stream().map(toCast::cast).collect(Collectors.toUnmodifiableList());
     }
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/ModelManager.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/ModelManager.java
@@ -4,8 +4,10 @@ import static ay2021s1_cs2103_w16_3.finesse.commons.util.CollectionUtil.requireA
 import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import ay2021s1_cs2103_w16_3.finesse.commons.core.GuiSettings;
 import ay2021s1_cs2103_w16_3.finesse.commons.core.LogsCenter;
@@ -33,6 +35,8 @@ public class ModelManager implements Model {
     private final FilteredList<Transaction> filteredIncomes;
     private final FilteredList<FrequentExpense> filteredFrequentExpenses;
     private final FilteredList<FrequentIncome> filteredFrequentIncomes;
+    private final ObservableList<Expense> castFilteredExpenses;
+    private final ObservableList<Income> castFilteredIncomes;
     private final MonthlyBudget monthlyBudget;
 
     /**
@@ -51,6 +55,8 @@ public class ModelManager implements Model {
         filteredIncomes = new FilteredList<>(this.financeTracker.getTransactionList(), PREDICATE_SHOW_ALL_INCOMES);
         filteredFrequentExpenses = new FilteredList<>(this.financeTracker.getFrequentExpenseList());
         filteredFrequentIncomes = new FilteredList<>(this.financeTracker.getFrequentIncomeList());
+        castFilteredExpenses = FXCollections.observableArrayList(castFilteredList(filteredExpenses, Expense.class));
+        castFilteredIncomes = FXCollections.observableArrayList(castFilteredList(filteredIncomes, Income.class));
         monthlyBudget = this.financeTracker.getMonthlyBudget();
     }
 
@@ -108,6 +114,7 @@ public class ModelManager implements Model {
     @Override
     public void deleteTransaction(Transaction target) {
         financeTracker.removeTransaction(target);
+        refreshTransactionLists();
     }
 
     @Override
@@ -127,6 +134,7 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedTransaction);
 
         financeTracker.setTransaction(target, editedTransaction);
+        refreshTransactionLists();
     }
 
     //=========== Frequent Transaction ================================================================================
@@ -193,9 +201,7 @@ public class ModelManager implements Model {
      */
     @Override
     public ObservableList<Expense> getFilteredExpenseList() {
-        ObservableList<Expense> newFilteredExpenses = FXCollections.observableArrayList();
-        filteredExpenses.forEach(e -> newFilteredExpenses.add((Expense) e));
-        return FXCollections.unmodifiableObservableList(newFilteredExpenses);
+        return FXCollections.unmodifiableObservableList(castFilteredExpenses);
     }
 
     /**
@@ -204,9 +210,7 @@ public class ModelManager implements Model {
      */
     @Override
     public ObservableList<Income> getFilteredIncomeList() {
-        ObservableList<Income> newFilteredIncomes = FXCollections.observableArrayList();
-        filteredIncomes.forEach(i -> newFilteredIncomes.add((Income) i));
-        return FXCollections.unmodifiableObservableList(newFilteredIncomes);
+        return FXCollections.unmodifiableObservableList(castFilteredIncomes);
     }
 
     /**
@@ -237,12 +241,40 @@ public class ModelManager implements Model {
     public void updateFilteredExpenseList(Predicate<Transaction> predicate) {
         requireNonNull(predicate);
         filteredExpenses.setPredicate(t -> predicate.test(t) && PREDICATE_SHOW_ALL_EXPENSES.test(t));
+        refreshTransactionLists();
     }
 
     @Override
     public void updateFilteredIncomeList(Predicate<Transaction> predicate) {
         requireNonNull(predicate);
         filteredIncomes.setPredicate(t -> predicate.test(t) && PREDICATE_SHOW_ALL_INCOMES.test(t));
+        refreshTransactionLists();
+    }
+
+    /**
+     * Casts a FilteredList into a List of the filtered subtype.
+     * Precondition: The given FilteredList must be either the expense list or income list.
+     * This guarantees that the elements of the FilteredList can successfully be cast to the target type.
+     * @param list The FilteredList to be cast.
+     * @param toCast The class of the target type to be cast. Required as casting to generic types is not allowed.
+     * @param <T> The type of transaction. Can be either Expense or Income, but not Transaction itself.
+     * @return A List whose elements are equal to the current state of the FilteredList.
+     */
+    private <T extends Transaction> List<T> castFilteredList(FilteredList<Transaction> list, Class<T> toCast) {
+        assert list == filteredExpenses || list == filteredIncomes
+                : "Casting can only be performed on expense or income list";
+        return list.stream().map(toCast::cast).collect(Collectors.toUnmodifiableList());
+    }
+
+    /**
+     * Refreshes the typecasted ObservableLists used by other components.
+     * To be called anytime the expense or income list updates.
+     */
+    private void refreshTransactionLists() {
+        castFilteredExpenses.clear();
+        castFilteredExpenses.addAll(castFilteredList(filteredExpenses, Expense.class));
+        castFilteredIncomes.clear();
+        castFilteredIncomes.addAll(castFilteredList(filteredIncomes, Income.class));
     }
 
     @Override

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/ModelManagerTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/ModelManagerTest.java
@@ -6,6 +6,7 @@ import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.BUBBLE_
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.TUITION_FEES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
@@ -15,9 +16,12 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import ay2021s1_cs2103_w16_3.finesse.commons.core.GuiSettings;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.TitleContainsKeywordsPredicate;
 import ay2021s1_cs2103_w16_3.finesse.testutil.FinanceTrackerBuilder;
 import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
+import javafx.collections.ObservableList;
 
 public class ModelManagerTest {
 
@@ -100,6 +104,40 @@ public class ModelManagerTest {
             -> modelManager.getFilteredFrequentIncomeList().remove(0));
     }
 
+    @Test
+    public void getFilteredTransactionLists_addTransactions_updatesList() {
+        ObservableList<Expense> expenseList = modelManager.getFilteredExpenseList();
+        ObservableList<Income> incomeList = modelManager.getFilteredIncomeList();
+        modelManager.addExpense(new TransactionBuilder().buildExpense());
+        assertEquals(1, expenseList.size());
+        assertEquals(0, incomeList.size());
+        modelManager.addIncome(new TransactionBuilder().buildIncome());
+        assertEquals(1, expenseList.size());
+        assertEquals(1, incomeList.size());
+    }
+
+    @Test
+    public void getFilteredTransactionLists_deleteTransaction_updatesList() {
+        Expense e = new TransactionBuilder().buildExpense();
+        modelManager.addExpense(e);
+        ObservableList<Expense> expenseList = modelManager.getFilteredExpenseList();
+        assertEquals(1, expenseList.size());
+        modelManager.deleteTransaction(e);
+        assertEquals(0, expenseList.size());
+    }
+
+    @Test
+    public void getFilteredTransactionLists_editTransaction_updatesList() {
+        Income i = new TransactionBuilder().buildIncome();
+        Income updated = new TransactionBuilder().withTitle("foo").buildIncome();
+        assertNotEquals(i.getTitle(), updated.getTitle()); // ensure no conflict
+        modelManager.addIncome(i);
+        ObservableList<Income> incomeList = modelManager.getFilteredIncomeList();
+        assertEquals(1, incomeList.size());
+        modelManager.setTransaction(i, updated);
+        assertFalse(incomeList.contains(i));
+        assertTrue(incomeList.contains(updated));
+    }
 
     @Test
     public void equals() {


### PR DESCRIPTION
Fixes #128 

The root cause of #128 is that a new `ObservableList` is constructed every time `getFilteredExpenseList` or `getFilteredIncomeList` is called. This makes it so that the UI must be responsible for calling these methods to update itself. However, this goes against the philosophy of an `ObservableList` in the first place.

Instead, inside `ModelManager` we will maintain two `ObservableList`s of the correct type parameter (`Expense` and `Income`). Any call to `getFilteredExpenseList` or `getFilteredIncomeList` will return a wrapper around the same `ObservableList` every time, instead of constructing a new list.

When changes are made to the filtered expense or income lists, the corresponding internal `ObservableList`s will be refreshed with the latest values. This unfortunately needs to be done 'manually' within the `ModelManager`, but at least it is contained within the `Model` component and is not dependent on any other components.

Pitest: https://ay2021s1-cs2103t-w16-3.github.io/reports/pitest/202010241722/