### PR TITLE
Make UI resizable

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/commons/core/GuiSettings.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/commons/core/GuiSettings.java
@@ -12,10 +12,12 @@ public class GuiSettings implements Serializable {
 
     private static final double DEFAULT_HEIGHT = 815.0;
     private static final double DEFAULT_WIDTH = 1240.0;
+    private static final boolean DEFAULT_FULLSCREEN = false;
 
     private final double windowWidth;
     private final double windowHeight;
     private final Point windowCoordinates;
+    private final boolean isFullscreen;
 
     /**
      * Constructs a {@code GuiSettings} with the default height, width and position.
@@ -24,15 +26,17 @@ public class GuiSettings implements Serializable {
         windowWidth = DEFAULT_WIDTH;
         windowHeight = DEFAULT_HEIGHT;
         windowCoordinates = null; // null represent no coordinates
+        isFullscreen = DEFAULT_FULLSCREEN;
     }
 
     /**
-     * Constructs a {@code GuiSettings} with the specified height, width and position.
+     * Constructs a {@code GuiSettings} with the specified height, width, position, and whether it is fullscreen.
      */
-    public GuiSettings(double windowWidth, double windowHeight, int xPosition, int yPosition) {
+    public GuiSettings(double windowWidth, double windowHeight, int xPosition, int yPosition, boolean isFullscreen) {
         this.windowWidth = windowWidth;
         this.windowHeight = windowHeight;
         windowCoordinates = new Point(xPosition, yPosition);
+        this.isFullscreen = isFullscreen;
     }
 
     public double getWindowWidth() {
@@ -45,6 +49,10 @@ public class GuiSettings implements Serializable {
 
     public Point getWindowCoordinates() {
         return windowCoordinates != null ? new Point(windowCoordinates) : null;
+    }
+
+    public boolean isFullscreen() {
+        return isFullscreen;
     }
 
     @Override
@@ -60,20 +68,22 @@ public class GuiSettings implements Serializable {
 
         return windowWidth == o.windowWidth
                 && windowHeight == o.windowHeight
-                && Objects.equals(windowCoordinates, o.windowCoordinates);
+                && Objects.equals(windowCoordinates, o.windowCoordinates)
+                && isFullscreen == o.isFullscreen;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(windowWidth, windowHeight, windowCoordinates);
+        return Objects.hash(windowWidth, windowHeight, windowCoordinates, isFullscreen);
     }
 
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("Width : " + windowWidth + "\n");
-        sb.append("Height : " + windowHeight + "\n");
-        sb.append("Position : " + windowCoordinates);
+        sb.append("Width: " + windowWidth + "\n");
+        sb.append("Height: " + windowHeight + "\n");
+        sb.append("Position: " + windowCoordinates + "\n");
+        sb.append("Is Fullscreen: " + (isFullscreen ? "Yes" : "No"));
         return sb.toString();
     }
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/budget/MonthlyBudget.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/budget/MonthlyBudget.java
@@ -137,7 +137,6 @@ public class MonthlyBudget {
 
         for (Transaction transaction: transactions) {
             int monthsBeforeToday = (int) ChronoUnit.MONTHS.between(YearMonth.from(transaction.getDateValue()), today);
-            System.out.println(monthsBeforeToday);
             if (monthsBeforeToday < numOfMonths) {
                 if (transaction instanceof Expense) {
                     monthlyExpenses[numOfMonths - 1 - monthsBeforeToday] =

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
@@ -90,10 +90,6 @@ public class MainWindow extends UiPart<Stage> {
         return primaryStage;
     }
 
-    public void disableStageResizing() {
-        this.primaryStage.setResizable(false);
-    }
-
     /**
      * Fills up all the placeholders of this window.
      */

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
@@ -148,10 +148,17 @@ public class MainWindow extends UiPart<Stage> {
      * Sets the default size based on {@code guiSettings}.
      */
     private void setWindowDefaultSize(GuiSettings guiSettings) {
+        // Set minimum window size.
+        primaryStage.setMinHeight(650.0);
+        primaryStage.setMinWidth(900.0);
+
+        // Retrieve window size and position from previous session.
         windowHeight = guiSettings.getWindowHeight();
         windowWidth = guiSettings.getWindowWidth();
         xPosition = (int) guiSettings.getWindowCoordinates().getX();
         yPosition = (int) guiSettings.getWindowCoordinates().getY();
+
+        // Restore window size and position from previous session.
         primaryStage.setHeight(windowHeight);
         primaryStage.setWidth(windowWidth);
         if (guiSettings.getWindowCoordinates() != null) {

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/UiManager.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/UiManager.java
@@ -42,8 +42,7 @@ public class UiManager implements Ui {
         try {
             loadCustomFonts();
             mainWindow = new MainWindow(primaryStage, logic, uiState);
-            mainWindow.show(); //This should be called before creating other UI parts
-            mainWindow.disableStageResizing();
+            mainWindow.show(); // This should be called before creating other UI parts.
             mainWindow.fillInnerParts();
             mainWindow.initializeTabs();
         } catch (Throwable e) {

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.Button?>
+<?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.HBox?>
-<?import javafx.geometry.Insets?>
 
 <?import javafx.scene.control.Label?>
 <HBox fx:id="commandBoxContainer" styleClass="stack-pane" xmlns="http://javafx.com/javafx/8"
       xmlns:fx="http://javafx.com/fxml/1" alignment="CENTER_LEFT">
-    <Label fx:id="commandBoxLabel" styleClass="command-box-label" text="Enter Command: " />
-    <TextField fx:id="commandTextField" onAction="#handleCommandEntered" prefWidth="330" HBox.hgrow="ALWAYS"
-               promptText="Enter command here..." styleClass="command-box"/>
-    <Button fx:id="commandBoxButton" styleClass="command-box-button" prefWidth="100" text="Enter"
-            onAction="#handleCommandEntered"/>
+  <Label fx:id="commandBoxLabel" styleClass="command-box-label" text="Enter Command: " />
+  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" prefWidth="330" HBox.hgrow="ALWAYS"
+             promptText="Enter command here..." styleClass="command-box"/>
+  <Button fx:id="commandBoxButton" styleClass="command-box-button" prefWidth="100" text="Enter"
+          onAction="#handleCommandEntered"/>
 </HBox>
 

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -92,7 +92,7 @@
 }
 
 .list-cell {
-    -fx-padding: 10px;
+    -fx-padding: 8px;
     -fx-background-color: transparent, -fx-background ;
     -fx-background-insets: 0px, 2px;
 }

--- a/src/main/resources/view/ExpensePanel.fxml
+++ b/src/main/resources/view/ExpensePanel.fxml
@@ -4,5 +4,5 @@
 <?import javafx.scene.layout.*?>
 
 <VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" alignment="CENTER">
-    <ListView fx:id="expenseListView" styleClass="list-view" VBox.vgrow="ALWAYS" />
+  <ListView fx:id="expenseListView" styleClass="list-view" VBox.vgrow="ALWAYS" />
 </VBox>

--- a/src/main/resources/view/FrequentTransactionPanel.fxml
+++ b/src/main/resources/view/FrequentTransactionPanel.fxml
@@ -4,5 +4,5 @@
 <?import javafx.scene.layout.VBox?>
 
 <VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-    <ListView fx:id="frequentTransactionList" styleClass="list-view" VBox.vgrow="ALWAYS"/>
+  <ListView fx:id="frequentTransactionList" styleClass="list-view" VBox.vgrow="ALWAYS"/>
 </VBox>

--- a/src/main/resources/view/IncomePanel.fxml
+++ b/src/main/resources/view/IncomePanel.fxml
@@ -4,5 +4,5 @@
 <?import javafx.scene.layout.*?>
 
 <VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" alignment="CENTER">
-    <ListView fx:id="incomeListView" styleClass="list-view" VBox.vgrow="ALWAYS" />
+  <ListView fx:id="incomeListView" styleClass="list-view" VBox.vgrow="ALWAYS" />
 </VBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -7,6 +7,7 @@
 <?import javafx.scene.control.Tab?>
 <?import javafx.scene.control.TabPane?>
 <?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.layout.HBox?>
@@ -20,36 +21,42 @@
         <URL value="@Extensions.css" />
       </stylesheets>
 
-      <VBox>
-        <AnchorPane>
-          <!-- Bottom anchor of AnchorPane has to be set programmatically after tabs are initialized. -->
-          <TabPane fx:id="tabPane" VBox.vgrow="NEVER" styleClass="tab-pane" tabMinHeight="30" AnchorPane.topAnchor="0.0"
-                   AnchorPane.rightAnchor="0.0" AnchorPane.leftAnchor="0.0">
-            <Tab fx:id="overviewTab" text="Overview" closable="false" />
-            <Tab fx:id="incomeTab" text="Incomes" closable="false" />
-            <Tab fx:id="expenseTab" text="Expenses" closable="false" />
-            <Tab fx:id="analyticsTab" text="Analytics" closable="false" />
-          </TabPane>
-          <Button fx:id="helpButton" text="Help" onMouseClicked="#handleHelp" AnchorPane.rightAnchor="0.0" />
-        </AnchorPane>
+      <BorderPane>
+        <center>
+          <AnchorPane>
+            <!-- Bottom anchor of AnchorPane has to be set programmatically after tabs are initialized. -->
+            <TabPane fx:id="tabPane" VBox.vgrow="NEVER" styleClass="tab-pane" tabMinHeight="30" AnchorPane.topAnchor="0.0"
+                     AnchorPane.rightAnchor="0.0" AnchorPane.leftAnchor="0.0">
+              <Tab fx:id="overviewTab" text="Overview" closable="false" />
+              <Tab fx:id="incomeTab" text="Incomes" closable="false" />
+              <Tab fx:id="expenseTab" text="Expenses" closable="false" />
+              <Tab fx:id="analyticsTab" text="Analytics" closable="false" />
+            </TabPane>
+            <Button fx:id="helpButton" text="Help" onMouseClicked="#handleHelp" AnchorPane.rightAnchor="0.0" />
+          </AnchorPane>
+        </center>
 
-        <StackPane VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS" fx:id="resultDisplayPlaceholder"
-                   styleClass="pane-with-border" minHeight="100" prefHeight="100" maxHeight="100">
-          <padding>
-            <Insets top="5" right="15" bottom="5" left="15" />
-          </padding>
-        </StackPane>
-
-          <HBox styleClass="command-pane" alignment="CENTER">
-            <StackPane VBox.vgrow="NEVER" HBox.hgrow="SOMETIMES" fx:id="commandBoxPlaceholder" styleClass="pane-with-border">
+        <bottom>
+          <VBox>
+            <StackPane VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS" fx:id="resultDisplayPlaceholder"
+                       styleClass="pane-with-border" minHeight="100" prefHeight="100" maxHeight="100">
               <padding>
-                <Insets top="5" right="10" bottom="5" left="10" />
+                <Insets top="5" right="15" bottom="5" left="15" />
               </padding>
             </StackPane>
-          </HBox>
 
-        <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
-      </VBox>
+            <HBox styleClass="command-pane" alignment="CENTER">
+              <StackPane VBox.vgrow="NEVER" HBox.hgrow="SOMETIMES" fx:id="commandBoxPlaceholder" styleClass="pane-with-border">
+                <padding>
+                  <Insets top="5" right="10" bottom="5" left="10" />
+                </padding>
+              </StackPane>
+            </HBox>
+
+            <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
+          </VBox>
+        </bottom>
+      </BorderPane>
     </Scene>
   </scene>
 </fx:root>

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -3,7 +3,6 @@
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.StackPane?>
 
-<StackPane fx:id="placeHolder" styleClass="result-container" xmlns="http://javafx.com/javafx/8"
-    xmlns:fx="http://javafx.com/fxml/1" >
-  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display" text="How may I help you today?"/>
+<StackPane styleClass="result-container" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" >
+  <TextArea fx:id="resultDisplay" editable="false" wrapText="true" styleClass="result-display" />
 </StackPane>

--- a/src/main/resources/view/SavingsGoalPanel.fxml
+++ b/src/main/resources/view/SavingsGoalPanel.fxml
@@ -1,51 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.control.*?>
-<?import javafx.scene.layout.*?>
 <?import javafx.scene.image.ImageView?>
+<?import javafx.scene.layout.*?>
 
 <?import javafx.geometry.Insets?>
 <VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" alignment="TOP_CENTER"
       styleClass="right-panel">
+  <padding>
+    <Insets left="10" top="10" bottom="15" />
+  </padding>
+  <HBox alignment="CENTER_LEFT" VBox.vgrow="ALWAYS">
     <padding>
-        <Insets left="10" top="10" bottom="15" />
+      <Insets bottom="10" top="20"/>
     </padding>
-    <HBox alignment="CENTER_LEFT" VBox.vgrow="ALWAYS">
-        <padding>
-            <Insets bottom="10" top="20"/>
-        </padding>
-        <Label fx:id="monthlyExpenseLimit" styleClass="right-panel-content"/>
-    </HBox>
-    <HBox alignment="CENTER_LEFT" VBox.vgrow="ALWAYS">
-        <padding>
-            <Insets bottom="10" top="10"/>
-        </padding>
-        <Label fx:id="monthlySavingsGoal" wrapText="true" styleClass="right-panel-content"/>
-    </HBox>
-    <HBox alignment="CENTER_LEFT" VBox.vgrow="ALWAYS">
-        <padding>
-            <Insets bottom="10" top="10"/>
-        </padding>
-        <Label fx:id="remainingBudget" wrapText="true" styleClass="right-panel-content"/>
-    </HBox>
-    <HBox alignment="CENTER_LEFT" VBox.vgrow="ALWAYS">
-        <padding>
-            <Insets bottom="10" top="10"/>
-        </padding>
-        <Label fx:id="currentSavings" wrapText="true" styleClass="right-panel-content"/>
-    </HBox>
-    <HBox alignment="CENTER_LEFT" VBox.vgrow="ALWAYS">
-        <padding>
-            <Insets bottom="10" top="10"/>
-        </padding>
-        <Label fx:id="budgetDeficit" wrapText="true" styleClass="right-panel-content"/>
-    </HBox>
-    <HBox alignment="CENTER_LEFT" VBox.vgrow="ALWAYS">
-        <padding>
-            <Insets bottom="10" top="10"/>
-        </padding>
-        <Label fx:id="savingsDeficit" wrapText="true" styleClass="right-panel-content"/>
-    </HBox>
-    <Region VBox.vgrow="ALWAYS"/>
-    <ImageView fx:id="savingsPicture" fitHeight="200.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true"/>
+    <Label fx:id="monthlyExpenseLimit" styleClass="right-panel-content"/>
+  </HBox>
+  <HBox alignment="CENTER_LEFT" VBox.vgrow="ALWAYS">
+  <padding>
+      <Insets bottom="10" top="10"/>
+  </padding>
+  <Label fx:id="monthlySavingsGoal" wrapText="true" styleClass="right-panel-content"/>
+  </HBox>
+  <HBox alignment="CENTER_LEFT" VBox.vgrow="ALWAYS">
+    <padding>
+      <Insets bottom="10" top="10"/>
+    </padding>
+    <Label fx:id="remainingBudget" wrapText="true" styleClass="right-panel-content"/>
+  </HBox>
+  <HBox alignment="CENTER_LEFT" VBox.vgrow="ALWAYS">
+    <padding>
+      <Insets bottom="10" top="10"/>
+    </padding>
+    <Label fx:id="currentSavings" wrapText="true" styleClass="right-panel-content"/>
+  </HBox>
+  <HBox alignment="CENTER_LEFT" VBox.vgrow="ALWAYS">
+    <padding>
+      <Insets bottom="10" top="10"/>
+    </padding>
+    <Label fx:id="budgetDeficit" wrapText="true" styleClass="right-panel-content"/>
+  </HBox>
+  <HBox alignment="CENTER_LEFT" VBox.vgrow="ALWAYS">
+    <padding>
+      <Insets bottom="10" top="10"/>
+    </padding>
+    <Label fx:id="savingsDeficit" wrapText="true" styleClass="right-panel-content"/>
+  </HBox>
+  <Region VBox.vgrow="ALWAYS"/>
+  <ImageView fx:id="savingsPicture" fitHeight="200.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true"/>
 </VBox>

--- a/src/main/resources/view/TransactionListCard.fxml
+++ b/src/main/resources/view/TransactionListCard.fxml
@@ -10,28 +10,28 @@
 <?import javafx.scene.layout.VBox?>
 
 <VBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" alignment="CENTER">
-      <GridPane fx:id="transactionDetails" alignment="CENTER_LEFT">
-          <columnConstraints>
-              <ColumnConstraints hgrow="ALWAYS" minWidth="30" prefWidth="130" />
-          </columnConstraints>
-          <padding>
-              <Insets top="5" right="10" bottom="5" left="10" />
-          </padding>
-          <HBox GridPane.columnIndex="0" GridPane.halignment="LEFT">
-              <Label fx:id="id" styleClass="cell_big_label">
-                  <minWidth>
-                      <Region fx:constant="USE_PREF_SIZE" />
-                  </minWidth>
-              </Label>
-              <Label fx:id="title" text="\$title" styleClass="cell_big_label" wrapText="true"/>
-          </HBox>
-          <columnConstraints>
-              <ColumnConstraints hgrow="ALWAYS" minWidth="20" prefWidth="160" halignment="CENTER"/>
-          </columnConstraints>
-          <FlowPane fx:id="categories" styleClass="cell_categories" GridPane.columnIndex="1" />
-          <columnConstraints>
-              <ColumnConstraints hgrow="SOMETIMES" minWidth="20" prefWidth="100" halignment="CENTER"/>
-          </columnConstraints>
-          <Label fx:id="amount" styleClass="cell_small_label" text="\$amount" GridPane.columnIndex="2" GridPane.halignment="RIGHT"/>
-      </GridPane>
+  <GridPane fx:id="transactionDetails" alignment="CENTER_LEFT">
+    <columnConstraints>
+      <ColumnConstraints hgrow="ALWAYS" minWidth="30" prefWidth="130" />
+    </columnConstraints>
+    <padding>
+      <Insets top="5" right="10" bottom="5" left="10" />
+    </padding>
+    <HBox GridPane.columnIndex="0" GridPane.halignment="LEFT">
+      <Label fx:id="id" styleClass="cell_big_label">
+        <minWidth>
+          <Region fx:constant="USE_PREF_SIZE" />
+        </minWidth>
+      </Label>
+      <Label fx:id="title" text="\$title" styleClass="cell_big_label" wrapText="true"/>
+    </HBox>
+    <columnConstraints>
+      <ColumnConstraints hgrow="ALWAYS" minWidth="20" prefWidth="160" halignment="CENTER"/>
+    </columnConstraints>
+    <FlowPane fx:id="categories" styleClass="cell_categories" GridPane.columnIndex="1" />
+    <columnConstraints>
+      <ColumnConstraints hgrow="SOMETIMES" minWidth="20" prefWidth="100" halignment="CENTER"/>
+    </columnConstraints>
+    <Label fx:id="amount" styleClass="cell_small_label" text="\$amount" GridPane.columnIndex="2" GridPane.halignment="RIGHT"/>
+  </GridPane>
 </VBox>

--- a/src/main/resources/view/TwoColumnTabPane.fxml
+++ b/src/main/resources/view/TwoColumnTabPane.fxml
@@ -2,25 +2,34 @@
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-  <VBox styleClass="pane-with-border" HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS" alignment="CENTER">
-    <Label fx:id="mainPanelLabel" styleClass="panel-label" />
-    <padding>
-      <Insets top="10" right="10" bottom="10" left="10" />
-    </padding>
-    <StackPane fx:id="mainPanelPlaceholder" maxWidth="Infinity" minWidth="400"
-               HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS" />
-  </VBox>
-  <VBox styleClass="pane-with-border" HBox.hgrow="ALWAYS" alignment="CENTER">
-    <Label fx:id="sidePanelLabel" styleClass="panel-label" />
-    <padding>
-      <Insets bottom="10" left="10" right="10" top="10" />
-    </padding>
-    <StackPane fx:id="sidePanelPlaceholder" maxWidth="Infinity" minWidth="100" prefWidth="150"
-               HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS" />
-  </VBox>
-</HBox>
+<GridPane xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+  <children>
+    <VBox styleClass="pane-with-border" alignment="TOP_CENTER" GridPane.columnIndex="0">
+      <Label fx:id="mainPanelLabel" styleClass="panel-label" />
+      <padding>
+        <Insets top="10" right="10" bottom="10" left="10" />
+      </padding>
+      <StackPane fx:id="mainPanelPlaceholder" />
+    </VBox>
+    <VBox styleClass="pane-with-border" alignment="TOP_CENTER" GridPane.columnIndex="1">
+      <Label fx:id="sidePanelLabel" styleClass="panel-label" />
+      <padding>
+        <Insets bottom="10" left="10" right="10" top="10" />
+      </padding>
+      <StackPane fx:id="sidePanelPlaceholder" />
+    </VBox>
+  </children>
+  <columnConstraints>
+    <ColumnConstraints hgrow="ALWAYS" percentWidth="60.0" />
+    <ColumnConstraints hgrow="ALWAYS" percentWidth="40.0" />
+  </columnConstraints>
+  <rowConstraints>
+    <RowConstraints vgrow="ALWAYS" />
+  </rowConstraints>
+</GridPane>

--- a/src/main/resources/view/TwoColumnTabPane.fxml
+++ b/src/main/resources/view/TwoColumnTabPane.fxml
@@ -15,14 +15,14 @@
       <padding>
         <Insets top="10" right="10" bottom="10" left="10" />
       </padding>
-      <StackPane fx:id="mainPanelPlaceholder" />
+      <StackPane fx:id="mainPanelPlaceholder" VBox.vgrow="ALWAYS" />
     </VBox>
     <VBox styleClass="pane-with-border" alignment="TOP_CENTER" GridPane.columnIndex="1">
       <Label fx:id="sidePanelLabel" styleClass="panel-label" />
       <padding>
         <Insets bottom="10" left="10" right="10" top="10" />
       </padding>
-      <StackPane fx:id="sidePanelPlaceholder" />
+      <StackPane fx:id="sidePanelPlaceholder" VBox.vgrow="ALWAYS" />
     </VBox>
   </children>
   <columnConstraints>

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/LogicManagerTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/LogicManagerTest.java
@@ -134,7 +134,7 @@ public class LogicManagerTest {
 
     @Test
     public void setGuiSettings_validGuiSettings_setsGuiSettings() {
-        GuiSettings guiSettings = new GuiSettings(800, 1200, 100, 100);
+        GuiSettings guiSettings = new GuiSettings(800, 1200, 100, 100, false);
         logic.setGuiSettings(guiSettings);
         assertEquals(guiSettings, logic.getGuiSettings());
     }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/ModelManagerTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/ModelManagerTest.java
@@ -43,7 +43,7 @@ public class ModelManagerTest {
     public void setUserPrefs_validUserPrefs_copiesUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
         userPrefs.setFinanceTrackerFilePath(Paths.get("finance/tracker/file/path"));
-        userPrefs.setGuiSettings(new GuiSettings(1, 2, 3, 4));
+        userPrefs.setGuiSettings(new GuiSettings(1, 2, 3, 4, true));
         modelManager.setUserPrefs(userPrefs);
         assertEquals(userPrefs, modelManager.getUserPrefs());
 
@@ -60,7 +60,7 @@ public class ModelManagerTest {
 
     @Test
     public void setGuiSettings_validGuiSettings_setsGuiSettings() {
-        GuiSettings guiSettings = new GuiSettings(1, 2, 3, 4);
+        GuiSettings guiSettings = new GuiSettings(1, 2, 3, 4, true);
         modelManager.setGuiSettings(guiSettings);
         assertEquals(guiSettings, modelManager.getGuiSettings());
     }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/UserPrefsTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/UserPrefsTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import ay2021s1_cs2103_w16_3.finesse.commons.core.GuiSettings;
 
 public class UserPrefsTest {
-    private final GuiSettings guiSettings = new GuiSettings(1200, 800, 100, 100);
+    private final GuiSettings guiSettings = new GuiSettings(1200, 800, 100, 100, false);
 
     @Test
     public void setGuiSettings_nullGuiSettings_throwsNullPointerException() {
@@ -27,7 +27,7 @@ public class UserPrefsTest {
     @Test
     public void equals_sameUserPrefs_returnsTrue() {
         UserPrefs userPrefs = new UserPrefs();
-        GuiSettings guiSettings = new GuiSettings(1200, 800, 100, 100);
+        GuiSettings guiSettings = new GuiSettings(1200, 800, 100, 100, false);
         userPrefs.setGuiSettings(guiSettings);
         assertEquals(userPrefs, userPrefs);
     }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/storage/JsonUserPrefsStorageTest.java
@@ -72,7 +72,7 @@ public class JsonUserPrefsStorageTest {
 
     private UserPrefs getTypicalUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
-        userPrefs.setGuiSettings(new GuiSettings(1000, 500, 300, 100));
+        userPrefs.setGuiSettings(new GuiSettings(1000, 500, 300, 100, false));
         userPrefs.setFinanceTrackerFilePath(Paths.get("fine$$e.json"));
         return userPrefs;
     }
@@ -103,7 +103,7 @@ public class JsonUserPrefsStorageTest {
     public void saveUserPrefs_allInOrder_success() throws DataConversionException, IOException {
 
         UserPrefs original = new UserPrefs();
-        original.setGuiSettings(new GuiSettings(1200, 200, 0, 2));
+        original.setGuiSettings(new GuiSettings(1200, 200, 0, 2, false));
 
         Path pefsFilePath = testFolder.resolve("TempPrefs.json");
         JsonUserPrefsStorage jsonUserPrefsStorage = new JsonUserPrefsStorage(pefsFilePath);
@@ -114,7 +114,7 @@ public class JsonUserPrefsStorageTest {
         assertEquals(original, readBack);
 
         //Try saving when the file exists
-        original.setGuiSettings(new GuiSettings(5, 5, 5, 5));
+        original.setGuiSettings(new GuiSettings(5, 5, 5, 5, false));
         jsonUserPrefsStorage.saveUserPrefs(original);
         readBack = jsonUserPrefsStorage.readUserPrefs().get();
         assertEquals(original, readBack);

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/storage/StorageManagerTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/storage/StorageManagerTest.java
@@ -41,7 +41,7 @@ public class StorageManagerTest {
          * More extensive testing of UserPref saving/reading is done in {@link JsonUserPrefsStorageTest} class.
          */
         UserPrefs original = new UserPrefs();
-        original.setGuiSettings(new GuiSettings(300, 600, 4, 6));
+        original.setGuiSettings(new GuiSettings(300, 600, 4, 6, false));
         storageManager.saveUserPrefs(original);
         UserPrefs retrieved = storageManager.readUserPrefs().get();
         assertEquals(original, retrieved);


### PR DESCRIPTION
Changes:
- Enable resizing of application window.
- Set minimum window size of 900 by 650.
- Update UI components to be resizable.
  - Tabs are now anchored to the top of the window, while the result display box and command line are anchored to the bottom. The contents of the tab resize freely to fill empty space.
  - On the `Overview`, `Incomes`, and `Expenses` tabs, the main panel and side panel are fixed to a 3:2 ratio.
- Update application to keep track of window fullscreen status across sessions.
  - If the application was closed while fullscreen previously, it will launch in fullscreen.
  - Window size and position are captured whenever the window is moved or resized while not fullscreen.
    - This is to allow for proper exiting out of fullscreen mode across sessions.
- Add text wrap to the result display box.
- Use 2 spaces per indentation instead of 4 for `fxml` files.

**Note that the savings goal panel has an image that still has a hardcoded size. This has not been fixed due to @zhaojj2209 making changes to it in #172 as well.**

Resolves #162.