### PR TITLE
Refactor add command for frequent expense and frequent income

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/frequent/AddFrequentExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/frequent/AddFrequentExpenseCommand.java
@@ -5,7 +5,6 @@ import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_CATEGO
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_TITLE;
 import static java.util.Objects.requireNonNull;
 
-import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.Command;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/frequent/AddFrequentExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/frequent/AddFrequentExpenseCommand.java
@@ -31,8 +31,6 @@ public class AddFrequentExpenseCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New frequent expense added: %1$s";
 
-    private static final Index EXPENSE_TAB_INDEX = Index.fromZeroBased(2);
-
     private final FrequentExpense toAdd;
 
     /**
@@ -52,8 +50,7 @@ public class AddFrequentExpenseCommand extends Command {
         } catch (DuplicateFrequentTransactionException e) {
             throw new CommandException(e.getMessage());
         }
-        Tab tabToSwitchTo = Tab.values()[EXPENSE_TAB_INDEX.getZeroBased()];
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), tabToSwitchTo);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), Tab.EXPENSES);
     }
 
     @Override

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/frequent/AddFrequentExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/frequent/AddFrequentExpenseCommand.java
@@ -5,14 +5,17 @@ import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_CATEGO
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_TITLE;
 import static java.util.Objects.requireNonNull;
 
+import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.Command;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.frequent.FrequentExpense;
 import ay2021s1_cs2103_w16_3.finesse.model.frequent.exceptions.DuplicateFrequentTransactionException;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
 public class AddFrequentExpenseCommand extends Command {
+
     public static final String COMMAND_WORD = "add-frequent-expense";
     public static final String COMMAND_ALIAS = "addfe";
 
@@ -27,6 +30,8 @@ public class AddFrequentExpenseCommand extends Command {
             + PREFIX_CATEGORY + "Utilities";
 
     public static final String MESSAGE_SUCCESS = "New frequent expense added: %1$s";
+
+    private static final Index EXPENSE_TAB_INDEX = Index.fromZeroBased(2);
 
     private final FrequentExpense toAdd;
 
@@ -47,7 +52,8 @@ public class AddFrequentExpenseCommand extends Command {
         } catch (DuplicateFrequentTransactionException e) {
             throw new CommandException(e.getMessage());
         }
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+        Tab tabToSwitchTo = Tab.values()[EXPENSE_TAB_INDEX.getZeroBased()];
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), tabToSwitchTo);
     }
 
     @Override
@@ -56,4 +62,5 @@ public class AddFrequentExpenseCommand extends Command {
                 || (other instanceof AddFrequentExpenseCommand // instanceof handles nulls
                 && toAdd.equals(((AddFrequentExpenseCommand) other).toAdd));
     }
+
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/frequent/AddFrequentIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/frequent/AddFrequentIncomeCommand.java
@@ -5,14 +5,17 @@ import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_CATEGO
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_TITLE;
 import static java.util.Objects.requireNonNull;
 
+import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.Command;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.frequent.FrequentIncome;
 import ay2021s1_cs2103_w16_3.finesse.model.frequent.exceptions.DuplicateFrequentTransactionException;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
 public class AddFrequentIncomeCommand extends Command {
+
     public static final String COMMAND_WORD = "add-frequent-income";
     public static final String COMMAND_ALIAS = "addfi";
 
@@ -27,6 +30,8 @@ public class AddFrequentIncomeCommand extends Command {
             + PREFIX_CATEGORY + "Utilities";
 
     public static final String MESSAGE_SUCCESS = "New frequent income added: %1$s";
+
+    private static final Index INCOME_TAB_INDEX = Index.fromZeroBased(1);
 
     private final FrequentIncome toAdd;
 
@@ -49,7 +54,8 @@ public class AddFrequentIncomeCommand extends Command {
             throw new CommandException(e.getMessage());
         }
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+        Tab tabToSwitchTo = Tab.values()[INCOME_TAB_INDEX.getZeroBased()];
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), tabToSwitchTo);
     }
 
     @Override
@@ -58,4 +64,5 @@ public class AddFrequentIncomeCommand extends Command {
                 || (other instanceof AddFrequentIncomeCommand // instanceof handles nulls
                 && toAdd.equals(((AddFrequentIncomeCommand) other).toAdd));
     }
+
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/frequent/AddFrequentIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/frequent/AddFrequentIncomeCommand.java
@@ -5,7 +5,6 @@ import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_CATEGO
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_TITLE;
 import static java.util.Objects.requireNonNull;
 
-import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.Command;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/frequent/AddFrequentIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/frequent/AddFrequentIncomeCommand.java
@@ -31,8 +31,6 @@ public class AddFrequentIncomeCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New frequent income added: %1$s";
 
-    private static final Index INCOME_TAB_INDEX = Index.fromZeroBased(1);
-
     private final FrequentIncome toAdd;
 
     /**
@@ -54,8 +52,7 @@ public class AddFrequentIncomeCommand extends Command {
             throw new CommandException(e.getMessage());
         }
 
-        Tab tabToSwitchTo = Tab.values()[INCOME_TAB_INDEX.getZeroBased()];
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), tabToSwitchTo);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), Tab.INCOME);
     }
 
     @Override


### PR DESCRIPTION
Resolves #182.

Changes:
- Created and returned a new `CommandResult`upon creating a new `AddFrequentExpenseCommand`. The new `CommandResult` contains the index of the `Expense Tab` to switch to.
- Created and returned a new `CommandResult`upon creating a new `AddFrequentIncomeCommand`. The new `CommandResult` contains the index of the `Income Tab` to switch to.