### PR TITLE
Restrict users from using certain commands for Bookmark Transactions

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -480,11 +480,11 @@ Shortcut: `addbe`
 
 Examples:
 - `add-bookmark-expense t/Phone Bill a/60 c/Utilities c/Personal`
-adds a bookmark expense titled `Phone Bill` with amount `$60.00` and two categories`Utilities` and `Personal`.
+adds a bookmark expense titled `Phone Bill` with amount `$60.00` and two categories `Utilities` and `Personal`.
 - `add-bookmark-expense t/Spotify Subscription a/$9 c/Others`
 adds a bookmark expense titled `Spotify Subscription` with amount `$9.00` and a single category `Others`.
-- `addbe t/Bubble Tea a/$4.50 c/Food & Drink`
-adds a bookmark expense titled `Bubble Tea` with amount `$4.50` and a single category `Food & Drink`.
+- `addbe t/Bubble Tea a/$4.50 c/Food & Beverage`
+adds a bookmark expense titled `Bubble Tea` with amount `$4.50` and a single category `Food & Beverage`.
 - `addbe t/Lunch a/$5.00`
 adds a bookmark expense titled `Lunch` with amount `$5.00` and no categories.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -268,7 +268,7 @@ Format: (when on the [Expenses tab](#213-expenses-tab)) `delete INDEX`
 
 * `INDEX` allows you to choose which expense to delete by specifying its position in the expenses list.
 
-Examples:
+Example:
 * `delete 3` deletes the third expense in the expenses list.
 
 Example Usage:
@@ -286,7 +286,7 @@ Deleted Expense: Bubble Tea Amount: $4.80 Date: 14/10/2020 Categories: [Food & B
 Shows a list of all the expenses in the finance tracker.
 This effectively resets any current filtering of the expense list, such as those made by `find`.
 
-Format: (when on the [Expenses tab](#)) `list`
+Format: (when on the [Expenses tab](#213-expenses-tab)) `list`
 
 Example Usage:
 ```
@@ -405,7 +405,7 @@ Format: (when on the [Incomes tab](#212-incomes-tab)) `delete INDEX`
 
 * `INDEX` allows you to choose which income to delete by specifying its position in the incomes list.
 
-Examples:
+Example:
 * `delete 3` deletes the third income in the incomes list.
 
 Example Usage:
@@ -423,7 +423,7 @@ Deleted Income: Teaching Assistant Amount: $1920.00 Date: 18/10/2020 Categories:
 Shows a list of all the incomes in the finance tracker.
 This effectively resets any current filtering of the income list, such as those made by `find`.
 
-Format: (when on the [Income tab](#)) `list`
+Format: (when on the [Incomes tab](#212-incomes-tab)) `list`
 
 Example Usage:
 ```

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -465,286 +465,238 @@ Expected Outcome:
 
 ### 4.5 Bookmark Expense
 
-Fine<span>$<span>$<span>e's Bookmark Expense feature is used to store frequent expenses that the user makes such as paying of monthly phone bills or buying bubble tea weekly.
-The user will be then be able to edit, delete and convert a bookmarked expense to conveniently add it into Fine$$e's expense list.
+Fine\\$\\$e's Bookmark Expense feature is used to store frequent expenses that the user makes such as paying of monthly phone bills or buying bubble tea weekly.
+The user will be then be able to edit, delete and convert a bookmarked expense to conveniently add it into Fine\\$\\$e's expense list.
 
-#### 4.5.1 Add Bookmark Expense: `add-bookmark-expense`
+#### 4.5.1 Add Bookmark Expense
 
 Adds a bookmarked expense into the bookmark expense list in Fine$$e.
 
-**Format**:
-```$xslt
-add-bookmark-expense t/TITLE a/AMOUNT [c/CATEGORIES]...
-```
+Format: `add-bookmark-expense t/TITLE a/AMOUNT [c/CATEGORIES]...`
 
-**Shortcut**:
-```$xslt
-addbe t/TITLE a/AMOUNT [c/CATEGORIES]...
-```
+- The title, amount, and categories of the bookmark expense follows the same rules as the [Add Expense](#431-add-expense) feature above.
 
-- Adds a new bookmark expense with the given details.
-- The title and the amount of the bookmark expense **cannot be empty**.
-- The title should contain only alphanumeric characters and spaces.
-- The amount inputted should only contain positive numbers and reflect the value in dollars.
-The inputted amount can have either 0 or 2 decimal places and also have an optional $ prefix.
+Shortcut: `addbe`
 
->  :bulb: Inputting of categories for the bookmark expense is optional and is up to the user's discretion.
-
-**Examples**:
+Examples:
 - `add-bookmark-expense t/Phone Bill a/60 c/Utilities c/Personal`
+adds a bookmark expense titled `Phone Bill` with amount `$60.00` and two categories`Utilities` and `Personal`.
 - `add-bookmark-expense t/Spotify Subscription a/$9 c/Others`
+adds a bookmark expense titled `Spotify Subscription` with amount `$9.00` and a single category `Others`.
 - `addbe t/Bubble Tea a/$4.50 c/Food & Drink`
+adds a bookmark expense titled `Bubble Tea` with amount `$4.50` and a single category `Food & Drink`.
 - `addbe t/Lunch a/$5.00`
+adds a bookmark expense titled `Lunch` with amount `$5.00` and no categories.
 
-**Example Usage**:
-```$xslt
+Example Usage:
+```
 add-bookmark-expense t/Phone Bill a/60 c/Utilities
 ```
 
-Adds a bookmark expense with a title of Phone Bill into the bookmark expense list along with its amount and categories.
-
-**Expected Outcome**:
-```$xslt
+Expected Outcome:
+```
 New bookmark expense added: Phone Bill Amount: $60.00 Categories: [Utilities]
 ```
 
-#### 4.5.2 Edit Bookmark Expense: `edit-bookmark-expense`
+#### 4.5.2 Edit Bookmark Expense
 
 Edits the details of bookmark expenses.
 
-**Format**:
-```$xslt
-edit-bookmark-expense INDEX [t/TITLE] [a/AMOUNT] [c/CATEGORIES]
-```
-- Edits the bookmark expense at the specified `INDEX` in the bookmark expense list.
-- The index refers to the bookmark expense in the displayed bookmark expense list on the Expense Tab.
-The index has to be a positive integer and **cannot be empty**.
-- At least one of the optional fields has to be provided.
-- Existing values will be updated to the input values.
+Format: (when on the [Expenses tab](#213-expenses-tab)) `edit-bookmark INDEX [t/TITLE] [a/AMOUNT] [c/CATEGORIES]`
 
-> :bulb: You can omit [optional] parameters by leaving them empty.
+- `INDEX` allows you to choose which bookmark expense to edit by specifying its position in the bookmark expense list.
+- `TITLE`, `AMOUNT`, `DATE`, `CATEGORY` allow you to specify the updated bookmark expense information.
+None of them are mandatory, but at least one must be specified.
+For parameters that have been omitted, the value will remain unchanged.
+  - The restrictions on the input values are identical to the [Add Expense](#431-add-expense) feature above.
 
 > :bulb: To specify an edit that removes all categories, use the parameter `c/` with no category name.
 
-**Examples**:
-- `edit-bookmark-expense 1 t/Part Time a/400 c/Work`
-- `edit-bookmark-expense 2 a/65 c/Food & Drink`
-- `edit-bookmark-expense 3 c/Others`
+Examples:
+- `edit-bookmark 1 a/65`
+edits the first bookmark expense in the bookmark expense list to have an amount of `$65.00`.
+- `edit-bookmark 2 t/Part Time a/400 c/Work`
+edits the second bookmark expense in the bookmark expense list to have a title of `Part Time`, an amount of `$65.00`,
+and a single category `Work`.
+- `edit-bookmark 3 c/Others`
+edits the third bookmark expense in the bookmark expense list to have a single category `Others`.
 
-**Example Usage**:
-```$xslt
-edit-bookmark-expense 1 a/65
+Example Usage:
+```
+edit-bookmark 1 a/65
 ```
 
-Edits the amount of the first bookmark expense in the bookmark expense list to `65`.
-
-**Expected Outcome**:
-```$xslt
+Expected Outcome:
+```
 Edited Bookmark Expense: Phone Bill Amount: $65.00 Categories: [Utilities][Personal]
 ```
 
-#### 4.5.3 Delete Bookmark Expense: `delete-bookmark-expense`
+#### 4.5.3 Delete Bookmark Expense
 
 Deletes the bookmark expense and all of its information from the bookmark expense list in Fine$$e.
 
-**Format**:
-```$xslt
-delete-bookmark-expense INDEX
+Format: (when on the [Expenses tab](#213-expenses-tab)) `delete-bookmark INDEX`
+
+* `INDEX` allows you to choose which bookmark expense to delete by specifying its position in the bookmark expense list.
+
+Example:
+* `delete-bookmark 3` deletes the bookmark expense at index 3 in the bookmark expense list.
+
+Example Usage:
+```
+delete-bookmark 3
 ```
 
-- Deletes the bookmark expense at the specified `INDEX`.
-- The index refers to the index number of the bookmark expense shown in the bookmark expense list.
-- The index has to be a positive integer and **cannot be empty**.
-
-**Example**:
-```$xslt
-delete-bookmark-expense 3
+Expected Outcome:
 ```
-
-Deletes the bookmark expense at index 3 in the bookmark expense list.
-
-**Example Usage**
-```$xslt
-delete-bookmark-expense 3
-```
-
-**Expected Outcome**:
-```$xslt
 Deleted Bookmark Expense: Phone Bill Amount: $60.00 Categories: [Utilities]
 ```
 
-#### 4.5.4 Convert Bookmark Expense: `convert-bookmark-expense`
+#### 4.5.4 Convert Bookmark Expense
 
 Converts a bookmark expense with the date it has been converted on, and adds it to the expense list in Fine$$e.
 
-**Format**:
-```$xslt
-convert-bookmark-expense INDEX d/DATE
+Format: (when on the [Expenses tab](#213-expenses-tab)) `convert-bookmark INDEX d/DATE`
+
+- The `INDEX` refers to the index number of the bookmark expense shown in the bookmark expense list.
+- The `DATE` should be in `dd/mm/yyyy` format, and cannot be later than the current date.
+
+Shortcut: (when on the [Expenses tab](#213-expenses-tab)) `convertb`
+
+Examples:
+- `convert-bookmark 2 d/10/10/2020`
+converts the bookmark expense at index 2 in the bookmark expense list into an expense with the information of the
+specified bookmark expense and date `10/10/2020`.
+- `convertb 1 d/05/05/2020`
+converts the bookmark expense at index 1 in the bookmark expense list into an expense with the information of the
+specified bookmark expense and date `05/05/2020`.
+
+Example Usage:
+```
+convert-bookmark 2 d/10/10/2020
 ```
 
-**Shortcut**:
-```$xslt
-convertbe INDEX d/DATE
+Expected Outcome:
 ```
-
-- Converts the bookmark expense at the specified `INDEX` into an `EXPENSE`, using the `DATE` it has been converted on, and adds it to the expense list in Fine$$e.
-- The `INDEX` and `DATE` **cannot be empty**.
-- The `DATE` should be in dd/mm/yyyy format and it cannot be later than the current date.
-- The `INDEX` refers to the index number of the bookmark expense shown in the bookmark-expense list.
-- The index has to be a positive integer.
-
-**Examples**:
-- `convert-bookmark-expense 2 d/10/10/2020`
-- `convertbe 1 d/05/05/2020`
-
-**Example Usage**:
-```$xslt
-convert-bookmark-expense 2 d/10/10/2020
-```
-
-Converts the bookmark expense at index 2 in the bookmark list into an expense with the information of the specified bookmark expense and the inputted date.
-
-**Expected Outcome**:
-```$xslt
 Bookmark expense has been converted and successfully added to finance tracker: Phone Bill Amount: $65.00 Date: 10/10/2020 Categories: [Utilities][Personal]
 ```
 
 ### 4.6 Bookmark Income
 
-Fine<span>$<span>$<span>e's Bookmark Income feature is used to store frequent incomes that the user receives such as monthly salary or stipend for being a teaching assistant.
-The user will then be able to edit, delete and convert a bookmarked income to conveniently add it into Fine<span>$<span>$<span>e's income list.
+Fine\\$\\$e's Bookmark Income feature is used to store frequent incomes that the user receives such as monthly salary or stipend for being a teaching assistant.
+The user will then be able to edit, delete and convert a bookmarked income to conveniently add it into Fine\\$\\$e's income list.
 
-#### 4.6.1 Add Bookmark Income: `add-bookmark-income`
+#### 4.6.1 Add Bookmark Income
 
 Adds a bookmarked income into the bookmark income list in Fine$$e.
 
-**Format**:
-```$xslt
-add-bookmark-income t/TITLE a/AMOUNT [c/CATEGORIES]...
-```
+Format: `add-bookmark-income t/TITLE a/AMOUNT [c/CATEGORIES]...`
 
-**Shortcut**:
-```$xslt
-addbi t/TITLE a/AMOUNT [c/CATEGORIES]...
-```
+- The title, amount, and categories of the bookmark income follows the same rules as the [Add Income](#441-add-income) feature above.
 
-- Adds a new bookmark income with the given details.
-- The title and amount of the bookmark income **cannot be empty**.
-- The title should only contain alphanumeric characters and spaces
-- The amount indicated should only contain positive numbers and reflect the value in dollars.
-The inputted amount can have either 0 or 2 decimal places and also have an optional $ prefix.
+Shortcut: `addbi`
 
-**Examples**:
-- `add-bookmark-income t/Part Time a/450 c/Work c/Startup`
+Examples:
 - `add-bookmark-income t/Internship a/$1000 c/Work`
+adds a bookmark income titled `Internship` with amount `$1000.00` and a single category `Work`.
+- `add-bookmark-income t/Part Time a/450 c/Work c/Startup`
+adds a bookmark income titled `Part Time` with amount `$450.00` and two categories `Work` and `Startup`.
 - `addbi t/Investments a/400 c/Personal c/Dividends`
+adds a bookmark income titled `Investments` with amount `$400.00` and two categories `Personal` and `Dividends`.
 - `addbi t/Monthly Allowance a/300`
+adds a bookmark income titled `Monthly Allowance` with amount `$300.00` and no categories.
 
-**Example Usage**:
-```$xslt
-add-bookmark-income t/Internship a/1000 c/Work c/Summer
+Example Usage:
+```
+add-bookmark-income t/Internship a/1000 c/Work
 ```
 
-Adds a bookmark income with a title of Internship into the bookmark income along with its amount and categories.
-
-**Expected Outcome**:
-```$xslt
-New bookmark income added: Internship Amount: $1000.00 Categories: [Work][Summer]
+Expected Outcome:
+```
+New bookmark income added: Internship Amount: $1000.00 Categories: [Work]
 ```
 
-#### 4.6.2 Edit Bookmark Income: `edit-bookmark-income`
+#### 4.6.2 Edit Bookmark Income
 
 Edits the details of bookmark incomes.
 
-**Format**:
-- `edit-bookmark-income INDEX [t/TITLE] [a/AMOUNT] [c/CATEGORIES]...`
+Format: (when on the [Incomes tab](#212-incomes-tab)) `edit-bookmark INDEX [t/TITLE] [a/AMOUNT] [c/CATEGORIES]...`
 
-- Edits the bookmark income at the specified INDEX in the bookmark income list.
-- The index refers to the bookmark income in the displayed bookmark income list on the Income Tab.
-The index has to be a positive integer and **cannot be empty**.
-- At least one of the optional fields has to be provided.
-- Existing values will be updated to the input values.
-
-> :bulb: You can omit [optional] parameters by leaving them empty.
+- `INDEX` allows you to choose which bookmark income to edit by specifying its position in the bookmark income list.
+- `TITLE`, `AMOUNT`, `DATE`, `CATEGORY` allow you to specify the updated bookmark income information.
+None of them are mandatory, but at least one must be specified.
+For parameters that have been omitted, the value will remain unchanged.
+  - The restrictions on the input values are identical to the [Add Income](#441-add-income) feature above.
 
 > :bulb: To specify an edit that removes all categories, use the parameter `c/` with no category name.
 
-**Examples**:
-- `edit-bookmark-income 3 t/Monthly Tuition c/Work c/Part Time`
-- `edit-bookmark-income 1 a/800`
-- `edit-bookmark-income 2 t/Investments a/$300.00`
+Examples:
+- `edit-bookmark 1 t/Monthly Tuition c/Work c/Part Time`
+edits the first bookmark income in the bookmark income list to have a title of `Monthly Tuition` and
+two categories `Work` and `Part Time`.
+- `edit-bookmark 2 a/1200`
+edits the second bookmark income in the bookmark income list to have an amount of `$1200.00`.
+- `edit-bookmark 3 t/Investments a/$300.00`
+edits the third bookmark income in the bookmark income list to have a title of `Investments` and an amount of `$300.00`.
 
-**Example Usage**:
-```$xslt
-edit-bookmark-income 2 a/1200
+Example Usage:
+```
+edit-bookmark 2 a/1200
 ```
 
-Edits the amount of the second bookmark income in the bookmark income list to `1200`.
-
-**Expected Outcome**:
-```$xslt
+Expected Outcome:
+```
 Edited Bookmark Income: Internship Amount: $1200.00 Categories: [Work][Summer]
 ```
 
-#### 4.6.3 Delete Bookmark Income: `delete-bookmark-income`
+#### 4.6.3 Delete Bookmark Income
 
 Deletes the bookmark income and all of its information from the bookmark income list in Fine$$e.
 
-**Format**:
-```$xslt
-delete-bookmark-income INDEX
+Format: (when on the [Incomes tab](#212-incomes-tab)) `delete-bookmark INDEX`
+
+* `INDEX` allows you to choose which bookmark income to delete by specifying its position in the bookmark income list.
+
+Example:
+- `delete-bookmark 2`
+deletes the bookmark income at index 2 in the bookmark income list.
+
+Example Usage:
+```
+delete-bookmark 2
 ```
 
-- Deletes the bookmark income at the specified INDEX in the bookmark income list.
-- `INDEX` refers to the index number of the bookmark income shown in the bookmark income list.
-- The index has to be a positive integer and **cannot be empty**.
-
-**Examples**:
-- `delete-bookmark-income 2`
-
-Deletes the bookmark income income at index 2 in the bookmark income list.
-
-**Example Usage**
-```$xslt
-delete-bookmark-income 2`
+Expected Outcome:
 ```
-
-**Expected Outcome**:
-```$xslt
 Deleted Bookmark Income: Internship Amount: $1200.00 Categories: [Work][Summer]
 ```
 
-#### 4.6.4 Convert Bookmark Income: `convert-bookmark-income`
+#### 4.6.4 Convert Bookmark Income
 
 Converts a bookmark income with the date it has been converted on and adds it to the income list in Fine$$e.
 
-**Format**:
-```$xslt
-convert-bookmark-income INDEX d/DATE
+Format: (when on the [Incomes tab](#212-incomes-tab)) `convert-bookmark INDEX d/DATE`
+
+- The `INDEX` refers to the index number of the bookmark expense shown in the bookmark expense list.
+- The `DATE` should be in `dd/mm/yyyy` format, and cannot be later than the current date.
+
+Shortcut: (when on the [Incomes tab](#212-incomes-tab)) `convertb INDEX d/DATE`
+
+Examples:
+- `convert-bookmark 1 d/10/10/2020`
+converts the bookmark income at index 1 in the bookmark list into an income with the information of the
+specified bookmark income and date `10/10/2020`.
+- `convertb 2 d/15/10/2020`
+converts the bookmark income at index 2 in the bookmark list into an income with the information of the
+specified bookmark income and date `15/10/2020`.
+
+Example Usage:
+```
+convert-bookmark 1 d/10/10/2020
 ```
 
-**Shortcut**:
-```$xslt
-convertbi INDEX d/DATE
+Expected Outcome:
 ```
-
-- Converts the bookmark income at the specified `INDEX` into an `INCOME`, using the `DATE` it has been converted on, and adds it to the income list in Fine$$e.
-- The `INDEX` and `d/DATE` **cannot be empty**.
-- The `DATE` should be in dd/mm/yyyy and it cannot be later than the current date.
-- The `INDEX` refers to the index number of the bookmark income shown in the bookmark income list.
-- The index has to be a positive integer.
-
-**Examples**:
-- `convert-bookmark-income 2 d/10/10/2020`
-- `convertbi 2 d/15/10/2020`
-
-**Example Usage**:
-- `convert-bookmark-income 1 d/10/10/2020`
-
-Converts the bookmark income at index 1 in the bookmark list into an income with the information of the specified bookmark income and inputted date.
-
-**Expected Outcome**:
-```$xslt
 Bookmark income has been converted and successfully added to finance tracker: Teaching Assistant Amount: $1890.00 Date: 10/10/2020 Categories: [CS1231S][CS1101S]
 ```
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/ConvertBookmarkCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/ConvertBookmarkCommand.java
@@ -1,0 +1,8 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark;
+
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.Command;
+
+public abstract class ConvertBookmarkCommand extends Command {
+    public static final String COMMAND_WORD = "convert-bookmark";
+    public static final String COMMAND_ALIAS = "convertb";
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/ConvertBookmarkExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/ConvertBookmarkExpenseCommand.java
@@ -7,7 +7,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
-import ay2021s1_cs2103_w16_3.finesse.logic.commands.Command;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
@@ -18,10 +17,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
 /**
  * Converts a specified bookmark expense and adds it as an expense to the finance tracker.
  */
-public class ConvertBookmarkExpenseCommand extends Command {
-    public static final String COMMAND_WORD = "convert-bookmark-expense";
-    public static final String COMMAND_ALIAS = "convertbe";
-
+public class ConvertBookmarkExpenseCommand extends ConvertBookmarkCommand {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Converts the specified bookmark expense and adds"
             + " it as an expense to the finance tracker.\n"
             + "Parameters: INDEX (must be a positive integer) "

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/ConvertBookmarkIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/ConvertBookmarkIncomeCommand.java
@@ -7,7 +7,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
-import ay2021s1_cs2103_w16_3.finesse.logic.commands.Command;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
@@ -18,10 +17,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 /**
  * Converts a specified bookmark income and adds it as an income to the finance tracker.
  */
-public class ConvertBookmarkIncomeCommand extends Command {
-    public static final String COMMAND_WORD = "convert-bookmark-income";
-    public static final String COMMAND_ALIAS = "convertbi";
-
+public class ConvertBookmarkIncomeCommand extends ConvertBookmarkCommand {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Converts the specified bookmark income and adds"
             + " it as an income to the finance tracker.\n"
             + "Parameters: INDEX (must be a positive integer) "

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/DeleteBookmarkCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/DeleteBookmarkCommand.java
@@ -1,0 +1,7 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark;
+
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.Command;
+
+public abstract class DeleteBookmarkCommand extends Command {
+    public static final String COMMAND_WORD = "delete-bookmark";
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/DeleteBookmarkExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/DeleteBookmarkExpenseCommand.java
@@ -6,7 +6,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
-import ay2021s1_cs2103_w16_3.finesse.logic.commands.Command;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
@@ -15,9 +14,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkExpense;
 /**
  * Deletes a bookmark expense identified using its displayed index from the finance tracker.
  */
-public class DeleteBookmarkExpenseCommand extends Command {
-    public static final String COMMAND_WORD = "delete-bookmark-expense";
-
+public class DeleteBookmarkExpenseCommand extends DeleteBookmarkCommand {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the bookmark expense identified by the index number used in the displayed "
             + "bookmark expense list. \n"

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/DeleteBookmarkIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/DeleteBookmarkIncomeCommand.java
@@ -6,7 +6,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
-import ay2021s1_cs2103_w16_3.finesse.logic.commands.Command;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
@@ -15,9 +14,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkIncome;
 /**
  * Deletes a bookmark income identified using its displayed index from the finance tracker.
  */
-public class DeleteBookmarkIncomeCommand extends Command {
-    public static final String COMMAND_WORD = "delete-bookmark-income";
-
+public class DeleteBookmarkIncomeCommand extends DeleteBookmarkCommand {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the bookmark income identified by the index number used in the displayed "
             + "bookmark income list. \n"

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/EditBookmarkCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/EditBookmarkCommand.java
@@ -1,0 +1,7 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark;
+
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.Command;
+
+public abstract class EditBookmarkCommand extends Command {
+    public static final String COMMAND_WORD = "edit-bookmark";
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/EditBookmarkExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/EditBookmarkExpenseCommand.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Set;
 
 import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
-import ay2021s1_cs2103_w16_3.finesse.logic.commands.Command;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
@@ -24,9 +23,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
  * Edits the details of an existing bookmark expense using its displayed index from the bookmark expense list
  * in the expense tab.
  */
-public class EditBookmarkExpenseCommand extends Command {
-    public static final String COMMAND_WORD = "edit-bookmark-expense";
-
+public class EditBookmarkExpenseCommand extends EditBookmarkCommand {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the bookmark expense identified "
             + "by the index number used in the displayed bookmark expense list on the expense tab. "
             + "Existing values will be overwritten by the input values.\n"

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/EditBookmarkIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/EditBookmarkIncomeCommand.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Set;
 
 import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
-import ay2021s1_cs2103_w16_3.finesse.logic.commands.Command;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
@@ -24,10 +23,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
  * Edits the details of an existing bookmark income using its displayed index from the bookmark income list
  * in the income tab.
  */
-public class EditBookmarkIncomeCommand extends Command {
-
-    public static final String COMMAND_WORD = "edit-bookmark-income";
-
+public class EditBookmarkIncomeCommand extends EditBookmarkCommand {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the bookmark income identified "
             + "by the index number used in the displayed bookmark income list on the income tab. "
             + "Existing values will be overwritten by the input values.\n"

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
@@ -134,10 +134,22 @@ public class FinanceTrackerParser {
             }
 
         case EditBookmarkExpenseCommand.COMMAND_WORD:
-            return new EditBookmarkExpenseCommandParser().parse(arguments);
+            switch (uiCurrentTab) {
+            case EXPENSES:
+                return new EditBookmarkExpenseCommandParser().parse(arguments);
+            default:
+                throw new ParseException(commandInvalidTabMessage(commandWord,
+                        Tab.EXPENSES));
+            }
 
         case EditBookmarkIncomeCommand.COMMAND_WORD:
-            return new EditBookmarkIncomeCommandParser().parse(arguments);
+            switch (uiCurrentTab) {
+            case INCOME:
+                return new EditBookmarkIncomeCommandParser().parse(arguments);
+            default:
+                throw new ParseException(commandInvalidTabMessage(commandWord,
+                        Tab.INCOME));
+            }
 
         case DeleteCommand.COMMAND_WORD:
             switch (uiCurrentTab) {
@@ -151,10 +163,22 @@ public class FinanceTrackerParser {
             }
 
         case DeleteBookmarkExpenseCommand.COMMAND_WORD:
-            return new DeleteBookmarkExpenseCommandParser().parse(arguments);
+            switch (uiCurrentTab) {
+            case EXPENSES:
+                return new DeleteBookmarkExpenseCommandParser().parse(arguments);
+            default:
+                throw new ParseException(commandInvalidTabMessage(commandWord,
+                        Tab.EXPENSES));
+            }
 
         case DeleteBookmarkIncomeCommand.COMMAND_WORD:
-            return new DeleteBookmarkIncomeCommandParser().parse(arguments);
+            switch (uiCurrentTab) {
+            case INCOME:
+                return new DeleteBookmarkIncomeCommandParser().parse(arguments);
+            default:
+                throw new ParseException(commandInvalidTabMessage(commandWord,
+                        Tab.INCOME));
+            }
 
         case ConvertBookmarkExpenseCommand.COMMAND_WORD:
         case ConvertBookmarkExpenseCommand.COMMAND_ALIAS:

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
@@ -34,12 +34,9 @@ import ay2021s1_cs2103_w16_3.finesse.logic.commands.ListTransactionCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.TabCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.AddBookmarkExpenseCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.AddBookmarkIncomeCommand;
-import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.ConvertBookmarkExpenseCommand;
-import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.ConvertBookmarkIncomeCommand;
-import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.DeleteBookmarkExpenseCommand;
-import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.DeleteBookmarkIncomeCommand;
-import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.EditBookmarkExpenseCommand;
-import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.EditBookmarkIncomeCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.ConvertBookmarkCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.DeleteBookmarkCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.EditBookmarkCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.budget.SetExpenseLimitCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.budget.SetSavingsGoalCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.bookmarkparsers.AddBookmarkExpenseCommandParser;
@@ -133,22 +130,15 @@ public class FinanceTrackerParser {
                         Tab.EXPENSES, Tab.INCOME));
             }
 
-        case EditBookmarkExpenseCommand.COMMAND_WORD:
+        case EditBookmarkCommand.COMMAND_WORD:
             switch (uiCurrentTab) {
             case EXPENSES:
                 return new EditBookmarkExpenseCommandParser().parse(arguments);
-            default:
-                throw new ParseException(commandInvalidTabMessage(commandWord,
-                        Tab.EXPENSES));
-            }
-
-        case EditBookmarkIncomeCommand.COMMAND_WORD:
-            switch (uiCurrentTab) {
             case INCOME:
                 return new EditBookmarkIncomeCommandParser().parse(arguments);
             default:
                 throw new ParseException(commandInvalidTabMessage(commandWord,
-                        Tab.INCOME));
+                        Tab.EXPENSES, Tab.INCOME));
             }
 
         case DeleteCommand.COMMAND_WORD:
@@ -162,31 +152,28 @@ public class FinanceTrackerParser {
                         Tab.EXPENSES, Tab.INCOME));
             }
 
-        case DeleteBookmarkExpenseCommand.COMMAND_WORD:
+        case DeleteBookmarkCommand.COMMAND_WORD:
             switch (uiCurrentTab) {
             case EXPENSES:
                 return new DeleteBookmarkExpenseCommandParser().parse(arguments);
-            default:
-                throw new ParseException(commandInvalidTabMessage(commandWord,
-                        Tab.EXPENSES));
-            }
-
-        case DeleteBookmarkIncomeCommand.COMMAND_WORD:
-            switch (uiCurrentTab) {
             case INCOME:
                 return new DeleteBookmarkIncomeCommandParser().parse(arguments);
             default:
                 throw new ParseException(commandInvalidTabMessage(commandWord,
-                        Tab.INCOME));
+                        Tab.EXPENSES, Tab.INCOME));
             }
 
-        case ConvertBookmarkExpenseCommand.COMMAND_WORD:
-        case ConvertBookmarkExpenseCommand.COMMAND_ALIAS:
-            return new ConvertBookmarkExpenseCommandParser().parse(arguments);
-
-        case ConvertBookmarkIncomeCommand.COMMAND_WORD:
-        case ConvertBookmarkIncomeCommand.COMMAND_ALIAS:
-            return new ConvertBookmarkIncomeCommandParser().parse(arguments);
+        case ConvertBookmarkCommand.COMMAND_WORD:
+        case ConvertBookmarkCommand.COMMAND_ALIAS:
+            switch (uiCurrentTab) {
+            case EXPENSES:
+                return new ConvertBookmarkExpenseCommandParser().parse(arguments);
+            case INCOME:
+                return new ConvertBookmarkIncomeCommandParser().parse(arguments);
+            default:
+                throw new ParseException(commandInvalidTabMessage(commandWord,
+                        Tab.EXPENSES, Tab.INCOME));
+            }
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();


### PR DESCRIPTION
Resolves #167 

Editing/Deleting/Converting bookmark expenses/incomes have been changed to use a generic command based on the current tab.

Adding bookmark expenses/incomes remain unchanged.

User guide has been updated to reflect the new behavior and also be more consistent with the other sections (although there is probably still room to improve)

Outstanding tasks: ~~Update user guide to reflect the new commands (hopefully within this PR)~~ (done), test coverage (possibly pushed to v1.4)