### PR TITLE
Add amount prefix to set expense limit/savings goal commands

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budgetparsers/SetExpenseLimitCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budgetparsers/SetExpenseLimitCommandParser.java
@@ -1,8 +1,11 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.parser.budgetparsers;
 
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT;
 
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.budget.SetExpenseLimitCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.parser.ArgumentMultimap;
+import ay2021s1_cs2103_w16_3.finesse.logic.parser.ArgumentTokenizer;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.Parser;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.ParserUtil;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
@@ -19,13 +22,14 @@ public class SetExpenseLimitCommandParser implements Parser<SetExpenseLimitComma
      * @throws ParseException if the user input does not conform the expected format
      */
     public SetExpenseLimitCommand parse(String args) throws ParseException {
-        try {
-            Amount amount = ParserUtil.parseAmount(args);
-            return new SetExpenseLimitCommand(amount);
-        } catch (ParseException pe) {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_AMOUNT);
+        if (!argMultimap.arePrefixesPresent(PREFIX_AMOUNT)
+                || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetExpenseLimitCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetExpenseLimitCommand.MESSAGE_USAGE));
         }
+        Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
+        return new SetExpenseLimitCommand(amount);
     }
 
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budgetparsers/SetSavingsGoalCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budgetparsers/SetSavingsGoalCommandParser.java
@@ -1,8 +1,11 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.parser.budgetparsers;
 
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT;
 
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.budget.SetSavingsGoalCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.parser.ArgumentMultimap;
+import ay2021s1_cs2103_w16_3.finesse.logic.parser.ArgumentTokenizer;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.Parser;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.ParserUtil;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
@@ -19,13 +22,14 @@ public class SetSavingsGoalCommandParser implements Parser<SetSavingsGoalCommand
      * @throws ParseException if the user input does not conform the expected format
      */
     public SetSavingsGoalCommand parse(String args) throws ParseException {
-        try {
-            Amount amount = ParserUtil.parseAmount(args);
-            return new SetSavingsGoalCommand(amount);
-        } catch (ParseException pe) {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_AMOUNT);
+        if (!argMultimap.arePrefixesPresent(PREFIX_AMOUNT)
+                || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetSavingsGoalCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetSavingsGoalCommand.MESSAGE_USAGE));
         }
+        Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
+        return new SetSavingsGoalCommand(amount);
     }
 
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budget/SetExpenseLimitCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budget/SetExpenseLimitCommandParserTest.java
@@ -1,6 +1,9 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.parser.budget;
 
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUNT_DESC_INTERNSHIP;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_AMOUNT_INTERNSHIP;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -22,18 +25,21 @@ public class SetExpenseLimitCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a/20", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                SetExpenseLimitCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "hello a/-5", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                SetExpenseLimitCommand.MESSAGE_USAGE));
+        // no whitespace in front
+        assertParseFailure(parser, PREFIX_AMOUNT + VALID_AMOUNT_INTERNSHIP,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetExpenseLimitCommand.MESSAGE_USAGE));
+        // preamble before amount prefix
+        assertParseFailure(parser, "hello" + AMOUNT_DESC_INTERNSHIP,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetExpenseLimitCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_validArgs_returnsSetExpenseLimitCommand() {
-        assertParseSuccess(parser, " a/500", new SetExpenseLimitCommand(new Amount("500")));
-        assertParseSuccess(parser, " a/314.15", new SetExpenseLimitCommand(new Amount("314.15")));
-        assertParseSuccess(parser, " a/$300", new SetExpenseLimitCommand(new Amount("$300")));
-        assertParseSuccess(parser, " a/$123.45", new SetExpenseLimitCommand(new Amount("$123.45")));
+        assertParseSuccess(parser, AMOUNT_DESC_INTERNSHIP,
+                new SetExpenseLimitCommand(new Amount(VALID_AMOUNT_INTERNSHIP)));
+        // whitespaces before/after keywords
+        assertParseSuccess(parser, "   " + AMOUNT_DESC_INTERNSHIP + "   ",
+                new SetExpenseLimitCommand(new Amount(VALID_AMOUNT_INTERNSHIP)));
     }
 
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budget/SetExpenseLimitCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budget/SetExpenseLimitCommandParserTest.java
@@ -22,26 +22,18 @@ public class SetExpenseLimitCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseFailure(parser, "a/20", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 SetExpenseLimitCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "-5", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                SetExpenseLimitCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "$", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                SetExpenseLimitCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "123.4", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                SetExpenseLimitCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "567.890", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                SetExpenseLimitCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "2 hello", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseFailure(parser, "hello a/-5", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 SetExpenseLimitCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_validArgs_returnsSetExpenseLimitCommand() {
-        assertParseSuccess(parser, "500", new SetExpenseLimitCommand(new Amount("500")));
-        assertParseSuccess(parser, "314.15", new SetExpenseLimitCommand(new Amount("314.15")));
-        assertParseSuccess(parser, "$300", new SetExpenseLimitCommand(new Amount("$300")));
-        assertParseSuccess(parser, "$123.45", new SetExpenseLimitCommand(new Amount("$123.45")));
+        assertParseSuccess(parser, " a/500", new SetExpenseLimitCommand(new Amount("500")));
+        assertParseSuccess(parser, " a/314.15", new SetExpenseLimitCommand(new Amount("314.15")));
+        assertParseSuccess(parser, " a/$300", new SetExpenseLimitCommand(new Amount("$300")));
+        assertParseSuccess(parser, " a/$123.45", new SetExpenseLimitCommand(new Amount("$123.45")));
     }
 
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budget/SetExpenseLimitCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budget/SetExpenseLimitCommandParserTest.java
@@ -2,6 +2,8 @@ package ay2021s1_cs2103_w16_3.finesse.logic.parser.budget;
 
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUNT_DESC_INTERNSHIP;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_AMOUNT_INTERNSHIP;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -19,7 +21,7 @@ public class SetExpenseLimitCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseFailure(parser, PREAMBLE_WHITESPACE, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 SetExpenseLimitCommand.MESSAGE_USAGE));
     }
 
@@ -29,7 +31,7 @@ public class SetExpenseLimitCommandParserTest {
         assertParseFailure(parser, PREFIX_AMOUNT + VALID_AMOUNT_INTERNSHIP,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetExpenseLimitCommand.MESSAGE_USAGE));
         // preamble before amount prefix
-        assertParseFailure(parser, "hello" + AMOUNT_DESC_INTERNSHIP,
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + AMOUNT_DESC_INTERNSHIP,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetExpenseLimitCommand.MESSAGE_USAGE));
     }
 
@@ -38,7 +40,7 @@ public class SetExpenseLimitCommandParserTest {
         assertParseSuccess(parser, AMOUNT_DESC_INTERNSHIP,
                 new SetExpenseLimitCommand(new Amount(VALID_AMOUNT_INTERNSHIP)));
         // whitespaces before/after keywords
-        assertParseSuccess(parser, "   " + AMOUNT_DESC_INTERNSHIP + "   ",
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + AMOUNT_DESC_INTERNSHIP + PREAMBLE_WHITESPACE,
                 new SetExpenseLimitCommand(new Amount(VALID_AMOUNT_INTERNSHIP)));
     }
 

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budget/SetSavingsGoalCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budget/SetSavingsGoalCommandParserTest.java
@@ -22,26 +22,18 @@ public class SetSavingsGoalCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseFailure(parser, "a/20", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 SetSavingsGoalCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "-5", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                SetSavingsGoalCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "$", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                SetSavingsGoalCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "123.4", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                SetSavingsGoalCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "567.890", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                SetSavingsGoalCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "2 hello", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseFailure(parser, "hello a/-5", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 SetSavingsGoalCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_validArgs_returnsSetSavingsGoalCommand() {
-        assertParseSuccess(parser, "500", new SetSavingsGoalCommand(new Amount("500")));
-        assertParseSuccess(parser, "314.15", new SetSavingsGoalCommand(new Amount("314.15")));
-        assertParseSuccess(parser, "$300", new SetSavingsGoalCommand(new Amount("$300")));
-        assertParseSuccess(parser, "$123.45", new SetSavingsGoalCommand(new Amount("$123.45")));
+        assertParseSuccess(parser, " a/500", new SetSavingsGoalCommand(new Amount("500")));
+        assertParseSuccess(parser, " a/314.15", new SetSavingsGoalCommand(new Amount("314.15")));
+        assertParseSuccess(parser, " a/$300", new SetSavingsGoalCommand(new Amount("$300")));
+        assertParseSuccess(parser, " a/$123.45", new SetSavingsGoalCommand(new Amount("$123.45")));
     }
 
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budget/SetSavingsGoalCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budget/SetSavingsGoalCommandParserTest.java
@@ -2,6 +2,8 @@ package ay2021s1_cs2103_w16_3.finesse.logic.parser.budget;
 
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUNT_DESC_INTERNSHIP;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_AMOUNT_INTERNSHIP;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -19,7 +21,7 @@ public class SetSavingsGoalCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseFailure(parser, PREAMBLE_WHITESPACE, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 SetSavingsGoalCommand.MESSAGE_USAGE));
     }
 
@@ -29,7 +31,7 @@ public class SetSavingsGoalCommandParserTest {
         assertParseFailure(parser, PREFIX_AMOUNT + VALID_AMOUNT_INTERNSHIP,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetSavingsGoalCommand.MESSAGE_USAGE));
         // preamble before amount prefix
-        assertParseFailure(parser, "hello" + AMOUNT_DESC_INTERNSHIP,
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + AMOUNT_DESC_INTERNSHIP,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetSavingsGoalCommand.MESSAGE_USAGE));
     }
 
@@ -38,7 +40,7 @@ public class SetSavingsGoalCommandParserTest {
         assertParseSuccess(parser, AMOUNT_DESC_INTERNSHIP,
                 new SetSavingsGoalCommand(new Amount(VALID_AMOUNT_INTERNSHIP)));
         // whitespaces before/after keywords
-        assertParseSuccess(parser, "   " + AMOUNT_DESC_INTERNSHIP + "   ",
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + AMOUNT_DESC_INTERNSHIP + PREAMBLE_WHITESPACE,
                 new SetSavingsGoalCommand(new Amount(VALID_AMOUNT_INTERNSHIP)));
     }
 

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budget/SetSavingsGoalCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budget/SetSavingsGoalCommandParserTest.java
@@ -1,6 +1,9 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.parser.budget;
 
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUNT_DESC_INTERNSHIP;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_AMOUNT_INTERNSHIP;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -22,18 +25,21 @@ public class SetSavingsGoalCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a/20", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                SetSavingsGoalCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "hello a/-5", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                SetSavingsGoalCommand.MESSAGE_USAGE));
+        // no whitespace in front
+        assertParseFailure(parser, PREFIX_AMOUNT + VALID_AMOUNT_INTERNSHIP,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetSavingsGoalCommand.MESSAGE_USAGE));
+        // preamble before amount prefix
+        assertParseFailure(parser, "hello" + AMOUNT_DESC_INTERNSHIP,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetSavingsGoalCommand.MESSAGE_USAGE));
     }
 
     @Test
-    public void parse_validArgs_returnsSetSavingsGoalCommand() {
-        assertParseSuccess(parser, " a/500", new SetSavingsGoalCommand(new Amount("500")));
-        assertParseSuccess(parser, " a/314.15", new SetSavingsGoalCommand(new Amount("314.15")));
-        assertParseSuccess(parser, " a/$300", new SetSavingsGoalCommand(new Amount("$300")));
-        assertParseSuccess(parser, " a/$123.45", new SetSavingsGoalCommand(new Amount("$123.45")));
+    public void parse_validArgs_returnsSetExpenseLimitCommand() {
+        assertParseSuccess(parser, AMOUNT_DESC_INTERNSHIP,
+                new SetSavingsGoalCommand(new Amount(VALID_AMOUNT_INTERNSHIP)));
+        // whitespaces before/after keywords
+        assertParseSuccess(parser, "   " + AMOUNT_DESC_INTERNSHIP + "   ",
+                new SetSavingsGoalCommand(new Amount(VALID_AMOUNT_INTERNSHIP)));
     }
 
 }


### PR DESCRIPTION
Resolves #185.

Adds the "a/" prefix to the set expense limit and set savings goal command for consistency with the other commands.