### PR TITLE
Add user guide to application

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,12 @@ dependencies {
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'win'
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'mac'
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'linux'
+    implementation group: 'org.openjfx', name: 'javafx-media', version: javaFxVersion, classifier: 'win'
+    implementation group: 'org.openjfx', name: 'javafx-media', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-media', version: javaFxVersion, classifier: 'linux'
+    implementation group: 'org.openjfx', name: 'javafx-web', version: javaFxVersion, classifier: 'win'
+    implementation group: 'org.openjfx', name: 'javafx-web', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-web', version: javaFxVersion, classifier: 'linux'
 
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.0'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
@@ -21,6 +21,7 @@ import javafx.scene.control.Button;
 import javafx.scene.control.SelectionModel;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
+import javafx.scene.control.ToggleButton;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.StackPane;
 import javafx.scene.text.Text;
@@ -68,7 +69,7 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     private Tab userGuideTab;
     @FXML
-    private Button userGuideButton;
+    private ToggleButton userGuideButton;
     @FXML
     private TabPane tabPane;
     @FXML
@@ -153,6 +154,9 @@ public class MainWindow extends UiPart<Stage> {
 
             // Disable the user guide tab when not selected to prevent the user from clicking the invisible tab.
             userGuideTab.setDisable(newTabIndex.intValue() != UiState.Tab.USER_GUIDE.getTabIndex().getZeroBased());
+
+            // Set the user guide button to be unselected.
+            userGuideButton.setSelected(false);
         });
     }
 
@@ -209,11 +213,12 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
-     * Switches to the hidden user guide tab.
+     * Switches to the hidden user guide tab and sets the user guide button to be selected.
      */
     @FXML
     public void switchToUserGuideTab() {
         tabPane.getSelectionModel().select(userGuideTab);
+        userGuideButton.setSelected(true);
     }
 
     void show() {

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
@@ -147,9 +147,13 @@ public class MainWindow extends UiPart<Stage> {
         // Set the bottom anchor after the tabs have been initialized.
         AnchorPane.setBottomAnchor(tabPane, 0.0);
 
-        // Update UI state on tab change.
-        tabPane.getSelectionModel().selectedIndexProperty().addListener((observable, oldTabIndex, newTabIndex) ->
-                uiState.setCurrentTab(UiState.Tab.values()[newTabIndex.intValue()]));
+        tabPane.getSelectionModel().selectedIndexProperty().addListener((observable, oldTabIndex, newTabIndex) -> {
+            // Update UI state on tab change.
+            uiState.setCurrentTab(UiState.Tab.values()[newTabIndex.intValue()]);
+
+            // Disable the user guide tab when not selected to prevent the user from clicking the invisible tab.
+            userGuideTab.setDisable(newTabIndex.intValue() != UiState.Tab.USER_GUIDE.getTabIndex().getZeroBased());
+        });
     }
 
     /**

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
@@ -15,6 +15,7 @@ import ay2021s1_cs2103_w16_3.finesse.ui.tabs.AnalyticsTabPane;
 import ay2021s1_cs2103_w16_3.finesse.ui.tabs.ExpenseTabPane;
 import ay2021s1_cs2103_w16_3.finesse.ui.tabs.IncomeTabPane;
 import ay2021s1_cs2103_w16_3.finesse.ui.tabs.OverviewTabPane;
+import ay2021s1_cs2103_w16_3.finesse.ui.tabs.UserGuideTabPane;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.SelectionModel;
@@ -53,8 +54,6 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     private Button commandBoxButton;
     @FXML
-    private Button helpButton;
-    @FXML
     private StackPane resultDisplayPlaceholder;
     @FXML
     private StackPane statusbarPlaceholder;
@@ -66,6 +65,10 @@ public class MainWindow extends UiPart<Stage> {
     private Tab expenseTab;
     @FXML
     private Tab analyticsTab;
+    @FXML
+    private Tab userGuideTab;
+    @FXML
+    private Button userGuideButton;
     @FXML
     private TabPane tabPane;
     @FXML
@@ -118,6 +121,7 @@ public class MainWindow extends UiPart<Stage> {
      * Initialize the contents of each tab.
      */
     public void initializeTabs() {
+        // Set up tab contents.
         OverviewTabPane overviewTabPane =
                 new OverviewTabPane(logic.getFilteredTransactionList(), logic.getMonthlyBudget());
         overviewTab.setContent(overviewTabPane.getRoot());
@@ -133,6 +137,10 @@ public class MainWindow extends UiPart<Stage> {
         AnalyticsTabPane analyticsTabPane = new AnalyticsTabPane(logic.getMonthlyBudget());
         analyticsTab.setContent(analyticsTabPane.getRoot());
 
+        UserGuideTabPane userGuideTabPane = new UserGuideTabPane();
+        userGuideTab.setContent(userGuideTabPane.getRoot());
+
+        // Set default selection.
         SelectionModel<Tab> selectionModel = tabPane.getSelectionModel();
         selectionModel.select(overviewTab);
 
@@ -197,11 +205,11 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
-     * Displays the help message in the result display.
+     * Switches to the hidden user guide tab.
      */
     @FXML
-    public void handleHelp() {
-        resultDisplay.setFeedbackToUser(HELP_MESSAGE);
+    public void switchToUserGuideTab() {
+        tabPane.getSelectionModel().select(userGuideTab);
     }
 
     void show() {
@@ -231,7 +239,7 @@ public class MainWindow extends UiPart<Stage> {
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 
             if (commandResult.isShowHelp()) {
-                handleHelp();
+                switchToUserGuideTab();
             }
 
             if (commandResult.isExit()) {

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
@@ -37,9 +37,6 @@ public class MainWindow extends UiPart<Stage> {
 
     private static final String WELCOME_MESSAGE = "Welcome to Fine$$e - your personal finance tracker."
             + "\nPlease enter the command \"help\" to view the user guide on the various commands you can use.";
-    private static final String USERGUIDE_URL = "https://ay2021s1-cs2103t-w16-3.github.io/tp/UserGuide.html";
-    private static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL + "."
-            + "\nPlease copy the url and paste it in your favourite browser to view all valid commands.";
 
     private final Logger logger = LogsCenter.getLogger(getClass());
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/UiState.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/UiState.java
@@ -15,7 +15,8 @@ public class UiState {
         OVERVIEW(1),
         INCOME(2),
         EXPENSES(3),
-        ANALYTICS(4);
+        ANALYTICS(4),
+        USER_GUIDE(5);
 
         /** The index of the tab in the {@code TabPane}. */
         private final Index tabIndex;

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/UserGuideTabPane.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/UserGuideTabPane.java
@@ -1,0 +1,29 @@
+package ay2021s1_cs2103_w16_3.finesse.ui.tabs;
+
+import ay2021s1_cs2103_w16_3.finesse.ui.UiPart;
+import javafx.fxml.FXML;
+import javafx.scene.layout.StackPane;
+import javafx.scene.web.WebView;
+
+/**
+ * Tab pane that displays the user guide.
+ */
+public class UserGuideTabPane extends UiPart<StackPane> {
+    private static final String FXML = "UserGuideTabPane.fxml";
+    private static final String USER_GUIDE_URL = "https://ay2021s1-cs2103t-w16-3.github.io/tp/UserGuide.html";
+
+    @FXML
+    private WebView webView;
+
+    /**
+     * Constructs a {@code UserGuideTabPane}.
+     */
+    public UserGuideTabPane() {
+        super(FXML);
+        initialiseUserGuide();
+    }
+
+    private void initialiseUserGuide() {
+        webView.getEngine().load(USER_GUIDE_URL);
+    }
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/UserGuideTabPane.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/UserGuideTabPane.java
@@ -49,6 +49,9 @@ public class UserGuideTabPane extends UiPart<StackPane> {
      * Initializes the {@code WebEngine} that is backing the {@code WebView}.
      */
     private void initializeUserGuide() {
+        // Disable right click.
+        webView.setContextMenuEnabled(false);
+
         WebEngine webEngine = webView.getEngine();
 
         webEngine.locationProperty().addListener((observableValue, oldUrl, newUrl) -> {

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/UserGuideTabPane.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/UserGuideTabPane.java
@@ -1,8 +1,10 @@
 package ay2021s1_cs2103_w16_3.finesse.ui.tabs;
 
 import ay2021s1_cs2103_w16_3.finesse.ui.UiPart;
+import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.scene.layout.StackPane;
+import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
 
 /**
@@ -10,7 +12,10 @@ import javafx.scene.web.WebView;
  */
 public class UserGuideTabPane extends UiPart<StackPane> {
     private static final String FXML = "UserGuideTabPane.fxml";
+
+    private static final String GITHUB_PAGES_DOMAIN = "https://ay2021s1-cs2103t-w16-3.github.io";
     private static final String USER_GUIDE_URL = "https://ay2021s1-cs2103t-w16-3.github.io/tp/UserGuide.html";
+    private static final String ERROR_PAGE_URL = "https://ay2021s1-cs2103t-w16-3.github.io";
 
     @FXML
     private WebView webView;
@@ -20,10 +25,25 @@ public class UserGuideTabPane extends UiPart<StackPane> {
      */
     public UserGuideTabPane() {
         super(FXML);
-        initialiseUserGuide();
+        initializeUserGuide();
     }
 
-    private void initialiseUserGuide() {
-        webView.getEngine().load(USER_GUIDE_URL);
+    /**
+     * Initializes the {@code WebEngine} that is backing the {@code WebView}.
+     */
+    private void initializeUserGuide() {
+        WebEngine webEngine = webView.getEngine();
+
+        webEngine.locationProperty().addListener((observableValue, oldUrl, newUrl) -> {
+            if (!newUrl.contains(GITHUB_PAGES_DOMAIN)) {
+                // Block requests to external sites.
+                Platform.runLater(() -> {
+                    // Load the error page.
+                    webEngine.load(ERROR_PAGE_URL);
+                });
+            }
+        });
+
+        webEngine.load(USER_GUIDE_URL);
     }
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/UserGuideTabPane.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/UserGuideTabPane.java
@@ -1,5 +1,8 @@
 package ay2021s1_cs2103_w16_3.finesse.ui.tabs;
 
+import java.util.logging.Logger;
+
+import ay2021s1_cs2103_w16_3.finesse.commons.core.LogsCenter;
 import ay2021s1_cs2103_w16_3.finesse.ui.UiPart;
 import javafx.application.Platform;
 import javafx.fxml.FXML;
@@ -13,11 +16,23 @@ import javafx.scene.web.WebView;
 public class UserGuideTabPane extends UiPart<StackPane> {
     private static final String FXML = "UserGuideTabPane.fxml";
 
+    // Links
     private static final String GITHUB_PAGES_DOMAIN = "https://ay2021s1-cs2103t-w16-3.github.io";
     private static final String USER_GUIDE_URL = "https://ay2021s1-cs2103t-w16-3.github.io/tp/UserGuide.html";
     // Note: Does not work if '.html' is appended for some reason.
     private static final String NO_EXTERNAL_SITE_PAGE_URL =
             "https://ay2021s1-cs2103t-w16-3.github.io/tp/NoExternalSite";
+
+    // Logging messages
+    private static final String WEB_ENGINE_EXTERNAL_SITE_REQUEST_BLOCKED =
+            "Request to load page on external site blocked";
+    private static final String WEB_ENGINE_WORKER_STATE_CANCELLED = "Page load cancelled: ";
+    private static final String WEB_ENGINE_WORKER_STATE_FAILED = "Unable to load page (no internet connection): ";
+    private static final String WEB_ENGINE_WORKER_STATE_RUNNING = "Loading page: ";
+    private static final String WEB_ENGINE_WORKER_STATE_SCHEDULED = "Page load scheduled: ";
+    private static final String WEB_ENGINE_WORKER_STATE_SUCCEEDED = "Page successfully loaded: ";
+
+    private final Logger logger = LogsCenter.getLogger(getClass());
 
     @FXML
     private WebView webView;
@@ -38,11 +53,35 @@ public class UserGuideTabPane extends UiPart<StackPane> {
 
         webEngine.locationProperty().addListener((observableValue, oldUrl, newUrl) -> {
             if (!newUrl.startsWith(GITHUB_PAGES_DOMAIN)) {
+                logger.info(WEB_ENGINE_EXTERNAL_SITE_REQUEST_BLOCKED);
+
                 // Block requests to external sites.
                 Platform.runLater(() -> {
                     // Load the 'No External Site' page.
                     webEngine.load(NO_EXTERNAL_SITE_PAGE_URL);
                 });
+            }
+        });
+
+        webEngine.getLoadWorker().stateProperty().addListener((observableValue, oldState, newState) -> {
+            String location = webEngine.getLocation();
+            switch (newState) {
+            case CANCELLED:
+                logger.info(WEB_ENGINE_WORKER_STATE_CANCELLED + location);
+                break;
+            case FAILED:
+                logger.warning(WEB_ENGINE_WORKER_STATE_FAILED + location);
+                break;
+            case RUNNING:
+                logger.info(WEB_ENGINE_WORKER_STATE_RUNNING + location);
+                break;
+            case SCHEDULED:
+                logger.info(WEB_ENGINE_WORKER_STATE_SCHEDULED + location);
+                break;
+            case SUCCEEDED:
+                logger.info(WEB_ENGINE_WORKER_STATE_SUCCEEDED + location);
+                break;
+            default:
             }
         });
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/UserGuideTabPane.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/UserGuideTabPane.java
@@ -4,11 +4,14 @@ import java.util.logging.Logger;
 
 import ay2021s1_cs2103_w16_3.finesse.commons.core.LogsCenter;
 import ay2021s1_cs2103_w16_3.finesse.ui.UiPart;
+import javafx.animation.KeyFrame;
+import javafx.animation.Timeline;
 import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.scene.layout.StackPane;
 import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
+import javafx.util.Duration;
 
 /**
  * Tab pane that displays the user guide.
@@ -22,6 +25,9 @@ public class UserGuideTabPane extends UiPart<StackPane> {
     // Note: Does not work if '.html' is appended for some reason.
     private static final String NO_EXTERNAL_SITE_PAGE_URL =
             "https://ay2021s1-cs2103t-w16-3.github.io/tp/NoExternalSite";
+
+    // Constants
+    private static final double REFRESH_TIMEOUT_DELAY = 10000.0;
 
     // Logging messages
     private static final String WEB_ENGINE_EXTERNAL_SITE_REQUEST_BLOCKED =
@@ -66,14 +72,23 @@ public class UserGuideTabPane extends UiPart<StackPane> {
             }
         });
 
+        // Initialize refresh task.
+        Timeline refreshTask = new Timeline(new KeyFrame(Duration.millis(REFRESH_TIMEOUT_DELAY),
+            actionEvent -> refreshPage()));
+
         webEngine.getLoadWorker().stateProperty().addListener((observableValue, oldState, newState) -> {
             String location = webEngine.getLocation();
+
+            // Stop the refresh task to prevent multiple tasks running.
+            refreshTask.stop();
+
             switch (newState) {
             case CANCELLED:
                 logger.info(WEB_ENGINE_WORKER_STATE_CANCELLED + location);
                 break;
             case FAILED:
                 logger.warning(WEB_ENGINE_WORKER_STATE_FAILED + location);
+                refreshTask.playFromStart();
                 break;
             case RUNNING:
                 logger.info(WEB_ENGINE_WORKER_STATE_RUNNING + location);

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/UserGuideTabPane.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/UserGuideTabPane.java
@@ -87,4 +87,14 @@ public class UserGuideTabPane extends UiPart<StackPane> {
 
         webEngine.load(USER_GUIDE_URL);
     }
+
+    /**
+     * Refreshes the WebView.
+     */
+    public void refreshPage() {
+        // Cannot simply reload the page because if the page has not loaded a single time,
+        // reloading does not work.
+        String currentPage = webView.getEngine().getLocation();
+        webView.getEngine().load(currentPage);
+    }
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/UserGuideTabPane.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/UserGuideTabPane.java
@@ -15,7 +15,9 @@ public class UserGuideTabPane extends UiPart<StackPane> {
 
     private static final String GITHUB_PAGES_DOMAIN = "https://ay2021s1-cs2103t-w16-3.github.io";
     private static final String USER_GUIDE_URL = "https://ay2021s1-cs2103t-w16-3.github.io/tp/UserGuide.html";
-    private static final String ERROR_PAGE_URL = "https://ay2021s1-cs2103t-w16-3.github.io";
+    // Note: Does not work if '.html' is appended for some reason.
+    private static final String NO_EXTERNAL_SITE_PAGE_URL =
+            "https://ay2021s1-cs2103t-w16-3.github.io/tp/NoExternalSite";
 
     @FXML
     private WebView webView;
@@ -35,11 +37,11 @@ public class UserGuideTabPane extends UiPart<StackPane> {
         WebEngine webEngine = webView.getEngine();
 
         webEngine.locationProperty().addListener((observableValue, oldUrl, newUrl) -> {
-            if (!newUrl.contains(GITHUB_PAGES_DOMAIN)) {
+            if (!newUrl.startsWith(GITHUB_PAGES_DOMAIN)) {
                 // Block requests to external sites.
                 Platform.runLater(() -> {
-                    // Load the error page.
-                    webEngine.load(ERROR_PAGE_URL);
+                    // Load the 'No External Site' page.
+                    webEngine.load(NO_EXTERNAL_SITE_PAGE_URL);
                 });
             }
         });

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/UserGuideTabPane.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/UserGuideTabPane.java
@@ -22,9 +22,8 @@ public class UserGuideTabPane extends UiPart<StackPane> {
     // Links
     private static final String GITHUB_PAGES_DOMAIN = "https://ay2021s1-cs2103t-w16-3.github.io";
     private static final String USER_GUIDE_URL = "https://ay2021s1-cs2103t-w16-3.github.io/tp/UserGuide.html";
-    // Note: Does not work if '.html' is appended for some reason.
     private static final String NO_EXTERNAL_SITE_PAGE_URL =
-            "https://ay2021s1-cs2103t-w16-3.github.io/tp/NoExternalSite";
+            "https://ay2021s1-cs2103t-w16-3.github.io/tp/NoExternalSite.html";
 
     // Constants
     private static final double REFRESH_TIMEOUT_DELAY = 10000.0;

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -276,8 +276,7 @@
     -fx-padding: 20, 0, 0, 0;
 }
 
-#userGuideButton:hover {
-    -fx-background-color: transparent;
+#userGuideButton:hover, #userGuideButton:selected {
     -fx-text-fill: white;
 }
 

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -268,7 +268,7 @@
     -fx-text-fill: white;
 }
 
-#helpButton {
+#userGuideButton {
     -fx-background-color: transparent;
     -fx-font-family: "Roboto Condensed";
     -fx-font-size: 24px;
@@ -276,7 +276,7 @@
     -fx-padding: 20, 0, 0, 0;
 }
 
-#helpButton:hover {
+#userGuideButton:hover {
     -fx-background-color: transparent;
     -fx-text-fill: white;
 }

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -33,7 +33,8 @@
               <Tab fx:id="analyticsTab" text="Analytics" closable="false" />
               <Tab fx:id="userGuideTab" text="" closable="false" />
             </TabPane>
-            <ToggleButton fx:id="userGuideButton" text="User Guide" onMouseClicked="#switchToUserGuideTab" AnchorPane.rightAnchor="0.0" />
+            <ToggleButton fx:id="userGuideButton" text="User Guide" onMouseClicked="#switchToUserGuideTab"
+                          AnchorPane.topAnchor="0.0" AnchorPane.rightAnchor="0.0" />
           </AnchorPane>
         </center>
 

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -3,9 +3,9 @@
 <?import java.net.URL?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.Scene?>
-<?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Tab?>
 <?import javafx.scene.control.TabPane?>
+<?import javafx.scene.control.ToggleButton?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.StackPane?>
@@ -33,7 +33,7 @@
               <Tab fx:id="analyticsTab" text="Analytics" closable="false" />
               <Tab fx:id="userGuideTab" text="" closable="false" />
             </TabPane>
-            <Button fx:id="userGuideButton" text="User Guide" onMouseClicked="#switchToUserGuideTab" AnchorPane.rightAnchor="0.0" />
+            <ToggleButton fx:id="userGuideButton" text="User Guide" onMouseClicked="#switchToUserGuideTab" AnchorPane.rightAnchor="0.0" />
           </AnchorPane>
         </center>
 

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -31,8 +31,9 @@
               <Tab fx:id="incomeTab" text="Incomes" closable="false" />
               <Tab fx:id="expenseTab" text="Expenses" closable="false" />
               <Tab fx:id="analyticsTab" text="Analytics" closable="false" />
+              <Tab fx:id="userGuideTab" text="" closable="false" />
             </TabPane>
-            <Button fx:id="helpButton" text="Help" onMouseClicked="#handleHelp" AnchorPane.rightAnchor="0.0" />
+            <Button fx:id="userGuideButton" text="User Guide" onMouseClicked="#switchToUserGuideTab" AnchorPane.rightAnchor="0.0" />
           </AnchorPane>
         </center>
 

--- a/src/main/resources/view/UserGuideTabPane.fxml
+++ b/src/main/resources/view/UserGuideTabPane.fxml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.web.WebView?>
+
+<StackPane xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+  <WebView fx:id="webView" />
+</StackPane>


### PR DESCRIPTION
Changes:
- Add `javafx-media` and `javafx-web`.
  - These dependencies are necessary for `WebView` to work.
- Add a new tab to hold the user guide.
  - The actual tab button is hidden and disabled. This is to make it clear that the user guide tab is not a core functionality of the application. Because the `TabPane` does not support having a specific tab being right aligned, a `ToggleButton` is used instead that is styled exactly like a tab. The behaviour of the `ToggleButton` was also changed to behave exactly like a normal `Tab`.
- Update `UiState.Tab` to include `USER_GUIDE`.
- Add a `WebView` to view the user guide.
  - The user is able to navigate to any pages in the domain: https://ay2021s1-cs2103t-w16-3.github.io.
  - If the user attempts to navigate to any other page, it will be deemed as an external site, and the user will get redirected to https://ay2021s1-cs2103t-w16-3.github.io/tp/NoExternalSite.html. This forces the user to stay within our documentation, reducing the likelihood of weird things happening (the JavaFX `WebView` is quite buggy on certain websites).
  - Should the web page fail to load (due to there being no internet connection), the application will automatically attempt to reload the page every 10 seconds.
- Add logging to actions performed in the `WebView`.

Resolves #184.