### PR TITLE
Add restrictions to command inputs

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddExpenseCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddExpenseCommandParser.java
@@ -15,6 +15,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 
 /**
  * Parses input arguments and creates a new AddExpenseCommand object
@@ -33,6 +34,21 @@ public class AddExpenseCommandParser implements Parser<AddExpenseCommand> {
         if (!argMultimap.arePrefixesPresent(PREFIX_TITLE, PREFIX_AMOUNT, PREFIX_DATE)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddExpenseCommand.MESSAGE_USAGE));
+        }
+
+        if (argMultimap.moreThanOneValuePresent(PREFIX_TITLE)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_TITLE_CONSTRAINTS));
+        }
+
+        if (argMultimap.moreThanOneValuePresent(PREFIX_AMOUNT)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_AMOUNT_CONSTRAINTS));
+        }
+
+        if (argMultimap.moreThanOneValuePresent(PREFIX_DATE)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_DATE_CONSTRAINTS));
         }
 
         Title title = ParserUtil.parseTitle(argMultimap.getValue(PREFIX_TITLE).get());

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddIncomeCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddIncomeCommandParser.java
@@ -15,6 +15,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 
 /**
  * Parses input arguments and creates a new AddIncomeCommand object
@@ -33,6 +34,21 @@ public class AddIncomeCommandParser implements Parser<AddIncomeCommand> {
         if (!argMultimap.arePrefixesPresent(PREFIX_TITLE, PREFIX_AMOUNT, PREFIX_DATE)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddIncomeCommand.MESSAGE_USAGE));
+        }
+
+        if (argMultimap.moreThanOneValuePresent(PREFIX_TITLE)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_TITLE_CONSTRAINTS));
+        }
+
+        if (argMultimap.moreThanOneValuePresent(PREFIX_AMOUNT)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_AMOUNT_CONSTRAINTS));
+        }
+
+        if (argMultimap.moreThanOneValuePresent(PREFIX_DATE)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_DATE_CONSTRAINTS));
         }
 
         Title title = ParserUtil.parseTitle(argMultimap.getValue(PREFIX_TITLE).get());

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ArgumentMultimap.java
@@ -60,6 +60,13 @@ public class ArgumentMultimap {
     }
 
     /**
+     * Returns true if the prefix contains more than one value.
+     */
+    public boolean moreThanOneValuePresent(Prefix prefix) {
+        return getAllValues(prefix).size() > 1;
+    }
+
+    /**
      * Returns the preamble (text before the first valid prefix). Trims any leading/trailing spaces.
      */
     public String getPreamble() {

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budgetparsers/SetExpenseLimitCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budgetparsers/SetExpenseLimitCommandParser.java
@@ -16,6 +16,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
  */
 public class SetExpenseLimitCommandParser implements Parser<SetExpenseLimitCommand> {
 
+    public static final String MESSAGE_CONSTRAINTS = "Only one amount should be input as the expense limit.";
     /**
      * Parses the given {@code String} of arguments in the context of the SetExpenseLimitCommand
      * and returns a SetExpenseLimitCommand object for execution.
@@ -28,6 +29,12 @@ public class SetExpenseLimitCommandParser implements Parser<SetExpenseLimitComma
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetExpenseLimitCommand.MESSAGE_USAGE));
         }
+
+        if (argMultimap.moreThanOneValuePresent(PREFIX_AMOUNT)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_CONSTRAINTS));
+        }
+
         Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
         return new SetExpenseLimitCommand(amount);
     }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budgetparsers/SetSavingsGoalCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budgetparsers/SetSavingsGoalCommandParser.java
@@ -16,6 +16,8 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
  */
 public class SetSavingsGoalCommandParser implements Parser<SetSavingsGoalCommand> {
 
+    public static final String MESSAGE_CONSTRAINTS = "Only one amount should be input as the savings goal.";
+
     /**
      * Parses the given {@code String} of arguments in the context of the SetSavingsGoalCommand
      * and returns a SetSavingsGoalCommand object for execution.
@@ -28,6 +30,12 @@ public class SetSavingsGoalCommandParser implements Parser<SetSavingsGoalCommand
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetSavingsGoalCommand.MESSAGE_USAGE));
         }
+
+        if (argMultimap.moreThanOneValuePresent(PREFIX_AMOUNT)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_CONSTRAINTS));
+        }
+
         Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
         return new SetSavingsGoalCommand(amount);
     }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Amount.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Amount.java
@@ -11,7 +11,6 @@ import java.math.BigDecimal;
  */
 public class Amount implements Comparable<Amount> {
 
-
     public static final String MESSAGE_CONSTRAINTS =
             "Amounts should only contain non-negative numbers, with an optional 2 decimal places or '$' prefix";
     public static final String VALIDATION_REGEX = "^\\$?\\d+(\\.\\d{2})?$";

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Transaction.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Transaction.java
@@ -20,6 +20,10 @@ public abstract class Transaction {
     public static final Comparator<Transaction> TRANSACTION_COMPARATOR =
             Comparator.comparing((Transaction t) -> t.date).reversed().thenComparing(t -> t.title);
 
+    public static final String MESSAGE_TITLE_CONSTRAINTS = "Transactions should only contain one title.";
+    public static final String MESSAGE_AMOUNT_CONSTRAINTS = "Transactions should only contain one amount.";
+    public static final String MESSAGE_DATE_CONSTRAINTS = "Transactions should only contain one date.";
+
     // Identity fields
     private final Title title;
     private final Amount amount;

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddExpenseCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddExpenseCommandParserTest.java
@@ -33,6 +33,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
 
 public class AddExpenseCommandParserTest {
@@ -45,18 +46,6 @@ public class AddExpenseCommandParserTest {
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP
-                + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE, new AddExpenseCommand(expectedExpense));
-
-        // multiple titles - last title accepted
-        assertParseSuccess(parser, TITLE_DESC_BUBBLE_TEA + TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP
-                + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE, new AddExpenseCommand(expectedExpense));
-
-        // multiple amounts - last amount accepted
-        assertParseSuccess(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_BUBBLE_TEA + AMOUNT_DESC_INTERNSHIP
-                + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE, new AddExpenseCommand(expectedExpense));
-
-        // multiple dates - last date accepted
-        assertParseSuccess(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP + DATE_DESC_BUBBLE_TEA
                 + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE, new AddExpenseCommand(expectedExpense));
 
         // multiple categories - all accepted
@@ -113,6 +102,21 @@ public class AddExpenseCommandParserTest {
         // invalid category
         assertParseFailure(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP + DATE_DESC_INTERNSHIP
                 + INVALID_CATEGORY_DESC + VALID_CATEGORY_FOOD_BEVERAGE, Category.MESSAGE_CONSTRAINTS);
+
+        // multiple titles
+        assertParseFailure(parser, TITLE_DESC_BUBBLE_TEA + TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP
+                + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_TITLE_CONSTRAINTS));
+
+        // multiple amounts
+        assertParseFailure(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_BUBBLE_TEA + AMOUNT_DESC_INTERNSHIP
+                + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_AMOUNT_CONSTRAINTS));
+
+        // multiple dates
+        assertParseFailure(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP + DATE_DESC_BUBBLE_TEA
+                + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_DATE_CONSTRAINTS));
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_TITLE_DESC + AMOUNT_DESC_INTERNSHIP + INVALID_DATE_DESC,

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddIncomeCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddIncomeCommandParserTest.java
@@ -33,6 +33,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
 
 public class AddIncomeCommandParserTest {
@@ -45,18 +46,6 @@ public class AddIncomeCommandParserTest {
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP
-                + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE, new AddIncomeCommand(expectedIncome));
-
-        // multiple titles - last title accepted
-        assertParseSuccess(parser, TITLE_DESC_BUBBLE_TEA + TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP
-                + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE, new AddIncomeCommand(expectedIncome));
-
-        // multiple amounts - last amount accepted
-        assertParseSuccess(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_BUBBLE_TEA + AMOUNT_DESC_INTERNSHIP
-                + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE, new AddIncomeCommand(expectedIncome));
-
-        // multiple dates - last date accepted
-        assertParseSuccess(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP + DATE_DESC_BUBBLE_TEA
                 + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE, new AddIncomeCommand(expectedIncome));
 
         // multiple categories - all accepted
@@ -118,9 +107,52 @@ public class AddIncomeCommandParserTest {
         assertParseFailure(parser, INVALID_TITLE_DESC + AMOUNT_DESC_INTERNSHIP + INVALID_DATE_DESC,
                 Title.MESSAGE_CONSTRAINTS);
 
+        // multiple titles
+        assertParseFailure(parser, TITLE_DESC_BUBBLE_TEA + TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP
+                + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_TITLE_CONSTRAINTS));
+
+        // multiple amounts
+        assertParseFailure(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_BUBBLE_TEA + AMOUNT_DESC_INTERNSHIP
+                + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_AMOUNT_CONSTRAINTS));
+
+        // multiple dates -
+        assertParseFailure(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP + DATE_DESC_BUBBLE_TEA
+                + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_DATE_CONSTRAINTS));
+
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP
                 + DATE_DESC_INTERNSHIP + CATEGORY_DESC_WORK + CATEGORY_DESC_FOOD_BEVERAGE,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddIncomeCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_moreThanOneField_failure() {
+        // invalid title
+        assertParseFailure(parser, INVALID_TITLE_DESC + AMOUNT_DESC_INTERNSHIP + DATE_DESC_INTERNSHIP
+                + CATEGORY_DESC_WORK + CATEGORY_DESC_FOOD_BEVERAGE, Title.MESSAGE_CONSTRAINTS);
+
+        // invalid amount
+        assertParseFailure(parser, TITLE_DESC_INTERNSHIP + INVALID_AMOUNT_DESC + DATE_DESC_INTERNSHIP
+                + CATEGORY_DESC_WORK + CATEGORY_DESC_FOOD_BEVERAGE, Amount.MESSAGE_CONSTRAINTS);
+
+        // invalid date
+        assertParseFailure(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP + INVALID_DATE_DESC
+                + CATEGORY_DESC_WORK + CATEGORY_DESC_FOOD_BEVERAGE, Date.MESSAGE_CONSTRAINTS);
+
+        // invalid category
+        assertParseFailure(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP + DATE_DESC_INTERNSHIP
+                + INVALID_CATEGORY_DESC + VALID_CATEGORY_FOOD_BEVERAGE, Category.MESSAGE_CONSTRAINTS);
+
+        // two invalid values, only first invalid value reported
+        assertParseFailure(parser, INVALID_TITLE_DESC + AMOUNT_DESC_INTERNSHIP + INVALID_DATE_DESC,
+                Title.MESSAGE_CONSTRAINTS);
+
+        // non-empty preamble
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP
+                        + DATE_DESC_INTERNSHIP + CATEGORY_DESC_WORK + CATEGORY_DESC_FOOD_BEVERAGE,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddIncomeCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddIncomeCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddIncomeCommandParserTest.java
@@ -117,7 +117,7 @@ public class AddIncomeCommandParserTest {
                 + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_AMOUNT_CONSTRAINTS));
 
-        // multiple dates -
+        // multiple dates
         assertParseFailure(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP + DATE_DESC_BUBBLE_TEA
                 + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_DATE_CONSTRAINTS));

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budget/SetExpenseLimitCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budget/SetExpenseLimitCommandParserTest.java
@@ -2,6 +2,7 @@ package ay2021s1_cs2103_w16_3.finesse.logic.parser.budget;
 
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUNT_DESC_INTERNSHIP;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUNT_DESC_PART_TIME;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_AMOUNT_INTERNSHIP;
@@ -33,6 +34,9 @@ public class SetExpenseLimitCommandParserTest {
         // preamble before amount prefix
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + AMOUNT_DESC_INTERNSHIP,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetExpenseLimitCommand.MESSAGE_USAGE));
+        // multiple amounts
+        assertParseFailure(parser, PREAMBLE_WHITESPACE + AMOUNT_DESC_INTERNSHIP + AMOUNT_DESC_PART_TIME,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetExpenseLimitCommandParser.MESSAGE_CONSTRAINTS));
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budget/SetSavingsGoalCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/budget/SetSavingsGoalCommandParserTest.java
@@ -2,6 +2,7 @@ package ay2021s1_cs2103_w16_3.finesse.logic.parser.budget;
 
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUNT_DESC_INTERNSHIP;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUNT_DESC_PART_TIME;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_AMOUNT_INTERNSHIP;
@@ -33,6 +34,9 @@ public class SetSavingsGoalCommandParserTest {
         // preamble before amount prefix
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + AMOUNT_DESC_INTERNSHIP,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetSavingsGoalCommand.MESSAGE_USAGE));
+        // multiple amounts
+        assertParseFailure(parser, PREAMBLE_WHITESPACE + AMOUNT_DESC_INTERNSHIP + AMOUNT_DESC_PART_TIME,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetSavingsGoalCommandParser.MESSAGE_CONSTRAINTS));
     }
 
     @Test


### PR DESCRIPTION
Resolves #200.

Restricts user command inputs to one title/amount/date for adding transactions, one amount/date for finding transactions, and one amount for setting expense limit/saving goal.
Additional restrictions placed on find command such that the lower bound for amount/date should not be larger than the upper bound.