### PR TITLE
Use relative URL for favicon path

### DIFF
--- a/docs/_includes/custom-head.html
+++ b/docs/_includes/custom-head.html
@@ -5,4 +5,4 @@
   2. Customize default _includes/custom-head.html in your source directory and insert the given code snippet.
 {% endcomment %}
 
-<link rel="shortcut icon" type="image/x-icon" href="/assets/favicon.png">
+<link rel="shortcut icon" type="image/x-icon" href={{ "/assets/favicon.png" | relative_url }}>


### PR DESCRIPTION
Fixes #204.

To test this change locally, run
```
jekyll s --baseurl /ay2021s1-cs2103t-w16-3.github.io/tp
```

on top of the usual
```
jekyll s
```

The favicon should work for both.