### PR TITLE
Fix user guide bugs

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -286,7 +286,9 @@ Deleted Expense: Bubble Tea Amount: $4.80 Date: 14/10/2020 Categories: [Food & B
 Shows a list of all the expenses in the finance tracker.
 This effectively resets any current filtering of the expense list, such as those made by `find`.
 
-Format: (when on the [Expenses tab](#213-expenses-tab)) `list`
+Format: `ls-expense`
+
+Shortcut: `lse`, (when on the [Expenses tab](#213-expenses-tab)) `list`
 
 Example Usage:
 ```
@@ -423,7 +425,9 @@ Deleted Income: Teaching Assistant Amount: $1920.00 Date: 18/10/2020 Categories:
 Shows a list of all the incomes in the finance tracker.
 This effectively resets any current filtering of the income list, such as those made by `find`.
 
-Format: (when on the [Incomes tab](#212-incomes-tab)) `list`
+Format: `ls-income`
+
+Shortcut: `lsi`, (when on the [Incomes tab](#212-incomes-tab)) `list`
 
 Example Usage:
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ title: Fine$$e
 
 **Fine$$e is a desktop app for managing finances, optimized for use via a Command Line Interface** (CLI) while still having the benefits of a Graphical User Interface (GUI). If you can type fast, Fine\$\$e can track and help you cultivate good financial habits faster than traditional GUI apps.
 
-* If you are interested in using Fine$$e, head over to the [_Quick Start_ section of the **User Guide**](UserGuide.html#quick-start).
+* If you are interested in using Fine$$e, head over to the [_Quick Start_ section of the **User Guide**](UserGuide.html#2-quick-start).
 * If you are interested in developing Fine$$e, the [**Developer Guide**](DeveloperGuide.html) is a good place to start.
 
 


### PR DESCRIPTION
https://github.com/AY2021S1-CS2103T-W16-3/tp/issues/131#issuecomment-717693608

Fixed a bug where `ls-expense`, `lse`, `ls-income`, and `lsi` were not included in the user guide.

Also fixed a link on the main page that broke when the sections were numbered.