### PR TITLE
Refactor parsing logic to make date input optional

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddExpenseCommand.java
@@ -23,6 +23,7 @@ public class AddExpenseCommand extends Command {
             + PREFIX_AMOUNT + "AMOUNT "
             + "[" + PREFIX_DATE + "DATE] "
             + "[" + PREFIX_CATEGORY + "CATEGORY]...\n"
+            + "Inputting the date is optional. If no input is given for d/DATE, current date will be used.\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_TITLE + "Bubble Tea "
             + PREFIX_AMOUNT + "5 "

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddExpenseCommand.java
@@ -21,7 +21,7 @@ public class AddExpenseCommand extends Command {
             + "Parameters: "
             + PREFIX_TITLE + "TITLE "
             + PREFIX_AMOUNT + "AMOUNT "
-            + PREFIX_DATE + "DATE "
+            + "[" + PREFIX_DATE + "DATE] "
             + "[" + PREFIX_CATEGORY + "CATEGORY]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_TITLE + "Bubble Tea "

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddExpenseCommand.java
@@ -23,7 +23,7 @@ public class AddExpenseCommand extends Command {
             + PREFIX_AMOUNT + "AMOUNT "
             + "[" + PREFIX_DATE + "DATE] "
             + "[" + PREFIX_CATEGORY + "CATEGORY]...\n"
-            + "Inputting the date is optional. If no input is given for d/DATE, current date will be used.\n"
+            + "Inputting the date is optional. If no input is given for d/DATE, the current date will be used.\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_TITLE + "Bubble Tea "
             + PREFIX_AMOUNT + "5 "

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommand.java
@@ -23,7 +23,7 @@ public class AddIncomeCommand extends Command {
             + PREFIX_AMOUNT + "AMOUNT "
             + "[" + PREFIX_DATE + "DATE] "
             + "[" + PREFIX_CATEGORY + "CATEGORY]...\n"
-            + "Inputting the date is optional. If no input is given for d/DATE, current date will be used.\n"
+            + "Inputting the date is optional. If no input is given for d/DATE, the current date will be used.\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_TITLE + "Internship "
             + PREFIX_AMOUNT + "560 "

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommand.java
@@ -21,7 +21,7 @@ public class AddIncomeCommand extends Command {
             + "Parameters: "
             + PREFIX_TITLE + "TITLE "
             + PREFIX_AMOUNT + "AMOUNT "
-            + PREFIX_DATE + "DATE "
+            + "[" + PREFIX_DATE + "DATE] "
             + "[" + PREFIX_CATEGORY + "CATEGORY]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_TITLE + "Internship "

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommand.java
@@ -23,6 +23,7 @@ public class AddIncomeCommand extends Command {
             + PREFIX_AMOUNT + "AMOUNT "
             + "[" + PREFIX_DATE + "DATE] "
             + "[" + PREFIX_CATEGORY + "CATEGORY]...\n"
+            + "Inputting the date is optional. If no input is given for d/DATE, current date will be used.\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_TITLE + "Internship "
             + PREFIX_AMOUNT + "560 "

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/ConvertBookmarkExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/ConvertBookmarkExpenseCommand.java
@@ -21,7 +21,7 @@ public class ConvertBookmarkExpenseCommand extends ConvertBookmarkCommand {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Converts the specified bookmark expense and adds"
             + " it as an expense to the finance tracker.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + PREFIX_DATE + "DATE\n"
+            + "[" + PREFIX_DATE + "DATE]\n"
             + "Example: " + COMMAND_WORD + " 1 " + PREFIX_DATE + "03/10/2020 ";
 
     public static final String MESSAGE_CONVERT_BOOKMARK_EXPENSE_SUCCESS = "Bookmark expense has been converted "

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/ConvertBookmarkExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/ConvertBookmarkExpenseCommand.java
@@ -22,7 +22,7 @@ public class ConvertBookmarkExpenseCommand extends ConvertBookmarkCommand {
             + " it as an expense to the finance tracker.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_DATE + "DATE]\n"
-            + "Inputting the date is optional. If no input is given for d/DATE, current date will be used.\n"
+            + "Inputting the date is optional. If no input is given for d/DATE, the current date will be used.\n"
             + "Example: " + COMMAND_WORD + " 1 " + PREFIX_DATE + "03/10/2020 ";
 
     public static final String MESSAGE_CONVERT_BOOKMARK_EXPENSE_SUCCESS = "Bookmark expense has been converted "

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/ConvertBookmarkExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/ConvertBookmarkExpenseCommand.java
@@ -22,6 +22,7 @@ public class ConvertBookmarkExpenseCommand extends ConvertBookmarkCommand {
             + " it as an expense to the finance tracker.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_DATE + "DATE]\n"
+            + "Inputting the date is optional. If no input is given for d/DATE, current date will be used.\n"
             + "Example: " + COMMAND_WORD + " 1 " + PREFIX_DATE + "03/10/2020 ";
 
     public static final String MESSAGE_CONVERT_BOOKMARK_EXPENSE_SUCCESS = "Bookmark expense has been converted "

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/ConvertBookmarkIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/ConvertBookmarkIncomeCommand.java
@@ -22,7 +22,7 @@ public class ConvertBookmarkIncomeCommand extends ConvertBookmarkCommand {
             + " it as an income to the finance tracker.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_DATE + "DATE]\n"
-            + "Inputting the date is optional. If no input is given for d/DATE, current date will be used.\n"
+            + "Inputting the date is optional. If no input is given for d/DATE, the current date will be used.\n"
             + "Example: " + COMMAND_WORD + " 1 " + PREFIX_DATE + "03/10/2020 ";
 
     public static final String MESSAGE_CONVERT_BOOKMARK_INCOME_SUCCESS = "Bookmark income has been converted "

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/ConvertBookmarkIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/ConvertBookmarkIncomeCommand.java
@@ -22,6 +22,7 @@ public class ConvertBookmarkIncomeCommand extends ConvertBookmarkCommand {
             + " it as an income to the finance tracker.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_DATE + "DATE]\n"
+            + "Inputting the date is optional. If no input is given for d/DATE, current date will be used.\n"
             + "Example: " + COMMAND_WORD + " 1 " + PREFIX_DATE + "03/10/2020 ";
 
     public static final String MESSAGE_CONVERT_BOOKMARK_INCOME_SUCCESS = "Bookmark income has been converted "

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/ConvertBookmarkIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/ConvertBookmarkIncomeCommand.java
@@ -21,7 +21,7 @@ public class ConvertBookmarkIncomeCommand extends ConvertBookmarkCommand {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Converts the specified bookmark income and adds"
             + " it as an income to the finance tracker.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + PREFIX_DATE + "DATE\n"
+            + "[" + PREFIX_DATE + "DATE]\n"
             + "Example: " + COMMAND_WORD + " 1 " + PREFIX_DATE + "03/10/2020 ";
 
     public static final String MESSAGE_CONVERT_BOOKMARK_INCOME_SUCCESS = "Bookmark income has been converted "

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddExpenseCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddExpenseCommandParser.java
@@ -6,6 +6,8 @@ import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_CATEGO
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_DATE;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_TITLE;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Set;
 
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddExpenseCommand;
@@ -31,7 +33,7 @@ public class AddExpenseCommandParser implements Parser<AddExpenseCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_AMOUNT, PREFIX_DATE, PREFIX_CATEGORY);
 
-        if (!argMultimap.arePrefixesPresent(PREFIX_TITLE, PREFIX_AMOUNT, PREFIX_DATE)
+        if (!argMultimap.arePrefixesPresent(PREFIX_TITLE, PREFIX_AMOUNT)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddExpenseCommand.MESSAGE_USAGE));
         }
@@ -46,15 +48,23 @@ public class AddExpenseCommandParser implements Parser<AddExpenseCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_AMOUNT_CONSTRAINTS));
         }
 
-        if (argMultimap.moreThanOneValuePresent(PREFIX_DATE)) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_DATE_CONSTRAINTS));
-        }
-
         Title title = ParserUtil.parseTitle(argMultimap.getValue(PREFIX_TITLE).get());
         Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
-        Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
         Set<Category> categoryList = ParserUtil.parseCategories(argMultimap.getAllValues(PREFIX_CATEGORY));
+        Date date;
+
+        if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
+            if (argMultimap.moreThanOneValuePresent(PREFIX_DATE)) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_DATE_CONSTRAINTS));
+            } else {
+                date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
+            }
+        } else {
+            DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+            LocalDate currentDate = LocalDate.now();
+            date = new Date(dateTimeFormatter.format(currentDate));
+        }
 
         Expense expense = new Expense(title, amount, date, categoryList);
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddIncomeCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddIncomeCommandParser.java
@@ -6,6 +6,8 @@ import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_CATEGO
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_DATE;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_TITLE;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Set;
 
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddIncomeCommand;
@@ -31,7 +33,7 @@ public class AddIncomeCommandParser implements Parser<AddIncomeCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_AMOUNT, PREFIX_DATE, PREFIX_CATEGORY);
 
-        if (!argMultimap.arePrefixesPresent(PREFIX_TITLE, PREFIX_AMOUNT, PREFIX_DATE)
+        if (!argMultimap.arePrefixesPresent(PREFIX_TITLE, PREFIX_AMOUNT)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddIncomeCommand.MESSAGE_USAGE));
         }
@@ -46,15 +48,23 @@ public class AddIncomeCommandParser implements Parser<AddIncomeCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_AMOUNT_CONSTRAINTS));
         }
 
-        if (argMultimap.moreThanOneValuePresent(PREFIX_DATE)) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_DATE_CONSTRAINTS));
-        }
-
         Title title = ParserUtil.parseTitle(argMultimap.getValue(PREFIX_TITLE).get());
         Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
-        Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
         Set<Category> categoryList = ParserUtil.parseCategories(argMultimap.getAllValues(PREFIX_CATEGORY));
+        Date date;
+
+        if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
+            if (argMultimap.moreThanOneValuePresent(PREFIX_DATE)) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_DATE_CONSTRAINTS));
+            } else {
+                date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
+            }
+        } else {
+            DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+            LocalDate currentDate = LocalDate.now();
+            date = new Date(dateTimeFormatter.format(currentDate));
+        }
 
         Income income = new Income(title, amount, date, categoryList);
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/ConvertBookmarkExpenseCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/ConvertBookmarkExpenseCommandParser.java
@@ -4,6 +4,9 @@ import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALI
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_DATE;
 import static java.util.Objects.requireNonNull;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.ConvertBookmarkExpenseCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.ArgumentMultimap;
@@ -12,6 +15,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.parser.Parser;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.ParserUtil;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 
 /**
  * Parser input arguments and creates a new ConvertBookmarkExpenseCommand object
@@ -26,12 +30,21 @@ public class ConvertBookmarkExpenseCommandParser implements Parser<ConvertBookma
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_DATE);
 
-        if (!argMultimap.arePrefixesPresent(PREFIX_DATE) || argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    ConvertBookmarkExpenseCommand.MESSAGE_USAGE));
+        Date date;
+
+        if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
+            if (argMultimap.moreThanOneValuePresent(PREFIX_DATE)) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_DATE_CONSTRAINTS));
+            } else {
+                date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
+            }
+        } else {
+            DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+            LocalDate currentDate = LocalDate.now();
+            date = new Date(dateTimeFormatter.format(currentDate));
         }
 
-        Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
         Index index;
 
         try {

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/ConvertBookmarkIncomeCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/ConvertBookmarkIncomeCommandParser.java
@@ -4,6 +4,9 @@ import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALI
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_DATE;
 import static java.util.Objects.requireNonNull;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.ConvertBookmarkIncomeCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.ArgumentMultimap;
@@ -12,6 +15,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.parser.Parser;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.ParserUtil;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 
 /**
  * Parser input arguments and creates a new ConvertBookmarkIncomeCommand object
@@ -26,12 +30,21 @@ public class ConvertBookmarkIncomeCommandParser implements Parser<ConvertBookmar
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_DATE);
 
-        if (!argMultimap.arePrefixesPresent(PREFIX_DATE) || argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    ConvertBookmarkIncomeCommand.MESSAGE_USAGE));
+        Date date;
+
+        if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
+            if (argMultimap.moreThanOneValuePresent(PREFIX_DATE)) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_DATE_CONSTRAINTS));
+            } else {
+                date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
+            }
+        } else {
+            DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+            LocalDate currentDate = LocalDate.now();
+            date = new Date(dateTimeFormatter.format(currentDate));
         }
 
-        Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
         Index index;
 
         try {

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddExpenseCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddExpenseCommandParserTest.java
@@ -68,11 +68,11 @@ public class AddExpenseCommandParserTest {
                 new AddExpenseCommand(expectedExpenseWithNoCategories));
 
         // arguments has no date
-        Expense expectedExpenseWithNoDate = new TransactionBuilder().withTitle(VALID_TITLE_INTERNSHIP)
+        Expense expectedExpenseWithCurrentDate = new TransactionBuilder().withTitle(VALID_TITLE_INTERNSHIP)
                 .withAmount(VALID_AMOUNT_INTERNSHIP).withCategories(VALID_CATEGORY_WORK).withDate(CURRENT_DATE)
                 .buildExpense();
         assertParseSuccess(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP + CATEGORY_DESC_WORK,
-                new AddExpenseCommand(expectedExpenseWithNoDate));
+                new AddExpenseCommand(expectedExpenseWithCurrentDate));
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddExpenseCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddExpenseCommandParserTest.java
@@ -63,7 +63,7 @@ public class AddExpenseCommandParserTest {
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero categories
-        Expense expectedExpenseWithNoCategories = new TransactionBuilder(BUBBLE_TEA_2).withCategories().buildExpense();
+        Expense expectedExpenseWithNoCategories = new TransactionBuilder(BUBBLE_TEA_2).buildExpense();
         assertParseSuccess(parser, TITLE_DESC_BUBBLE_TEA + AMOUNT_DESC_BUBBLE_TEA + DATE_DESC_BUBBLE_TEA,
                 new AddExpenseCommand(expectedExpenseWithNoCategories));
 

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddExpenseCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddExpenseCommandParserTest.java
@@ -25,6 +25,9 @@ import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CommandParserTestUtil.a
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.BUBBLE_TEA_2;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.INTERNSHIP_2;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 import org.junit.jupiter.api.Test;
 
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddExpenseCommand;
@@ -37,6 +40,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
 
 public class AddExpenseCommandParserTest {
+    private static final String CURRENT_DATE = LocalDate.now().format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
     private AddExpenseCommandParser parser = new AddExpenseCommandParser();
 
     @Test
@@ -59,9 +63,16 @@ public class AddExpenseCommandParserTest {
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero categories
-        Expense expectedExpense = new TransactionBuilder(BUBBLE_TEA_2).withCategories().buildExpense();
+        Expense expectedExpenseWithNoCategories = new TransactionBuilder(BUBBLE_TEA_2).withCategories().buildExpense();
         assertParseSuccess(parser, TITLE_DESC_BUBBLE_TEA + AMOUNT_DESC_BUBBLE_TEA + DATE_DESC_BUBBLE_TEA,
-                new AddExpenseCommand(expectedExpense));
+                new AddExpenseCommand(expectedExpenseWithNoCategories));
+
+        // arguments has no date
+        Expense expectedExpenseWithNoDate = new TransactionBuilder().withTitle(VALID_TITLE_INTERNSHIP)
+                .withAmount(VALID_AMOUNT_INTERNSHIP).withCategories(VALID_CATEGORY_WORK).withDate(CURRENT_DATE)
+                .buildExpense();
+        assertParseSuccess(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP + CATEGORY_DESC_WORK,
+                new AddExpenseCommand(expectedExpenseWithNoDate));
     }
 
     @Test
@@ -74,10 +85,6 @@ public class AddExpenseCommandParserTest {
 
         // missing amount prefix
         assertParseFailure(parser, TITLE_DESC_INTERNSHIP + VALID_AMOUNT_INTERNSHIP + DATE_DESC_INTERNSHIP,
-                expectedMessage);
-
-        // missing date prefix
-        assertParseFailure(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP + VALID_DATE_INTERNSHIP,
                 expectedMessage);
 
         // all prefixes missing

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddExpenseCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddExpenseCommandParserTest.java
@@ -63,7 +63,7 @@ public class AddExpenseCommandParserTest {
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero categories
-        Expense expectedExpenseWithNoCategories = new TransactionBuilder(BUBBLE_TEA_2).buildExpense();
+        Expense expectedExpenseWithNoCategories = new TransactionBuilder(BUBBLE_TEA_2).withCategories().buildExpense();
         assertParseSuccess(parser, TITLE_DESC_BUBBLE_TEA + AMOUNT_DESC_BUBBLE_TEA + DATE_DESC_BUBBLE_TEA,
                 new AddExpenseCommand(expectedExpenseWithNoCategories));
 

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddIncomeCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddIncomeCommandParserTest.java
@@ -63,8 +63,7 @@ public class AddIncomeCommandParserTest {
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero categories
-        Income expectedIncomeWithNoCategories = new TransactionBuilder(BUBBLE_TEA_2).withCategories()
-                .buildIncome();
+        Income expectedIncomeWithNoCategories = new TransactionBuilder(BUBBLE_TEA_2).buildIncome();
         assertParseSuccess(parser, TITLE_DESC_BUBBLE_TEA + AMOUNT_DESC_BUBBLE_TEA + DATE_DESC_BUBBLE_TEA,
                 new AddIncomeCommand(expectedIncomeWithNoCategories));
 

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddIncomeCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddIncomeCommandParserTest.java
@@ -63,17 +63,17 @@ public class AddIncomeCommandParserTest {
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero categories
-        Income expectedIncomeWithNoInputCategories = new TransactionBuilder(BUBBLE_TEA_2).withCategories()
+        Income expectedIncomeWithNoCategories = new TransactionBuilder(BUBBLE_TEA_2).withCategories()
                 .buildIncome();
         assertParseSuccess(parser, TITLE_DESC_BUBBLE_TEA + AMOUNT_DESC_BUBBLE_TEA + DATE_DESC_BUBBLE_TEA,
-                new AddIncomeCommand(expectedIncomeWithNoInputCategories));
+                new AddIncomeCommand(expectedIncomeWithNoCategories));
 
         // arguments has no date
-        Income expectedIncomeWithNoInputDate = new TransactionBuilder().withTitle(VALID_TITLE_INTERNSHIP)
+        Income expectedIncomeWithCurrentDate = new TransactionBuilder().withTitle(VALID_TITLE_INTERNSHIP)
                 .withAmount(VALID_AMOUNT_INTERNSHIP).withDate(CURRENT_DATE).withCategories(VALID_CATEGORY_WORK)
                 .buildIncome();
         assertParseSuccess(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP + CATEGORY_DESC_WORK,
-                new AddIncomeCommand(expectedIncomeWithNoInputDate));
+                new AddIncomeCommand(expectedIncomeWithCurrentDate));
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddIncomeCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddIncomeCommandParserTest.java
@@ -63,7 +63,7 @@ public class AddIncomeCommandParserTest {
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero categories
-        Income expectedIncomeWithNoCategories = new TransactionBuilder(BUBBLE_TEA_2).buildIncome();
+        Income expectedIncomeWithNoCategories = new TransactionBuilder(BUBBLE_TEA_2).withCategories().buildIncome();
         assertParseSuccess(parser, TITLE_DESC_BUBBLE_TEA + AMOUNT_DESC_BUBBLE_TEA + DATE_DESC_BUBBLE_TEA,
                 new AddIncomeCommand(expectedIncomeWithNoCategories));
 

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddIncomeCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddIncomeCommandParserTest.java
@@ -25,6 +25,9 @@ import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CommandParserTestUtil.a
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.BUBBLE_TEA_2;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.INTERNSHIP_2;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 import org.junit.jupiter.api.Test;
 
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.AddIncomeCommand;
@@ -37,6 +40,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
 
 public class AddIncomeCommandParserTest {
+    private static final String CURRENT_DATE = LocalDate.now().format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
     private AddIncomeCommandParser parser = new AddIncomeCommandParser();
 
     @Test
@@ -59,9 +63,17 @@ public class AddIncomeCommandParserTest {
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero categories
-        Income expectedIncome = new TransactionBuilder(BUBBLE_TEA_2).withCategories().buildIncome();
+        Income expectedIncomeWithNoInputCategories = new TransactionBuilder(BUBBLE_TEA_2).withCategories()
+                .buildIncome();
         assertParseSuccess(parser, TITLE_DESC_BUBBLE_TEA + AMOUNT_DESC_BUBBLE_TEA + DATE_DESC_BUBBLE_TEA,
-                new AddIncomeCommand(expectedIncome));
+                new AddIncomeCommand(expectedIncomeWithNoInputCategories));
+
+        // arguments has no date
+        Income expectedIncomeWithNoInputDate = new TransactionBuilder().withTitle(VALID_TITLE_INTERNSHIP)
+                .withAmount(VALID_AMOUNT_INTERNSHIP).withDate(CURRENT_DATE).withCategories(VALID_CATEGORY_WORK)
+                .buildIncome();
+        assertParseSuccess(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP + CATEGORY_DESC_WORK,
+                new AddIncomeCommand(expectedIncomeWithNoInputDate));
     }
 
     @Test
@@ -74,10 +86,6 @@ public class AddIncomeCommandParserTest {
 
         // missing amount prefix
         assertParseFailure(parser, TITLE_DESC_INTERNSHIP + VALID_AMOUNT_INTERNSHIP + DATE_DESC_INTERNSHIP,
-                expectedMessage);
-
-        // missing date prefix
-        assertParseFailure(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP + VALID_DATE_INTERNSHIP,
                 expectedMessage);
 
         // all prefixes missing

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/ConvertBookmarkExpenseCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/ConvertBookmarkExpenseCommandParserTest.java
@@ -1,6 +1,7 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.parser.bookmark;
 
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DATE_DESC_BUBBLE_TEA;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DATE_DESC_SPOTIFY_SUBSCRIPTION;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_DATE_SPOTIFY_SUBSCRIPTION;
@@ -8,15 +9,20 @@ import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CommandParserTestUtil.a
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalIndexes.INDEX_SECOND;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 import org.junit.jupiter.api.Test;
 
 import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.ConvertBookmarkExpenseCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.bookmarkparsers.ConvertBookmarkExpenseCommandParser;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 
 public class ConvertBookmarkExpenseCommandParserTest {
 
+    private static final String CURRENT_DATE = LocalDate.now().format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, ConvertBookmarkExpenseCommand.MESSAGE_USAGE);
 
@@ -26,9 +32,6 @@ public class ConvertBookmarkExpenseCommandParserTest {
     public void parse_missingParts_failure() {
         // no index specified
         assertParseFailure(parser, DATE_DESC_SPOTIFY_SUBSCRIPTION, MESSAGE_INVALID_FORMAT);
-
-        // no date specified
-        assertParseFailure(parser, "1", MESSAGE_INVALID_FORMAT);
 
         // no index and no field specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
@@ -51,7 +54,13 @@ public class ConvertBookmarkExpenseCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, "1" + INVALID_DATE_DESC, Date.MESSAGE_CONSTRAINTS); // invalid date
+        // invalid date
+        assertParseFailure(parser, "1" + INVALID_DATE_DESC, Date.MESSAGE_CONSTRAINTS);
+
+        // multiple dates
+        assertParseFailure(parser, INDEX_SECOND + DATE_DESC_SPOTIFY_SUBSCRIPTION
+                        + DATE_DESC_BUBBLE_TEA,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_DATE_CONSTRAINTS));
     }
 
     @Test
@@ -60,6 +69,19 @@ public class ConvertBookmarkExpenseCommandParserTest {
         Date convertedDate = new Date(VALID_DATE_SPOTIFY_SUBSCRIPTION);
 
         String userInput = targetIndex.getOneBased() + DATE_DESC_SPOTIFY_SUBSCRIPTION;
+
+        ConvertBookmarkExpenseCommand expectedConvertBookmarkExpenseCommand =
+                new ConvertBookmarkExpenseCommand(targetIndex, convertedDate);
+
+        assertParseSuccess(parser, userInput, expectedConvertBookmarkExpenseCommand);
+    }
+
+    @Test
+    public void parse_optionalDateFieldMissing_success() {
+        Index targetIndex = INDEX_SECOND;
+        Date convertedDate = new Date(CURRENT_DATE);
+
+        String userInput = String.valueOf(targetIndex.getOneBased());
 
         ConvertBookmarkExpenseCommand expectedConvertBookmarkExpenseCommand =
                 new ConvertBookmarkExpenseCommand(targetIndex, convertedDate);

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/ConvertBookmarkIncomeCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/ConvertBookmarkIncomeCommandParserTest.java
@@ -2,11 +2,15 @@ package ay2021s1_cs2103_w16_3.finesse.logic.parser.bookmark;
 
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DATE_DESC_INTERNSHIP;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DATE_DESC_SPOTIFY_SUBSCRIPTION;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_DATE_INTERNSHIP;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalIndexes.INDEX_SECOND;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 import org.junit.jupiter.api.Test;
 
@@ -14,9 +18,11 @@ import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.ConvertBookmarkIncomeCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.bookmarkparsers.ConvertBookmarkIncomeCommandParser;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 
 public class ConvertBookmarkIncomeCommandParserTest {
 
+    private static final String CURRENT_DATE = LocalDate.now().format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, ConvertBookmarkIncomeCommand.MESSAGE_USAGE);
 
@@ -26,9 +32,6 @@ public class ConvertBookmarkIncomeCommandParserTest {
     public void parse_missingParts_failure() {
         // no index specified
         assertParseFailure(parser, DATE_DESC_INTERNSHIP, MESSAGE_INVALID_FORMAT);
-
-        // no date specified
-        assertParseFailure(parser, "1", MESSAGE_INVALID_FORMAT);
 
         // no index and no field specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
@@ -51,7 +54,12 @@ public class ConvertBookmarkIncomeCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, "1" + INVALID_DATE_DESC, Date.MESSAGE_CONSTRAINTS); // invalid date
+        // invalid date
+        assertParseFailure(parser, "1" + INVALID_DATE_DESC, Date.MESSAGE_CONSTRAINTS);
+
+        // multiple dates
+        assertParseFailure(parser, INDEX_SECOND + DATE_DESC_INTERNSHIP + DATE_DESC_SPOTIFY_SUBSCRIPTION,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_DATE_CONSTRAINTS));
     }
 
     @Test
@@ -60,6 +68,19 @@ public class ConvertBookmarkIncomeCommandParserTest {
         Date convertedDate = new Date(VALID_DATE_INTERNSHIP);
 
         String userInput = targetIndex.getOneBased() + DATE_DESC_INTERNSHIP;
+
+        ConvertBookmarkIncomeCommand expectedConvertBookmarkIncomeCommand =
+                new ConvertBookmarkIncomeCommand(targetIndex, convertedDate);
+
+        assertParseSuccess(parser, userInput, expectedConvertBookmarkIncomeCommand);
+    }
+
+    @Test
+    public void parse_optionalDateFieldMissing_success() {
+        Index targetIndex = INDEX_SECOND;
+        Date convertedDate = new Date(CURRENT_DATE);
+
+        String userInput = String.valueOf(targetIndex.getOneBased());
 
         ConvertBookmarkIncomeCommand expectedConvertBookmarkIncomeCommand =
                 new ConvertBookmarkIncomeCommand(targetIndex, convertedDate);


### PR DESCRIPTION
Resolves #210.

Changes: 
- Refactored `AddExpenseCommandParser` and `AddIncomeCommandParser` logic to let the input of date be optional. If the date has not been inputted then the current date will be used instead.
- Refactored `ConvertBookmarkIncomeCommandParser` and `ConvertBookmarkExpenseCommandParser` logic to let the input of date be optional. If the date has not been inputted, then the current date will be used instead.