### PR TITLE
Load macOS default system font using its internal name

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/UserGuideTabPane.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/UserGuideTabPane.java
@@ -59,6 +59,12 @@ public class UserGuideTabPane extends UiPart<StackPane> {
 
         WebEngine webEngine = webView.getEngine();
 
+        // Override fonts to call the default macOS system font without using '-apple-system'.
+        webEngine.setUserStyleSheetLocation(getClass().getResource("/view/WebView.css").toString());
+
+        // Log user agent.
+        logger.info(webEngine.getUserAgent());
+
         webEngine.locationProperty().addListener((observableValue, oldUrl, newUrl) -> {
             if (!newUrl.startsWith(GITHUB_PAGES_DOMAIN)) {
                 logger.info(WEB_ENGINE_EXTERNAL_SITE_REQUEST_BLOCKED);

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/UserGuideTabPane.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/tabs/UserGuideTabPane.java
@@ -63,7 +63,7 @@ public class UserGuideTabPane extends UiPart<StackPane> {
         webEngine.setUserStyleSheetLocation(getClass().getResource("/view/WebView.css").toString());
 
         // Log user agent.
-        logger.info(webEngine.getUserAgent());
+        logger.info("User Agent: " + webEngine.getUserAgent());
 
         webEngine.locationProperty().addListener((observableValue, oldUrl, newUrl) -> {
             if (!newUrl.startsWith(GITHUB_PAGES_DOMAIN)) {

--- a/src/main/resources/view/WebView.css
+++ b/src/main/resources/view/WebView.css
@@ -1,0 +1,15 @@
+/**
+ * WebView is unable to load '-apple-system', and 'San Francisco' (the default macOS
+ * font) cannot be called by name. Thus, we call '.SFNSText-Regular' on failure.
+ */
+body {
+    font-family: -apple-system,
+                 ".SFNSText-Regular",
+                 "San Francisco",
+                 "Roboto",
+                 "Segoe UI",
+                 "Helvetica Neue",
+                 "Lucida Grande",
+                 sans-serif
+                 !important;
+}


### PR DESCRIPTION
The GitHub Pages for this repository use the default system fonts of popular OSes. This is beneficial as it greatly reduces page loading times in comparison to having to serve custom fonts, and gives the page a more "native" look. To achieve this, the `font` attribute of the `body` element is declared in the CSS file as such:

```
-apple-system, BlinkMacSystemFont, "Segoe UI", "Segoe UI Symbol", "Segoe UI Emoji", "Apple Color Emoji", Roboto, Helvetica, Arial, sans-serif
```

When the page is loaded, the browser will attempt to load each of these fonts sequentially. Upon failing to load a font, the browser will move on to the next font. The `sans-serif` font is a catch-all font that every major OS ships with.

Here is a mapping of each font to its corresponding OS:
- `-apple-system`: `San Francisco` on macOS 10.11 and higher as well as iOS, `Helvetica Neue` on macOS 10.10, and `Lucida Grande` on older macOS versions.
- `BlinkMacSystemFont`: Google Chrome's equivalent to `-apple-system`.
- `Segoe UI`: Windows and Windows Phone.
- `Roboto`: Android and Chrome OS
- `Helvetica`: Common fall-back font (especially for Apple systems)
- `Arial`: Common fall-back font
- `sans-serif`: Common fall-back font

Since macOS 10.11 (El Capitan), the default system font has been `San Francisco`. However, this system font is not publicly exposed. Instead, in a bid to abstract system font names, the font has to be called using `-apple-system`. For Chrome, the equivalent keyword is `BlinkMacSystemFont`.

The issue is that JavaFX 11's `WebView` is unable to properly parse the `-apple-system` keyword. As such, one of the abovementioned fall-back fonts gets loaded instead, which is very ugly.

To remedy this, we inject a user stylesheet into the `WebView`. Since we know that `-apple-system` will fail to load, we load the private name of the `San Francisco` font instead, `.SFNSText-Regular`. This way, the default system font will be able to load on macOS 10.11 and greater. In addition, we also add `Helvetica Neue` and `Lucida Grande` to handle macOS versions earlier than 10.11.

Note that the above only works because we restrict the sites that can be visited to https://ay2021s1-cs2103t-w16-3.github.io. Also, if Apple decides to ever change the private name of their `San Francisco` font, this fix will no longer work. The proper fix for this issue would be to fork JavaFX 11's `WebView`.

Fixes #202.