### PR TITLE
Fix crash when window coordinates is null

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
@@ -168,8 +168,10 @@ public class MainWindow extends UiPart<Stage> {
         // Retrieve window size and position from previous session.
         windowHeight = guiSettings.getWindowHeight();
         windowWidth = guiSettings.getWindowWidth();
-        xPosition = (int) guiSettings.getWindowCoordinates().getX();
-        yPosition = (int) guiSettings.getWindowCoordinates().getY();
+        if (guiSettings.getWindowCoordinates() != null) {
+            xPosition = (int) guiSettings.getWindowCoordinates().getX();
+            yPosition = (int) guiSettings.getWindowCoordinates().getY();
+        }
 
         // Restore window size and position from previous session.
         primaryStage.setHeight(windowHeight);


### PR DESCRIPTION
Before restoring window coordinates from file, check that the window coordinates are not `null`.

Fixes #214.