### PR TITLE
Add duplicate restrictions to edit transaction and add bookmark commands

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/EditCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/EditCommandParser.java
@@ -17,6 +17,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.commands.EditCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.EditCommand.EditTransactionDescriptor;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
 import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 
 /**
  * Parses input arguments and creates a new EditCommand object
@@ -39,6 +40,21 @@ public class EditCommandParser implements Parser<EditCommand> {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+        }
+
+        if (argMultimap.moreThanOneValuePresent(PREFIX_TITLE)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_TITLE_CONSTRAINTS));
+        }
+
+        if (argMultimap.moreThanOneValuePresent(PREFIX_AMOUNT)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_AMOUNT_CONSTRAINTS));
+        }
+
+        if (argMultimap.moreThanOneValuePresent(PREFIX_DATE)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_DATE_CONSTRAINTS));
         }
 
         EditTransactionDescriptor editTransactionDescriptor = new EditTransactionDescriptor();

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/AddBookmarkExpenseCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/AddBookmarkExpenseCommandParser.java
@@ -14,6 +14,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.parser.Parser;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.ParserUtil;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
 import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkExpense;
+import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkTransaction;
 import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
@@ -35,6 +36,16 @@ public class AddBookmarkExpenseCommandParser implements Parser<AddBookmarkExpens
         if (!argMultimap.arePrefixesPresent(PREFIX_TITLE, PREFIX_AMOUNT) || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     AddBookmarkExpenseCommand.MESSAGE_USAGE));
+        }
+
+        if (argMultimap.moreThanOneValuePresent(PREFIX_TITLE)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_TITLE_CONSTRAINTS));
+        }
+
+        if (argMultimap.moreThanOneValuePresent(PREFIX_AMOUNT)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_AMOUNT_CONSTRAINTS));
         }
 
         Title title = ParserUtil.parseTitle(argMultimap.getValue(PREFIX_TITLE).get());

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/AddBookmarkIncomeCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/AddBookmarkIncomeCommandParser.java
@@ -14,6 +14,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.parser.Parser;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.ParserUtil;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
 import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkIncome;
+import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkTransaction;
 import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
@@ -32,6 +33,16 @@ public class AddBookmarkIncomeCommandParser implements Parser<AddBookmarkIncomeC
         if (!argMultimap.arePrefixesPresent(PREFIX_TITLE, PREFIX_AMOUNT) || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     AddBookmarkIncomeCommand.MESSAGE_USAGE));
+        }
+
+        if (argMultimap.moreThanOneValuePresent(PREFIX_TITLE)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_TITLE_CONSTRAINTS));
+        }
+
+        if (argMultimap.moreThanOneValuePresent(PREFIX_AMOUNT)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_AMOUNT_CONSTRAINTS));
         }
 
         Title title = ParserUtil.parseTitle(argMultimap.getValue(PREFIX_TITLE).get());

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/EditBookmarkExpenseCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/EditBookmarkExpenseCommandParser.java
@@ -19,6 +19,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.parser.ArgumentTokenizer;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.Parser;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.ParserUtil;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
+import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkTransaction;
 import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
 
 /**
@@ -41,6 +42,16 @@ public class EditBookmarkExpenseCommandParser implements Parser<EditBookmarkExpe
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EditBookmarkExpenseCommand.MESSAGE_USAGE), pe);
+        }
+
+        if (argMultimap.moreThanOneValuePresent(PREFIX_TITLE)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_TITLE_CONSTRAINTS));
+        }
+
+        if (argMultimap.moreThanOneValuePresent(PREFIX_AMOUNT)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_AMOUNT_CONSTRAINTS));
         }
 
         EditBookmarkTransactionDescriptor editBookmarkExpenseDescriptor = new EditBookmarkTransactionDescriptor();

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/EditBookmarkIncomeCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/EditBookmarkIncomeCommandParser.java
@@ -19,6 +19,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.parser.ArgumentTokenizer;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.Parser;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.ParserUtil;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
+import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkTransaction;
 import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
 
 /**
@@ -41,6 +42,16 @@ public class EditBookmarkIncomeCommandParser implements Parser<EditBookmarkIncom
         } catch (ParseException e) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EditBookmarkIncomeCommand.MESSAGE_USAGE));
+        }
+
+        if (argMultimap.moreThanOneValuePresent(PREFIX_TITLE)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_TITLE_CONSTRAINTS));
+        }
+
+        if (argMultimap.moreThanOneValuePresent(PREFIX_AMOUNT)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_AMOUNT_CONSTRAINTS));
         }
 
         EditBookmarkTransactionDescriptor editBookmarkIncomeDescriptor = new EditBookmarkTransactionDescriptor();

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/bookmark/BookmarkTransaction.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/bookmark/BookmarkTransaction.java
@@ -14,6 +14,10 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public abstract class BookmarkTransaction<T extends Transaction> {
+
+    public static final String MESSAGE_TITLE_CONSTRAINTS = "Bookmark transactions should only contain one title.";
+    public static final String MESSAGE_AMOUNT_CONSTRAINTS = "Bookmark transactions should only contain one amount.";
+
     private final Title title;
     private final Amount amount;
     private final Set<Category> categories;

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddExpenseCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddExpenseCommandParserTest.java
@@ -110,21 +110,6 @@ public class AddExpenseCommandParserTest {
         assertParseFailure(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP + DATE_DESC_INTERNSHIP
                 + INVALID_CATEGORY_DESC + VALID_CATEGORY_FOOD_BEVERAGE, Category.MESSAGE_CONSTRAINTS);
 
-        // multiple titles
-        assertParseFailure(parser, TITLE_DESC_BUBBLE_TEA + TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP
-                + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_TITLE_CONSTRAINTS));
-
-        // multiple amounts
-        assertParseFailure(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_BUBBLE_TEA + AMOUNT_DESC_INTERNSHIP
-                + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_AMOUNT_CONSTRAINTS));
-
-        // multiple dates
-        assertParseFailure(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP + DATE_DESC_BUBBLE_TEA
-                + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_DATE_CONSTRAINTS));
-
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_TITLE_DESC + AMOUNT_DESC_INTERNSHIP + INVALID_DATE_DESC,
                 Title.MESSAGE_CONSTRAINTS);
@@ -133,5 +118,23 @@ public class AddExpenseCommandParserTest {
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP
                 + DATE_DESC_INTERNSHIP + CATEGORY_DESC_WORK + CATEGORY_DESC_FOOD_BEVERAGE,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddExpenseCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_multipleRepeatedFields_failure() {
+        // multiple titles
+        assertParseFailure(parser, TITLE_DESC_BUBBLE_TEA + TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP
+                        + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_TITLE_CONSTRAINTS));
+
+        // multiple amounts
+        assertParseFailure(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_BUBBLE_TEA + AMOUNT_DESC_INTERNSHIP
+                        + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_AMOUNT_CONSTRAINTS));
+
+        // multiple dates
+        assertParseFailure(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP + DATE_DESC_BUBBLE_TEA
+                        + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_DATE_CONSTRAINTS));
     }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddIncomeCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/AddIncomeCommandParserTest.java
@@ -114,21 +114,6 @@ public class AddIncomeCommandParserTest {
         assertParseFailure(parser, INVALID_TITLE_DESC + AMOUNT_DESC_INTERNSHIP + INVALID_DATE_DESC,
                 Title.MESSAGE_CONSTRAINTS);
 
-        // multiple titles
-        assertParseFailure(parser, TITLE_DESC_BUBBLE_TEA + TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP
-                + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_TITLE_CONSTRAINTS));
-
-        // multiple amounts
-        assertParseFailure(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_BUBBLE_TEA + AMOUNT_DESC_INTERNSHIP
-                + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_AMOUNT_CONSTRAINTS));
-
-        // multiple dates
-        assertParseFailure(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP + DATE_DESC_BUBBLE_TEA
-                + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_DATE_CONSTRAINTS));
-
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP
                 + DATE_DESC_INTERNSHIP + CATEGORY_DESC_WORK + CATEGORY_DESC_FOOD_BEVERAGE,
@@ -136,30 +121,20 @@ public class AddIncomeCommandParserTest {
     }
 
     @Test
-    public void parse_moreThanOneField_failure() {
-        // invalid title
-        assertParseFailure(parser, INVALID_TITLE_DESC + AMOUNT_DESC_INTERNSHIP + DATE_DESC_INTERNSHIP
-                + CATEGORY_DESC_WORK + CATEGORY_DESC_FOOD_BEVERAGE, Title.MESSAGE_CONSTRAINTS);
+    public void parse_multipleRepeatedFields_failure() {
+        // multiple titles
+        assertParseFailure(parser, TITLE_DESC_BUBBLE_TEA + TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP
+                        + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_TITLE_CONSTRAINTS));
 
-        // invalid amount
-        assertParseFailure(parser, TITLE_DESC_INTERNSHIP + INVALID_AMOUNT_DESC + DATE_DESC_INTERNSHIP
-                + CATEGORY_DESC_WORK + CATEGORY_DESC_FOOD_BEVERAGE, Amount.MESSAGE_CONSTRAINTS);
+        // multiple amounts
+        assertParseFailure(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_BUBBLE_TEA + AMOUNT_DESC_INTERNSHIP
+                        + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_AMOUNT_CONSTRAINTS));
 
-        // invalid date
-        assertParseFailure(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP + INVALID_DATE_DESC
-                + CATEGORY_DESC_WORK + CATEGORY_DESC_FOOD_BEVERAGE, Date.MESSAGE_CONSTRAINTS);
-
-        // invalid category
-        assertParseFailure(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP + DATE_DESC_INTERNSHIP
-                + INVALID_CATEGORY_DESC + VALID_CATEGORY_FOOD_BEVERAGE, Category.MESSAGE_CONSTRAINTS);
-
-        // two invalid values, only first invalid value reported
-        assertParseFailure(parser, INVALID_TITLE_DESC + AMOUNT_DESC_INTERNSHIP + INVALID_DATE_DESC,
-                Title.MESSAGE_CONSTRAINTS);
-
-        // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP
-                        + DATE_DESC_INTERNSHIP + CATEGORY_DESC_WORK + CATEGORY_DESC_FOOD_BEVERAGE,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddIncomeCommand.MESSAGE_USAGE));
+        // multiple dates
+        assertParseFailure(parser, TITLE_DESC_INTERNSHIP + AMOUNT_DESC_INTERNSHIP + DATE_DESC_BUBBLE_TEA
+                        + DATE_DESC_INTERNSHIP + CATEGORY_DESC_FOOD_BEVERAGE,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_DATE_CONSTRAINTS));
     }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/EditCommandParserTest.java
@@ -6,7 +6,6 @@ import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUN
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.CATEGORY_DESC_FOOD_BEVERAGE;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.CATEGORY_DESC_WORK;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DATE_DESC_BUBBLE_TEA;
-import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DATE_DESC_INTERNSHIP;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.INVALID_AMOUNT_DESC;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.INVALID_CATEGORY_DESC;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
@@ -17,7 +16,6 @@ import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_CATEGORY_FOOD_BEVERAGE;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_CATEGORY_WORK;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_DATE_BUBBLE_TEA;
-import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_DATE_INTERNSHIP;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_TITLE_BUBBLE_TEA;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -82,10 +80,6 @@ public class EditCommandParserTest {
 
         // invalid amount followed by valid date
         assertParseFailure(parser, "1" + INVALID_AMOUNT_DESC + DATE_DESC_BUBBLE_TEA, Amount.MESSAGE_CONSTRAINTS);
-
-        // valid amount followed by invalid amount. The test case for invalid amount followed by valid amount
-        // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
-        assertParseFailure(parser, "1" + AMOUNT_DESC_INTERNSHIP + INVALID_AMOUNT_DESC, Amount.MESSAGE_CONSTRAINTS);
 
         // while parsing {@code PREFIX_CATEGORY} alone will reset the categories of the {@code Transaction} being
         // edited, parsing it together with a valid category results in error
@@ -152,40 +146,6 @@ public class EditCommandParserTest {
         // categories
         userInput = targetIndex.getOneBased() + CATEGORY_DESC_FOOD_BEVERAGE;
         descriptor = new EditTransactionDescriptorBuilder().withCategories(VALID_CATEGORY_FOOD_BEVERAGE).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
-        assertParseSuccess(parser, userInput, expectedCommand);
-    }
-
-    @Test
-    public void parse_multipleRepeatedFields_acceptsLast() {
-        Index targetIndex = INDEX_FIRST;
-        String userInput = targetIndex.getOneBased() + AMOUNT_DESC_BUBBLE_TEA + DATE_DESC_BUBBLE_TEA
-                + CATEGORY_DESC_FOOD_BEVERAGE + AMOUNT_DESC_BUBBLE_TEA + DATE_DESC_BUBBLE_TEA
-                + CATEGORY_DESC_FOOD_BEVERAGE + AMOUNT_DESC_INTERNSHIP + DATE_DESC_INTERNSHIP
-                + CATEGORY_DESC_WORK;
-
-        EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder()
-                .withAmount(VALID_AMOUNT_INTERNSHIP).withDate(VALID_DATE_INTERNSHIP)
-                .withCategories(VALID_CATEGORY_FOOD_BEVERAGE, VALID_CATEGORY_WORK).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
-
-        assertParseSuccess(parser, userInput, expectedCommand);
-    }
-
-    @Test
-    public void parse_invalidValueFollowedByValidValue_success() {
-        // no other valid values specified
-        Index targetIndex = INDEX_FIRST;
-        String userInput = targetIndex.getOneBased() + INVALID_AMOUNT_DESC + AMOUNT_DESC_INTERNSHIP;
-        EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder()
-                .withAmount(VALID_AMOUNT_INTERNSHIP).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
-        assertParseSuccess(parser, userInput, expectedCommand);
-
-        // other valid values specified
-        userInput = targetIndex.getOneBased() + DATE_DESC_INTERNSHIP + INVALID_AMOUNT_DESC + AMOUNT_DESC_INTERNSHIP;
-        descriptor = new EditTransactionDescriptorBuilder().withAmount(VALID_AMOUNT_INTERNSHIP)
-                .withDate(VALID_DATE_INTERNSHIP).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/EditCommandParserTest.java
@@ -6,11 +6,13 @@ import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUN
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.CATEGORY_DESC_FOOD_BEVERAGE;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.CATEGORY_DESC_WORK;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DATE_DESC_BUBBLE_TEA;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DATE_DESC_INTERNSHIP;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.INVALID_AMOUNT_DESC;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.INVALID_CATEGORY_DESC;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.INVALID_TITLE_DESC;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.TITLE_DESC_BUBBLE_TEA;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.TITLE_DESC_INTERNSHIP;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_AMOUNT_BUBBLE_TEA;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_AMOUNT_INTERNSHIP;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_CATEGORY_FOOD_BEVERAGE;
@@ -33,6 +35,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import ay2021s1_cs2103_w16_3.finesse.testutil.EditTransactionDescriptorBuilder;
 
 public class EditCommandParserTest {
@@ -131,13 +134,13 @@ public class EditCommandParserTest {
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
-        // amounts
+        // amount
         userInput = targetIndex.getOneBased() + AMOUNT_DESC_BUBBLE_TEA;
         descriptor = new EditTransactionDescriptorBuilder().withAmount(VALID_AMOUNT_BUBBLE_TEA).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
-        // dates
+        // date
         userInput = targetIndex.getOneBased() + DATE_DESC_BUBBLE_TEA;
         descriptor = new EditTransactionDescriptorBuilder().withDate(VALID_DATE_BUBBLE_TEA).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
@@ -148,6 +151,19 @@ public class EditCommandParserTest {
         descriptor = new EditTransactionDescriptorBuilder().withCategories(VALID_CATEGORY_FOOD_BEVERAGE).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleRepeatedFields_failure() {
+        // multiple titles
+        assertParseFailure(parser, "1" + TITLE_DESC_BUBBLE_TEA + TITLE_DESC_INTERNSHIP,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_TITLE_CONSTRAINTS));
+        // multiple amounts
+        assertParseFailure(parser, "1" + AMOUNT_DESC_BUBBLE_TEA + AMOUNT_DESC_INTERNSHIP,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_AMOUNT_CONSTRAINTS));
+        // multiple dates
+        assertParseFailure(parser, "1" + DATE_DESC_BUBBLE_TEA + DATE_DESC_INTERNSHIP,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Transaction.MESSAGE_DATE_CONSTRAINTS));
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/AddBookmarkExpenseCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/AddBookmarkExpenseCommandParserTest.java
@@ -2,6 +2,7 @@ package ay2021s1_cs2103_w16_3.finesse.logic.parser.bookmark;
 
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUNT_DESC_PHONE_BILL;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUNT_DESC_SPOTIFY_SUBSCRIPTION;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.CATEGORY_DESC_UTILITIES;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.CATEGORY_DESC_WORK;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.INVALID_AMOUNT_DESC;
@@ -10,6 +11,7 @@ import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.INVAL
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.TITLE_DESC_PHONE_BILL;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.TITLE_DESC_SPOTIFY_SUBSCRIPTION;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_AMOUNT_PHONE_BILL;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_CATEGORY_UTILITIES;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_CATEGORY_WORK;
@@ -23,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.AddBookmarkExpenseCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.bookmarkparsers.AddBookmarkExpenseCommandParser;
 import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkExpense;
+import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkTransaction;
 import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
@@ -94,6 +97,19 @@ public class AddBookmarkExpenseCommandParserTest {
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + TITLE_DESC_PHONE_BILL
                         + CATEGORY_DESC_UTILITIES + CATEGORY_DESC_WORK,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddBookmarkExpenseCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_multipleRepeatedFields_failure() {
+        // multiple titles
+        assertParseFailure(parser, TITLE_DESC_PHONE_BILL + TITLE_DESC_SPOTIFY_SUBSCRIPTION
+                        + AMOUNT_DESC_PHONE_BILL + CATEGORY_DESC_UTILITIES,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_TITLE_CONSTRAINTS));
+
+        // multiple amounts
+        assertParseFailure(parser, TITLE_DESC_PHONE_BILL + AMOUNT_DESC_PHONE_BILL
+                        + AMOUNT_DESC_SPOTIFY_SUBSCRIPTION + CATEGORY_DESC_UTILITIES,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_AMOUNT_CONSTRAINTS));
     }
 
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/AddBookmarkExpenseCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/AddBookmarkExpenseCommandParserTest.java
@@ -2,7 +2,6 @@ package ay2021s1_cs2103_w16_3.finesse.logic.parser.bookmark;
 
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUNT_DESC_PHONE_BILL;
-import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUNT_DESC_SPOTIFY_SUBSCRIPTION;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.CATEGORY_DESC_UTILITIES;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.CATEGORY_DESC_WORK;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.INVALID_AMOUNT_DESC;
@@ -11,7 +10,6 @@ import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.INVAL
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.TITLE_DESC_PHONE_BILL;
-import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.TITLE_DESC_SPOTIFY_SUBSCRIPTION;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_AMOUNT_PHONE_BILL;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_CATEGORY_UTILITIES;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_CATEGORY_WORK;
@@ -41,16 +39,6 @@ public class AddBookmarkExpenseCommandParserTest {
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + TITLE_DESC_PHONE_BILL + AMOUNT_DESC_PHONE_BILL
                 + CATEGORY_DESC_UTILITIES, new AddBookmarkExpenseCommand(expectedBookmarkExpense));
-
-        // multiple titles - last title accepted
-        assertParseSuccess(parser, TITLE_DESC_SPOTIFY_SUBSCRIPTION + TITLE_DESC_PHONE_BILL
-                        + AMOUNT_DESC_PHONE_BILL + CATEGORY_DESC_UTILITIES,
-                new AddBookmarkExpenseCommand(expectedBookmarkExpense));
-
-        // multiple amounts - last amount accepted
-        assertParseSuccess(parser, TITLE_DESC_PHONE_BILL + AMOUNT_DESC_SPOTIFY_SUBSCRIPTION
-                + AMOUNT_DESC_PHONE_BILL + CATEGORY_DESC_UTILITIES,
-                new AddBookmarkExpenseCommand(expectedBookmarkExpense));
 
         // multiple categories - all accepted
         BookmarkExpense expectedExpenseMultipleCategories = new BookmarkTransactionBuilder(PHONE_BILL)

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/AddBookmarkIncomeCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/AddBookmarkIncomeCommandParserTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.AddBookmarkIncomeCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.bookmarkparsers.AddBookmarkIncomeCommandParser;
 import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkIncome;
+import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkTransaction;
 import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
@@ -99,4 +100,16 @@ public class AddBookmarkIncomeCommandParserTest {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddBookmarkIncomeCommand.MESSAGE_USAGE));
     }
 
+    @Test
+    public void parse_multipleRepeatedFields_failure() {
+        // multiple titles
+        assertParseFailure(parser, TITLE_DESC_PHONE_BILL + TITLE_DESC_PART_TIME
+                        + AMOUNT_DESC_PHONE_BILL + CATEGORY_DESC_UTILITIES,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_TITLE_CONSTRAINTS));
+
+        // multiple amounts
+        assertParseFailure(parser, TITLE_DESC_PHONE_BILL + AMOUNT_DESC_PHONE_BILL
+                        + AMOUNT_DESC_PART_TIME + CATEGORY_DESC_UTILITIES,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_AMOUNT_CONSTRAINTS));
+    }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/AddBookmarkIncomeCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/AddBookmarkIncomeCommandParserTest.java
@@ -43,16 +43,6 @@ public class AddBookmarkIncomeCommandParserTest {
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + TITLE_DESC_PART_TIME + AMOUNT_DESC_PART_TIME
                 + CATEGORY_DESC_WORK, new AddBookmarkIncomeCommand(expectedBookmarkIncome));
 
-        // multiple titles - last title accepted
-        assertParseSuccess(parser, TITLE_DESC_PHONE_BILL + TITLE_DESC_PART_TIME
-                        + AMOUNT_DESC_PART_TIME + CATEGORY_DESC_WORK,
-                new AddBookmarkIncomeCommand(expectedBookmarkIncome));
-
-        // multiple amounts - last amount accepted
-        assertParseSuccess(parser, TITLE_DESC_PART_TIME
-                        + AMOUNT_DESC_PHONE_BILL + AMOUNT_DESC_PART_TIME + CATEGORY_DESC_WORK,
-                new AddBookmarkIncomeCommand(expectedBookmarkIncome));
-
         // multiple categories - all accepted
         BookmarkIncome expectedExpenseMultipleCategories = new BookmarkTransactionBuilder(PART_TIME)
                 .withCategories(VALID_CATEGORY_UTILITIES, VALID_CATEGORY_WORK).buildBookmarkIncome();

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/EditBookmarkExpenseCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/EditBookmarkExpenseCommandParserTest.java
@@ -2,6 +2,7 @@ package ay2021s1_cs2103_w16_3.finesse.logic.parser.bookmark;
 
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUNT_DESC_PHONE_BILL;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUNT_DESC_SPOTIFY_SUBSCRIPTION;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.CATEGORY_DESC_FOOD_BEVERAGE;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.CATEGORY_DESC_MISCELLANEOUS;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.CATEGORY_DESC_UTILITIES;
@@ -29,6 +30,7 @@ import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.EditBookmarkExpenseCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.EditBookmarkTransactionDescriptor;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.bookmarkparsers.EditBookmarkExpenseCommandParser;
+import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkTransaction;
 import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
@@ -139,6 +141,19 @@ public class EditBookmarkExpenseCommandParserTest {
         descriptor = new EditBookmarkTransactionDescriptorBuilder().withCategories(VALID_CATEGORY_UTILITIES).build();
         expectedCommand = new EditBookmarkExpenseCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleRepeatedFields_failure() {
+        // multiple titles
+        assertParseFailure(parser, "1" + TITLE_DESC_PHONE_BILL + TITLE_DESC_SPOTIFY_SUBSCRIPTION
+                        + AMOUNT_DESC_PHONE_BILL + CATEGORY_DESC_UTILITIES,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_TITLE_CONSTRAINTS));
+
+        // multiple amounts
+        assertParseFailure(parser, "1" + TITLE_DESC_PHONE_BILL + AMOUNT_DESC_PHONE_BILL
+                        + AMOUNT_DESC_SPOTIFY_SUBSCRIPTION + CATEGORY_DESC_UTILITIES,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_AMOUNT_CONSTRAINTS));
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/EditBookmarkExpenseCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/EditBookmarkExpenseCommandParserTest.java
@@ -78,10 +78,6 @@ public class EditBookmarkExpenseCommandParserTest {
         assertParseFailure(parser, "1" + INVALID_AMOUNT_DESC + CATEGORY_DESC_UTILITIES,
                 Amount.MESSAGE_CONSTRAINTS);
 
-        // valid amount followed by invalid amount. The test case for invalid amount followed by valid amount
-        // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
-        assertParseFailure(parser, "1" + AMOUNT_DESC_PHONE_BILL + INVALID_AMOUNT_DESC, Amount.MESSAGE_CONSTRAINTS);
-
         // while parsing {@code PREFIX_CATEGORY} alone will reset the categories of the {@code BookmarkExpense} being
         // edited, parsing it together with a valid category results in error
         assertParseFailure(parser, "1" + CATEGORY_DESC_FOOD_BEVERAGE + CATEGORY_DESC_WORK + CATEGORY_EMPTY,

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/EditBookmarkIncomeCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/EditBookmarkIncomeCommandParserTest.java
@@ -78,10 +78,6 @@ public class EditBookmarkIncomeCommandParserTest {
         assertParseFailure(parser, "1" + INVALID_AMOUNT_DESC + CATEGORY_DESC_WORK,
                 Amount.MESSAGE_CONSTRAINTS);
 
-        // valid amount followed by invalid amount. The test case for invalid amount followed by valid amount
-        // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
-        assertParseFailure(parser, "1" + AMOUNT_DESC_PART_TIME + INVALID_AMOUNT_DESC, Amount.MESSAGE_CONSTRAINTS);
-
         // while parsing {@code PREFIX_CATEGORY} alone will reset the categories of the {@code BookmarkIncome} being
         // edited, parsing it together with a valid category results in error
         assertParseFailure(parser, "1" + CATEGORY_DESC_FOOD_BEVERAGE + CATEGORY_DESC_WORK + CATEGORY_EMPTY,

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/EditBookmarkIncomeCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/EditBookmarkIncomeCommandParserTest.java
@@ -2,6 +2,8 @@ package ay2021s1_cs2103_w16_3.finesse.logic.parser.bookmark;
 
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUNT_DESC_PART_TIME;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUNT_DESC_PHONE_BILL;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUNT_DESC_SPOTIFY_SUBSCRIPTION;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.CATEGORY_DESC_FOOD_BEVERAGE;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.CATEGORY_DESC_MISCELLANEOUS;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.CATEGORY_DESC_UTILITIES;
@@ -10,6 +12,8 @@ import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.INVAL
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.INVALID_CATEGORY_DESC;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.INVALID_TITLE_DESC;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.TITLE_DESC_PART_TIME;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.TITLE_DESC_PHONE_BILL;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.TITLE_DESC_SPOTIFY_SUBSCRIPTION;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_AMOUNT_PART_TIME;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_CATEGORY_MISCELLANEOUS;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_CATEGORY_UTILITIES;
@@ -28,6 +32,7 @@ import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.EditBookmarkIncomeCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.EditBookmarkTransactionDescriptor;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.bookmarkparsers.EditBookmarkIncomeCommandParser;
+import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkTransaction;
 import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
@@ -139,6 +144,20 @@ public class EditBookmarkIncomeCommandParserTest {
         descriptor = new EditBookmarkTransactionDescriptorBuilder().withCategories(VALID_CATEGORY_UTILITIES).build();
         expectedCommand = new EditBookmarkIncomeCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+
+    @Test
+    public void parse_multipleRepeatedFields_failure() {
+        // multiple titles
+        assertParseFailure(parser, "1" + TITLE_DESC_PHONE_BILL + TITLE_DESC_SPOTIFY_SUBSCRIPTION
+                        + AMOUNT_DESC_PHONE_BILL + CATEGORY_DESC_UTILITIES,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_TITLE_CONSTRAINTS));
+
+        // multiple amounts
+        assertParseFailure(parser, "1" + TITLE_DESC_PHONE_BILL + AMOUNT_DESC_PHONE_BILL
+                        + AMOUNT_DESC_SPOTIFY_SUBSCRIPTION + CATEGORY_DESC_UTILITIES,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_AMOUNT_CONSTRAINTS));
     }
 
     @Test


### PR DESCRIPTION
Resolves #216.

Restricts user command inputs to one title/amount/date for editing transactions and one title/amount for adding/editing bookmark transactions.