### PR TITLE
Modify duplicate check in bookmark expenses and incomes lists

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/bookmark/BookmarkExpense.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/bookmark/BookmarkExpense.java
@@ -14,6 +14,13 @@ public class BookmarkExpense extends BookmarkTransaction<Expense> {
         super(title, amount, categories);
     }
 
+    /**
+     * Returns true if the titles of both bookmark expenses are the same.
+     */
+    public boolean hasSameTitle(Object other) {
+        return other instanceof BookmarkExpense && getTitle().equals(((BookmarkExpense) other).getTitle());
+    }
+
     @Override
     public Expense convert(Date expenseDate) {
         Title title = getTitle();

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/bookmark/BookmarkExpenseList.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/bookmark/BookmarkExpenseList.java
@@ -35,11 +35,11 @@ public class BookmarkExpenseList implements Iterable<BookmarkExpense> {
     }
 
     /**
-     * Returns true if the bookmark expense list contains an equivalent bookmark expense as the given argument.
+     * Returns true if the bookmark expense list contains a bookmark expense with the same title as the given argument.
      */
     public boolean contains(BookmarkExpense toCheck) {
         requireNonNull(toCheck);
-        return internalBookmarkExpenseList.stream().anyMatch(toCheck::equals);
+        return internalBookmarkExpenseList.stream().anyMatch(toCheck::hasSameTitle);
     }
 
     /**

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/bookmark/BookmarkIncome.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/bookmark/BookmarkIncome.java
@@ -14,6 +14,13 @@ public class BookmarkIncome extends BookmarkTransaction<Income> {
         super(title, amount, categories);
     }
 
+    /**
+     * Returns true if the titles of both bookmark incomes are the same.
+     */
+    public boolean hasSameTitle(Object other) {
+        return other instanceof BookmarkIncome && getTitle().equals(((BookmarkIncome) other).getTitle());
+    }
+
     @Override
     public Income convert(Date date) {
         Title title = getTitle();

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/bookmark/BookmarkIncomeList.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/bookmark/BookmarkIncomeList.java
@@ -35,11 +35,11 @@ public class BookmarkIncomeList implements Iterable<BookmarkIncome> {
     }
 
     /**
-     * Returns true if the bookmark income list contains an equivalent bookmark income as the given argument.
+     * Returns true if the bookmark income list contains a bookmark income with the same title as the given argument.
      */
     public boolean contains(BookmarkIncome toCheck) {
         requireNonNull(toCheck);
-        return internalBookmarkIncomeList.stream().anyMatch(toCheck::equals);
+        return internalBookmarkIncomeList.stream().anyMatch(toCheck::hasSameTitle);
     }
 
     /**


### PR DESCRIPTION
Resolves #227.

Changes:
* Add method `hasSameTitle` in `BookmarkExpense` and `BookmarkIncome` to check for the same `Title` fields between two  `BookmarkExpense` objects or two `BookmarkIncome` objects.
* Modify method `contains` in `BookmarkExpenseList` and `BookmarkIncomeList` to use `hasSameTitle` instead of `equals`