### PR TITLE
Add command history

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -786,7 +786,7 @@ Sets the monthly expense limit in the finance tracker to be `$400.00`.
 
 ### 4.8 Savings Goal
 
-Want to save up for the new PS5 but can't seem to no matter what? Fine$$e has you covered!
+Want to save up for the new PlayStation 5 but can't seem to no matter what? Fine$$e has you covered!
 The savings goal feature allows you to save consistently by setting a monthly savings goal, so that you can save up bit by bit and build good financial habits.
 Once the savings goal is set, it will be visible on the Overview tab along with your current savings for this month.
 
@@ -832,10 +832,26 @@ Exits the program.
 
 Format: `exit`
 
-### 4.11 Saving the data
+### 4.11 Saving the Data
 
 Fine$$e data is saved in the hard disk automatically after any command that changes the data.
 There is no need to save manually.
+
+### 4.12 Command History
+
+Accidentally entered the wrong command and wish to modify it without typing it out again fully?
+Simply press the ↑ or ↓ arrow keys on your keyboard to navigate through your command history.
+
+* The command history keeps track of the latest 50 commands entered.
+* The command input box must be focused on.
+* Press the ↑ arrow key to retrieve the previous commands.
+  * Each press of the ↑ arrow key retrieves the command immediately preceding the current command.
+  * If the current command is the earliest command that is being tracked, then pressing the ↑ arrow key does nothing.
+* Press the ↓ arrow key to retrieve the next commands.
+  * Each press of the ↓ arrow key retrieves the command immediately succeeding the current command.
+  * If the current command is the latest command that has been entered, then the command input box will be cleared upon pressing the ↓ arrow key.
+
+> :warning: &nbsp; Pressing either the ↑ or ↓ arrow keys will cause whatever text is currently in the command box to be overwritten.
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -832,18 +832,13 @@ Exits the program.
 
 Format: `exit`
 
-### 4.11 Saving the Data
-
-Fine$$e data is saved in the hard disk automatically after any command that changes the data.
-There is no need to save manually.
-
-### 4.12 Command History
+### 4.11 Command History
 
 Accidentally entered the wrong command and wish to modify it without typing it out again fully?
 Simply press the ↑ or ↓ arrow keys on your keyboard to navigate through your command history.
 
 * The command history keeps track of the latest 50 commands entered.
-* The command input box must be focused on.
+* The command input box must be focused on, i.e. ensure that the text cursor is blinking in the command input box.
 * Press the ↑ arrow key to retrieve the previous commands.
   * Each press of the ↑ arrow key retrieves the command immediately preceding the current command.
   * If the current command is the earliest command that is being tracked, then pressing the ↑ arrow key does nothing.
@@ -852,6 +847,11 @@ Simply press the ↑ or ↓ arrow keys on your keyboard to navigate through your
   * If the current command is the latest command that has been entered, then the command input box will be cleared upon pressing the ↓ arrow key.
 
 > :warning: &nbsp; Pressing either the ↑ or ↓ arrow keys will cause whatever text is currently in the command box to be overwritten.
+
+### 4.12 Saving the Data
+
+Fine$$e data is saved in the hard disk automatically after any command that changes the data.
+There is no need to save manually.
 
 --------------------------------------------------------------------------------------------------------------------
 
@@ -881,12 +881,13 @@ Exit | `exit`
 
 ## 6. Glossary
 
-* Expense: A one-time transaction that results in a decrease in the amount of money you have.
-* Income: A one-time transaction that results in an increase in the amount of money you have.
 * ASCII: Characters that are recognised by a computer.
-* Current date: The system date on the computer on which Fine$$e is set up.
 * Bookmark Expense: A template for an expense, which can be used to create expenses and add them to the finance tracker.
 * Bookmark Income: A template for an income, which can be used to create incomes and add them to the finance tracker.
+* Current date: The system date on the computer on which Fine$$e is set up.
+* Expense: A one-time transaction that results in a decrease in the amount of money you have.
+* Income: A one-time transaction that results in an increase in the amount of money you have.
+* Text cursor: A blinking vertical line that indicates where text will be placed when entered.
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/command/history/CommandHistory.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/command/history/CommandHistory.java
@@ -1,0 +1,70 @@
+package ay2021s1_cs2103_w16_3.finesse.model.command.history;
+
+/**
+ * Keeps track of the user input history as well as the command history navigation state.
+ */
+public class CommandHistory {
+    /** An {@code EvictingStack} to keep track of the command history. **/
+    private final EvictingStack<String> commandHistory;
+    /** A reference to the current {@code Node} in the current command navigation state. **/
+    private Node<String> currentNode;
+
+    /**
+     * Creates a new {@code CommandHistory} which keeps track of the most recent commands.
+     *
+     * @param maxCommands The number of recent commands to keep track of.
+     * @throws IllegalArgumentException If the specified maximum commands is not at least 1.
+     */
+    public CommandHistory(int maxCommands) {
+        if (maxCommands < 1) {
+            throw new IllegalArgumentException("Maximum number of commands must be at least 1.");
+        }
+        commandHistory = new EvictingStack<>(maxCommands);
+    }
+
+    /**
+     * Adds a command to the command history and resets the state of the command navigation.
+     *
+     * @param command The command to be added.
+     */
+    public void addCommand(String command) {
+        commandHistory.push(command);
+        currentNode = null;
+    }
+
+    /**
+     * Returns the previous command in the current command navigation state. If the current
+     * command is already the earliest tracked command, then the current command is returned.
+     * If the command history is empty, returns an empty string.
+     *
+     * @return The previous command.
+     */
+    public String navigateUp() {
+        if (currentNode == null && commandHistory.isEmpty()) {
+            return "";
+        } else if (currentNode == null) {
+            currentNode = commandHistory.getTopNode();
+        } else if (currentNode.hasPreviousNode()) {
+            currentNode = currentNode.getPreviousNode();
+        }
+        return currentNode.getValue();
+    }
+
+    /**
+     * Returns the next command in the current command navigation state. If the current
+     * command is already the latest tracked command, then {@code null} is returned.
+     * If the command history is empty, returns an empty string.
+     *
+     * @return The next command.
+     */
+    public String navigateDown() {
+        if (currentNode == null) {
+            return "";
+        } else if (currentNode.hasNextNode()) {
+            currentNode = currentNode.getNextNode();
+        } else {
+            return null;
+        }
+        return currentNode.getValue();
+    }
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/command/history/EvictingStack.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/command/history/EvictingStack.java
@@ -1,0 +1,136 @@
+package ay2021s1_cs2103_w16_3.finesse.model.command.history;
+
+import java.util.EmptyStackException;
+
+/**
+ * A stack that can hold a fixed number of elements. When pushing a new element
+ * onto an already full {@code EvictingStack}, the bottom-most element is removed.
+ */
+public class EvictingStack<E> {
+    /** The maximum size of this {@code EvictingStack}. **/
+    private final int maxSize;
+    /** The current size of this {@code EvictingStack}. **/
+    private int currentSize;
+    /** A reference to the top-most {@code Node}. **/
+    private Node<E> topNode;
+    /** A reference to the bottom-most {@code Node}. **/
+    private Node<E> bottomNode;
+
+    /**
+     * Constructs an empty {@code EvictingStack} with the specified maximum size.
+     *
+     * @param maxSize The maximum size of the {@code EvictingStack}.
+     * @throws IllegalArgumentException If the specified maximum size is not at least 1.
+     */
+    public EvictingStack(int maxSize) {
+        if (maxSize < 1) {
+            throw new IllegalArgumentException("Maximum size of the evicting stack must be at least 1.");
+        }
+        this.maxSize = maxSize;
+        currentSize = 0;
+    }
+
+    /**
+     * Removes the bottom-most element in this {@code EvictingStack}.
+     */
+    private void removeBottomElement() {
+        assert currentSize >= 1;
+
+        Node<E> nextNode = bottomNode.getNextNode();
+        bottomNode.removeLinks();
+        bottomNode = nextNode;
+        currentSize--;
+
+        // Set the top node to null if the stack is empty.
+        if (currentSize == 0) {
+            topNode = null;
+        }
+    }
+
+    /**
+     * Checks if this {@code EvictingStack} is empty.
+     *
+     * @return {@code true} if this {@code EvictingStack} is empty; {@code false} otherwise.
+     */
+    public boolean isEmpty() {
+        return currentSize == 0;
+    }
+
+    /**
+     * Pushes an element onto the top of this {@code EvictingStack}. If the
+     * stack is full, the bottom element is evicted.
+     *
+     * @param element The element to be pushed onto the stack.
+     * @return The element that was pushed onto the stack.
+     */
+    public E push(E element) {
+        // Evict the bottom-most element if the stack is full.
+        if (currentSize == maxSize) {
+            removeBottomElement();
+        }
+
+        assert currentSize < maxSize;
+
+        // Push the new element onto the stack.
+        Node<E> newNode = new Node<>(element);
+        if (topNode != null) {
+            Node.linkNodes(topNode, newNode);
+        }
+        topNode = newNode;
+        currentSize++;
+
+        // Set the bottom node to the new node if the stack was previously empty.
+        if (currentSize == 1) {
+            bottomNode = newNode;
+        }
+
+        return element;
+    }
+
+    /**
+     * Returns the value of the top-most element in this {@code EvictingStack}.
+     *
+     * @return The value of the element at the top of this {@code EvictingStack}.
+     * @throws EmptyStackException If this {@code EvictingStack} is empty.
+     */
+    public E peek() {
+        if (isEmpty()) {
+            throw new EmptyStackException();
+        }
+        return topNode.getValue();
+    }
+
+    /**
+     * Removes the top-most element from this {@code EvictingStack} and returns it.
+     *
+     * @return The value of the element at the top of this {@code EvictingStack}.
+     */
+    public E pop() {
+        if (isEmpty()) {
+            throw new EmptyStackException();
+        }
+
+        // Pop the top-most element from the stack.
+        E element = topNode.getValue();
+        Node<E> previousNode = topNode.getPreviousNode();
+        topNode.removeLinks();
+        topNode = previousNode;
+        currentSize--;
+
+        // Set the bottom node to null if the stack is empty.
+        if (currentSize == 0) {
+            bottomNode = null;
+        }
+
+        return element;
+    }
+
+    /**
+     * Returns the {@code Node} containing the top-most element of this {@code EvictingStack}.
+     *
+     * @return The {@code Node} containing the top-most element of this {@code EvictingStack}.
+     */
+    public Node<E> getTopNode() {
+        return topNode;
+    }
+}

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/command/history/Node.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/command/history/Node.java
@@ -1,0 +1,113 @@
+package ay2021s1_cs2103_w16_3.finesse.model.command.history;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A node in a doubly linked list.
+ */
+public class Node<E> {
+    /** The value contained in this {@code Node}. **/
+    private final E value;
+    /** A reference to the next {@code Node}. **/
+    private Node<E> nextNode;
+    /** A reference to the previous {@code Node}. **/
+    private Node<E> previousNode;
+
+    /**
+     * Creates a new {@code Node} containing the specified value.
+     *
+     * @param value The value to be contained in this {@code Node}.
+     */
+    public Node(E value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns the value that is contained in this {@code Node}.
+     *
+     * @return The value that is contained in this {@code Node}.
+     */
+    public E getValue() {
+        return value;
+    }
+
+    /**
+     * Returns the {@code Node} that comes after this {@code Node}.
+     *
+     * @return The next {@code Node}.
+     */
+    public Node<E> getNextNode() {
+        return nextNode;
+    }
+
+    /**
+     * Returns the {@code Node} that comes before this {@code Node}.
+     *
+     * @return The previous {@code Node}.
+     */
+    public Node<E> getPreviousNode() {
+        return previousNode;
+    }
+
+    /**
+     * Returns whether there exists a node that comes after this {@code Node}.
+     *
+     * @return {@code true} if {@code nextNode} is not {@code null}; false otherwise.
+     */
+    public boolean hasNextNode() {
+        return nextNode != null;
+    }
+
+    /**
+     * Returns whether there exists a node that comes before this {@code Node}.
+     *
+     * @return {@code true} if {@code previousNode} is not {@code null}; false otherwise;
+     */
+    public boolean hasPreviousNode() {
+        return previousNode != null;
+    }
+
+    /**
+     * Links two nodes together by setting the respective nodes to point to each other.
+     * {@code firstNode} will have its {@code nextNode} be set to {@code secondNode}, while
+     * {@code secondNode} will have its {@code previousNode} be set to {@code firstNode}.
+     * If linking the two nodes together overrides existing links, the linking fails and
+     * {@code false} will be returned.
+     *
+     * @param firstNode The {@code Node} that comes before in the link.
+     * @param secondNode The {@code Node} that comes after in the link.
+     * @param <E> The type of the two {@code Node}s.
+     * @return {@code true} if the two nodes are successfully linked; {@code false} otherwise.
+     */
+    public static <E> boolean linkNodes(Node<E> firstNode, Node<E> secondNode) {
+        requireNonNull(firstNode);
+        requireNonNull(secondNode);
+
+        // Do not override existing links.
+        if (firstNode.hasNextNode() || secondNode.hasPreviousNode()) {
+            return false;
+        }
+
+        firstNode.nextNode = secondNode;
+        secondNode.previousNode = firstNode;
+
+        return true;
+    }
+
+    /**
+     * Removes all links for this {@code Node}.
+     */
+    public void removeLinks() {
+        // Remove link with the node that comes after this node.
+        if (nextNode != null) {
+            nextNode.previousNode = null;
+            nextNode = null;
+        }
+
+        // Remove link with the node that comes before this node.
+        if (previousNode != null) {
+            previousNode.nextNode = null;
+            previousNode = null;
+        }
+    }
+}

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/command/history/CommandHistoryTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/command/history/CommandHistoryTest.java
@@ -1,0 +1,48 @@
+package ay2021s1_cs2103_w16_3.finesse.model.command.history;
+
+import static ay2021s1_cs2103_w16_3.finesse.testutil.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+public class CommandHistoryTest {
+    @Test
+    public void constructor_invalidMaxCommands_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> new CommandHistory(0));
+        assertThrows(IllegalArgumentException.class, () -> new CommandHistory(-10));
+    }
+
+    @Test
+    public void addAndNavigateCommands() {
+        CommandHistory commandHistory = new CommandHistory(5);
+        IntStream.range(1, 9).mapToObj(i -> "Command " + i).forEach(commandHistory::addCommand);
+
+        // Check that the order of command history is maintained backwards.
+        assertEquals("Command 8", commandHistory.navigateUp());
+        assertEquals("Command 7", commandHistory.navigateUp());
+        assertEquals("Command 6", commandHistory.navigateUp());
+        assertEquals("Command 5", commandHistory.navigateUp());
+        assertEquals("Command 4", commandHistory.navigateUp());
+        // Check that the earliest commands are evicted.
+        assertEquals("Command 4", commandHistory.navigateUp());
+        // Check that the order of command history is maintained forwards.
+        assertEquals("Command 5", commandHistory.navigateDown());
+        assertEquals("Command 6", commandHistory.navigateDown());
+        assertEquals("Command 7", commandHistory.navigateDown());
+        assertEquals("Command 8", commandHistory.navigateDown());
+        // Check that navigating past the most recent command returns null.
+        assertNull(commandHistory.navigateDown());
+    }
+
+    @Test
+    public void navigate_emptyCommandHistory_returnsEmptyString() {
+        CommandHistory commandHistory = new CommandHistory(5);
+
+        // Check that the empty string is returned when the command history is empty.
+        assertEquals("", commandHistory.navigateUp());
+        assertEquals("", commandHistory.navigateDown());
+    }
+}

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/command/history/EvictingStackTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/command/history/EvictingStackTest.java
@@ -1,0 +1,64 @@
+package ay2021s1_cs2103_w16_3.finesse.model.command.history;
+
+import static ay2021s1_cs2103_w16_3.finesse.testutil.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.EmptyStackException;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+public class EvictingStackTest {
+    @Test
+    public void constructor_invalidMaxSize_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> new EvictingStack<Integer>(0));
+        assertThrows(IllegalArgumentException.class, () -> new EvictingStack<Integer>(-10));
+    }
+
+    @Test
+    public void push_moreElementsThanMaxSize_bottomElementEvicted() {
+        EvictingStack<Integer> evictingStack = new EvictingStack<>(1);
+        assertTrue(evictingStack.isEmpty());
+        evictingStack.push(1);
+        assertFalse(evictingStack.isEmpty());
+        evictingStack.push(2);
+        assertEquals(2, evictingStack.pop());
+        // Check that element 1 is no longer in the stack.
+        assertTrue(evictingStack.isEmpty());
+    }
+
+    @Test
+    public void peek_emptyEvictingStack_throwsEmptyStackException() {
+        EvictingStack<Integer> evictingStack = new EvictingStack<>(5);
+        assertThrows(EmptyStackException.class, evictingStack::peek);
+    }
+
+    @Test
+    public void pop_emptyEvictingStack_throwsEmptyStackException() {
+        EvictingStack<Integer> evictingStack = new EvictingStack<>(5);
+        assertThrows(EmptyStackException.class, evictingStack::pop);
+    }
+
+    @Test
+    public void getTopNode_iterateThroughStack_correctNumberOfNodes() {
+        EvictingStack<Integer> evictingStack = new EvictingStack<>(5);
+        IntStream.range(1, 9).forEach(evictingStack::push);
+
+        // Check that the top-most element is 8.
+        assertEquals(8, evictingStack.peek());
+
+        // Check that the stack only holds the maximum of 5 elements.
+        Node<Integer> node = evictingStack.getTopNode();
+        int numOfNodes = 1;
+        while (node.hasPreviousNode()) {
+            node = node.getPreviousNode();
+            numOfNodes++;
+        }
+        assertEquals(5, numOfNodes);
+
+        // Check that the bottom-most element is 4.
+        assertEquals(4, node.getValue());
+    }
+}

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/command/history/NodeTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/command/history/NodeTest.java
@@ -1,0 +1,94 @@
+package ay2021s1_cs2103_w16_3.finesse.model.command.history;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class NodeTest {
+    @Test
+    public void contructor() {
+        String value = "Hello World";
+        Node<String> node = new Node<>(value);
+
+        assertEquals(value, node.getValue());
+    }
+
+    @Test
+    public void linkNodes_noLinkConflicts_returnsTrue() {
+        Node<Integer> firstNode = new Node<>(1);
+        Node<Integer> secondNode = new Node<>(2);
+
+        assertTrue(Node.linkNodes(firstNode, secondNode));
+
+        // Check that the link was successfully created.
+        assertFalse(firstNode.hasPreviousNode());
+        assertTrue(firstNode.hasNextNode());
+        assertTrue(secondNode.hasPreviousNode());
+        assertFalse(secondNode.hasNextNode());
+
+        assertEquals(secondNode, firstNode.getNextNode());
+        assertEquals(firstNode, secondNode.getPreviousNode());
+    }
+
+    @Test
+    public void linkNodes_hasLinkConflicts_returnsFalse() {
+        Node<Integer> firstNode = new Node<>(1);
+        Node<Integer> secondNode = new Node<>(2);
+        Node<Integer> thirdNode = new Node<>(3);
+
+        assertTrue(Node.linkNodes(firstNode, secondNode));
+        assertFalse(Node.linkNodes(firstNode, thirdNode));
+
+        // Check that the link between firstNode and secondNode was not created.
+        assertFalse(firstNode.hasPreviousNode());
+        assertTrue(firstNode.hasNextNode());
+        assertFalse(thirdNode.hasPreviousNode());
+        assertFalse(thirdNode.hasNextNode());
+
+        assertEquals(secondNode, firstNode.getNextNode());
+        assertNull(thirdNode.getPreviousNode());
+    }
+
+    @Test
+    public void linkNodes_nullNode_throwsNullPointerException() {
+        Node<Integer> node = new Node<>(1);
+
+        assertThrows(NullPointerException.class, () -> Node.linkNodes(node, null));
+        assertThrows(NullPointerException.class, () -> Node.linkNodes(null, node));
+        assertThrows(NullPointerException.class, () -> Node.linkNodes(null, null));
+    }
+
+    @Test
+    public void removeLinks() {
+        Node<Integer> firstNode = new Node<>(1);
+        Node<Integer> secondNode = new Node<>(2);
+        Node<Integer> thirdNode = new Node<>(3);
+
+        // Create a circular chain of nodes.
+        assertTrue(Node.linkNodes(firstNode, secondNode));
+        assertTrue(Node.linkNodes(secondNode, thirdNode));
+        assertTrue(Node.linkNodes(thirdNode, firstNode));
+
+        // Check that all nodes have previous and next links.
+        assertTrue(firstNode.hasPreviousNode());
+        assertTrue(firstNode.hasNextNode());
+        assertTrue(secondNode.hasPreviousNode());
+        assertTrue(secondNode.hasNextNode());
+        assertTrue(thirdNode.hasPreviousNode());
+        assertTrue(thirdNode.hasNextNode());
+
+        secondNode.removeLinks();
+
+        // Check that all links with secondNode are be removed.
+        assertTrue(firstNode.hasPreviousNode());
+        assertFalse(firstNode.hasNextNode());
+        assertFalse(secondNode.hasPreviousNode());
+        assertFalse(secondNode.hasNextNode());
+        assertFalse(thirdNode.hasPreviousNode());
+        assertTrue(thirdNode.hasNextNode());
+    }
+}


### PR DESCRIPTION
Changes:
- Track the 50 most recent commands input.
  - This is achieved using an `EvictingStack`, a stack that evicts its bottom-most element when pushing a new element while it is full. It is backed by a doubly linked list.
- Set up cycling through the command history by listening for key events on the command box.
- Add section on `Command History` in the user guide.
- Add tests for the new classes.

Resolves #229.