### PR TITLE
Add additional parser method for parsing title

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -549,7 +549,7 @@ Shortcut: `addbe t/TITLE a/AMOUNT [c/CATEGORY...]`
 > Bookmark expenses with the same title are considered to be duplicates of each other.
 > Contiguous whitespace characters between words in the title will be treated as a single whitespace character.
 >
-> For example: `Phone Bill` and `Phone  Bill` are considered to be the same title while `Phone Bill` and `PhoneBill` are not considered to be the same title.
+> For example: `Phone Bill` and `Phone  Bill` are considered to be the same title while `Phone Bill` and `PhoneBill` are not considered to be the same title.
 
 Examples:
 * `add-bookmark-expense t/Phone Bill a/60 c/Utilities c/Personal`
@@ -683,7 +683,7 @@ Shortcut: `addbi t/TITLE a/AMOUNT [c/CATEGORY...]`
 > Bookmark incomes with the same title are considered to be duplicates of each other.
 > Contiguous whitespace characters between words in the title will be treated as a single whitespace character.
 >
-> For example: `Part Time` and `Part  Time` are considered to be the same title while `Part Time` and `PartTime` are not considered to be the same title.
+> For example: `Part Time` and `Part  Time` are considered to be the same title while `Part Time` and `PartTime` are not considered to be the same title.
 
 Examples:
 * `add-bookmark-income t/Internship a/$1000 c/Work`
@@ -875,7 +875,7 @@ Format: `exit`
 Accidentally entered the wrong command and wish to modify it without typing it out again fully?
 Simply press the ↑ or ↓ arrow keys on your keyboard to navigate through your command history.
 
-* The command history keeps track of the latest 50 commands entered.
+* The command history keeps track of the latest 50 commands entered in the current session.
 * The command input box must be focused on, i.e. ensure that the text cursor is blinking in the command input box.
 * Press the ↑ arrow key to retrieve the previous commands.
   * Each press of the ↑ arrow key retrieves the command immediately preceding the current command.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -545,6 +545,12 @@ Shortcut: `addbe t/TITLE a/AMOUNT [c/CATEGORY...]`
 
 * `CATEGORY` is optional. Multiple `c/` prefixes can be used to specify multiple categories.
 
+> :warning: &nbsp; Adding of duplicate bookmark expenses is not allowed.
+> Bookmark expenses with the same title are considered to be duplicates of each other.
+> Contiguous whitespace characters between words in the title will be treated as a single whitespace character.
+>
+> For example: `Phone Bill` and `Phone  Bill` are considered to be the same title while `Phone Bill` and `PhoneBill` are not considered to be the same title.
+
 Examples:
 * `add-bookmark-expense t/Phone Bill a/60 c/Utilities c/Personal`
 * `add-bookmark-expense t/Spotify Subscription a/$9 c/Others`
@@ -656,7 +662,7 @@ specified bookmark expense and date `10/08/2020`, and adds it to the expenses li
 
 ### 4.6 Bookmark Income
 
-Fine<span>$</span><span>$</span>e's Bookmark Income feature is used to store incomes that the user receives frequently, such as monthly salary or stipend for being a teaching assistant.
+Fine<span>$<span><span>$<span>e's Bookmark Income feature is used to store incomes that the user receives frequently, such as monthly salary or stipend for being a teaching assistant.
 The user will then be able to edit, delete and convert a bookmark income to conveniently add it into Fine\\$\\$e's incomes list.
 
 ![Overview Bookmark Income Panel](images/userguide/bookmark/AnnotatedBookmarkIncomeOverview.png)
@@ -672,6 +678,12 @@ Format: `add-bookmark-income t/TITLE a/AMOUNT [c/CATEGORY...]`
 Shortcut: `addbi t/TITLE a/AMOUNT [c/CATEGORY...]`
 
 * `CATEGORY` is optional. Multiple `c/` prefixes can be used to specify multiple categories.
+
+> :warning: &nbsp; Adding of duplicate bookmark incomes is not allowed.
+> Bookmark incomes with the same title are considered to be duplicates of each other.
+> Contiguous whitespace characters between words in the title will be treated as a single whitespace character.
+>
+> For example: `Part Time` and `Part  Time` are considered to be the same title while `Part Time` and `PartTime` are not considered to be the same title.
 
 Examples:
 * `add-bookmark-income t/Internship a/$1000 c/Work`

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtil.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtil.java
@@ -50,6 +50,23 @@ public class ParserUtil {
     }
 
     /**
+     * Parses a {@code String title} into a {@code Title}.
+     * Leading and trailing whitespaces will be trimmed.
+     * Any extra whitespaces between words will be removed.
+     *
+     * @throws ParseException if the given {@code title} is invalid.
+     */
+    public static Title parseTitleWithAdditionalWhiteSpaces(String title) throws ParseException {
+        requireNonNull(title);
+        String removedExtraWhiteSpacesTitle = title.replaceAll("\\s{2,}", " ");
+        String trimmedTitle = removedExtraWhiteSpacesTitle.trim();
+        if (!Title.isValidTitle(trimmedTitle)) {
+            throw new ParseException(Title.MESSAGE_CONSTRAINTS);
+        }
+        return new Title(trimmedTitle);
+    }
+
+    /**
      * Parses a {@code String amount} into a {@code Amount}.
      * Leading and trailing whitespaces will be trimmed.
      *

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtil.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtil.java
@@ -58,8 +58,8 @@ public class ParserUtil {
      */
     public static Title parseTitleWithAdditionalWhitespace(String title) throws ParseException {
         requireNonNull(title);
-        String removedExtraWhiteSpaceTitle = title.replaceAll("\\s{2,}", " ");
-        return parseTitle(removedExtraWhiteSpaceTitle);
+        String removedExtraWhitespaceTitle = title.replaceAll("\\s{2,}", " ");
+        return parseTitle(removedExtraWhitespaceTitle);
     }
 
     /**

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtil.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtil.java
@@ -56,14 +56,10 @@ public class ParserUtil {
      *
      * @throws ParseException if the given {@code title} is invalid.
      */
-    public static Title parseTitleWithAdditionalWhitespaces(String title) throws ParseException {
+    public static Title parseTitleWithAdditionalWhitespace(String title) throws ParseException {
         requireNonNull(title);
-        String removedExtraWhiteSpacesTitle = title.replaceAll("\\s{2,}", " ");
-        String trimmedTitle = removedExtraWhiteSpacesTitle.trim();
-        if (!Title.isValidTitle(trimmedTitle)) {
-            throw new ParseException(Title.MESSAGE_CONSTRAINTS);
-        }
-        return new Title(trimmedTitle);
+        String removedExtraWhiteSpaceTitle = title.replaceAll("\\s{2,}", " ");
+        return parseTitle(removedExtraWhiteSpaceTitle);
     }
 
     /**

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtil.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtil.java
@@ -56,7 +56,7 @@ public class ParserUtil {
      *
      * @throws ParseException if the given {@code title} is invalid.
      */
-    public static Title parseTitleWithAdditionalWhiteSpaces(String title) throws ParseException {
+    public static Title parseTitleWithAdditionalWhitespaces(String title) throws ParseException {
         requireNonNull(title);
         String removedExtraWhiteSpacesTitle = title.replaceAll("\\s{2,}", " ");
         String trimmedTitle = removedExtraWhiteSpacesTitle.trim();

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/AddBookmarkExpenseCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/AddBookmarkExpenseCommandParser.java
@@ -48,7 +48,7 @@ public class AddBookmarkExpenseCommandParser implements Parser<AddBookmarkExpens
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_AMOUNT_CONSTRAINTS));
         }
 
-        Title title = ParserUtil.parseTitleWithAdditionalWhitespaces(argMultimap.getValue(PREFIX_TITLE).get());
+        Title title = ParserUtil.parseTitleWithAdditionalWhitespace(argMultimap.getValue(PREFIX_TITLE).get());
         Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
         Set<Category> categoryList = ParserUtil.parseCategories(argMultimap.getAllValues(PREFIX_CATEGORY));
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/AddBookmarkExpenseCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/AddBookmarkExpenseCommandParser.java
@@ -48,7 +48,7 @@ public class AddBookmarkExpenseCommandParser implements Parser<AddBookmarkExpens
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_AMOUNT_CONSTRAINTS));
         }
 
-        Title title = ParserUtil.parseTitleWithAdditionalWhiteSpaces(argMultimap.getValue(PREFIX_TITLE).get());
+        Title title = ParserUtil.parseTitleWithAdditionalWhitespaces(argMultimap.getValue(PREFIX_TITLE).get());
         Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
         Set<Category> categoryList = ParserUtil.parseCategories(argMultimap.getAllValues(PREFIX_CATEGORY));
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/AddBookmarkExpenseCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/AddBookmarkExpenseCommandParser.java
@@ -48,7 +48,7 @@ public class AddBookmarkExpenseCommandParser implements Parser<AddBookmarkExpens
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_AMOUNT_CONSTRAINTS));
         }
 
-        Title title = ParserUtil.parseTitle(argMultimap.getValue(PREFIX_TITLE).get());
+        Title title = ParserUtil.parseTitleWithAdditionalWhiteSpaces(argMultimap.getValue(PREFIX_TITLE).get());
         Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
         Set<Category> categoryList = ParserUtil.parseCategories(argMultimap.getAllValues(PREFIX_CATEGORY));
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/AddBookmarkIncomeCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/AddBookmarkIncomeCommandParser.java
@@ -45,7 +45,7 @@ public class AddBookmarkIncomeCommandParser implements Parser<AddBookmarkIncomeC
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_AMOUNT_CONSTRAINTS));
         }
 
-        Title title = ParserUtil.parseTitle(argMultimap.getValue(PREFIX_TITLE).get());
+        Title title = ParserUtil.parseTitleWithAdditionalWhiteSpaces(argMultimap.getValue(PREFIX_TITLE).get());
         Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
         Set<Category> categoryList = ParserUtil.parseCategories(argMultimap.getAllValues(PREFIX_CATEGORY));
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/AddBookmarkIncomeCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/AddBookmarkIncomeCommandParser.java
@@ -45,7 +45,7 @@ public class AddBookmarkIncomeCommandParser implements Parser<AddBookmarkIncomeC
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_AMOUNT_CONSTRAINTS));
         }
 
-        Title title = ParserUtil.parseTitleWithAdditionalWhitespaces(argMultimap.getValue(PREFIX_TITLE).get());
+        Title title = ParserUtil.parseTitleWithAdditionalWhitespace(argMultimap.getValue(PREFIX_TITLE).get());
         Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
         Set<Category> categoryList = ParserUtil.parseCategories(argMultimap.getAllValues(PREFIX_CATEGORY));
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/AddBookmarkIncomeCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/AddBookmarkIncomeCommandParser.java
@@ -45,7 +45,7 @@ public class AddBookmarkIncomeCommandParser implements Parser<AddBookmarkIncomeC
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_AMOUNT_CONSTRAINTS));
         }
 
-        Title title = ParserUtil.parseTitleWithAdditionalWhiteSpaces(argMultimap.getValue(PREFIX_TITLE).get());
+        Title title = ParserUtil.parseTitleWithAdditionalWhitespaces(argMultimap.getValue(PREFIX_TITLE).get());
         Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
         Set<Category> categoryList = ParserUtil.parseCategories(argMultimap.getAllValues(PREFIX_CATEGORY));
 

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtilTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtilTest.java
@@ -77,12 +77,12 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseTitleWithAdditionalWhitespaces_returnsTitle() throws Exception {
+    public void parseTitleWithAdditionalWhitespace_returnsTitle() throws Exception {
         String moreThanOneWhitespace = WHITESPACE + WHITESPACE + WHITESPACE;
-        String titleWithExtraWhitespacesBetweenWords = VALID_TITLE.replaceAll(WHITESPACE, moreThanOneWhitespace);
+        String titleWithExtraWhitespaceBetweenWords = VALID_TITLE.replaceAll(WHITESPACE, moreThanOneWhitespace);
         Title expectedTitle = new Title(VALID_TITLE);
         assertEquals(expectedTitle,
-                ParserUtil.parseTitleWithAdditionalWhitespaces(titleWithExtraWhitespacesBetweenWords));
+                ParserUtil.parseTitleWithAdditionalWhitespace(titleWithExtraWhitespaceBetweenWords));
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtilTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtilTest.java
@@ -25,7 +25,7 @@ public class ParserUtilTest {
     private static final String INVALID_DATE = "example.com";
     private static final String INVALID_CATEGORY = "\u2416friend";
 
-    private static final String VALID_TITLE = "Rachel Walker";
+    private static final String VALID_TITLE = "Phone Bill";
     private static final String VALID_AMOUNT = "123456";
     private static final String VALID_DATE = "01/01/2020";
     private static final String VALID_CATEGORY_1 = "friend";
@@ -74,6 +74,15 @@ public class ParserUtilTest {
         String titleWithWhitespace = WHITESPACE + VALID_TITLE + WHITESPACE;
         Title expectedTitle = new Title(VALID_TITLE);
         assertEquals(expectedTitle, ParserUtil.parseTitle(titleWithWhitespace));
+    }
+
+    @Test
+    public void parseTitleWithAdditionalWhiteSpaces_returnsTitle() throws Exception {
+        String moreThanOneWhitespace = WHITESPACE + WHITESPACE + WHITESPACE;
+        String titleWithExtraWhitespacesBetweenWords = VALID_TITLE.replaceAll(WHITESPACE, moreThanOneWhitespace);
+        Title expectedTitle = new Title(VALID_TITLE);
+        assertEquals(expectedTitle,
+                ParserUtil.parseTitleWithAdditionalWhiteSpaces(titleWithExtraWhitespacesBetweenWords));
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtilTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtilTest.java
@@ -77,7 +77,7 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseTitleWithAdditionalWhiteSpaces_returnsTitle() throws Exception {
+    public void parseTitleWithAdditionalWhitespaces_returnsTitle() throws Exception {
         String moreThanOneWhitespace = WHITESPACE + WHITESPACE + WHITESPACE;
         String titleWithExtraWhitespacesBetweenWords = VALID_TITLE.replaceAll(WHITESPACE, moreThanOneWhitespace);
         Title expectedTitle = new Title(VALID_TITLE);

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtilTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtilTest.java
@@ -82,7 +82,7 @@ public class ParserUtilTest {
         String titleWithExtraWhitespacesBetweenWords = VALID_TITLE.replaceAll(WHITESPACE, moreThanOneWhitespace);
         Title expectedTitle = new Title(VALID_TITLE);
         assertEquals(expectedTitle,
-                ParserUtil.parseTitleWithAdditionalWhiteSpaces(titleWithExtraWhitespacesBetweenWords));
+                ParserUtil.parseTitleWithAdditionalWhitespaces(titleWithExtraWhitespacesBetweenWords));
     }
 
     @Test


### PR DESCRIPTION
Resolves #241.
Resolves #249.

Added an additional parser method to parse titles with more than 1 white space between words. This is done to avoid any unintentional duplicate `Bookmark Expense` or `Bookmark Income` being added to the finance tracker.

Changes:
* Added `parseTitleWithAdditionalWhitespace` method in `ParserUtil` to remove extra whitespaces between words in a `Title`. 
* Updated user guide to include a description on what consists as a duplicate bookmark transaction.