### PR TITLE
Explicitly list out printable ASCII characters

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -167,7 +167,12 @@ This section aims to provide you with in-depth details on Fine\$\$e's unique fea
 
 The formats of the parameters used in the rest of the document are as follows:
 * `TITLE` and `CATEGORY` should consist of printable ASCII characters, and cannot begin with a space.
-  * Printable ASCII characters consist of alphanumeric characters `0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz`, space, and the special characters ``!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~``.
+  * The set of printable ASCII characters consists of alphanumeric characters, space, and several special characters.
+    Below is an exhaustive list of printable ASCII characters (excluding line breaks):
+  ```
+0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl
+mnopqrstuvwxyz !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
+  ```
 * `AMOUNT`, `AMOUNT_FROM` and `AMOUNT_TO` should be non-negative numbers up to 8 digits with 0 or 2 decimal places, with an optional `$` in front.
 * `DATE`, `DATE_FROM` and `DATE_TO` should be in `dd/mm/yyyy` format, and cannot be later than the current date.
 * `INDEX` should be a positive integer.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -166,7 +166,8 @@ This section aims to provide you with in-depth details on Fine\$\$e's unique fea
 **:warning: &nbsp; IMPORTANT &nbsp; :warning:**<br>
 
 The formats of the parameters used in the rest of the document are as follows:
-* `TITLE` and `CATEGORY` should consist of <abbr title="Alphanumeric characters, space, and the special characters !&quot;#$%&'()*+,-./:;&lt;=&gt;?@[\]^_`{\|}~">printable ASCII characters</abbr>, and cannot begin with a space.
+* `TITLE` and `CATEGORY` should consist of printable ASCII characters, and cannot begin with a space.
+  * Printable ASCII characters consist of alphanumeric characters `0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz`, space, and the special characters ``!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~``.
 * `AMOUNT`, `AMOUNT_FROM` and `AMOUNT_TO` should be non-negative numbers up to 8 digits with 0 or 2 decimal places, with an optional `$` in front.
 * `DATE`, `DATE_FROM` and `DATE_TO` should be in `dd/mm/yyyy` format, and cannot be later than the current date.
 * `INDEX` should be a positive integer.

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/category/Category.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/category/Category.java
@@ -10,7 +10,8 @@ import static java.util.Objects.requireNonNull;
 public class Category {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Category names should contain at least one non-whitespace printable ASCII character.";
+            "Category names should contain at least one non-whitespace printable ASCII character "
+            + "and cannot contain any characters that are not printable ASCII characters.";
     public static final String VALIDATION_REGEX = "\\p{Graph}\\p{Print}*";
 
     private final String categoryName;

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Title.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Title.java
@@ -10,7 +10,8 @@ import static java.util.Objects.requireNonNull;
 public class Title implements Comparable<Title> {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Titles should contain at least one non-whitespace printable ASCII character.";
+            "Titles should contain at least one non-whitespace printable ASCII character "
+            + "and cannot contain any characters that are not printable ASCII characters.";
     public static final String VALIDATION_REGEX = "\\p{Graph}\\p{Print}*";
 
     private final String fullTitle;

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/category/CategoryTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/category/CategoryTest.java
@@ -49,6 +49,8 @@ public class CategoryTest {
         // 'at least one non-whitespace printable ASCII character' restriction.
         assertTrue(Category.isValidCategoryName(categoryNamePrefix));
 
+        // Each character is its own equivalence partition.
+
         // Check that the ASCII control characters (char codes 0 to 31 inclusive) are invalid.
         IntStream.range(0, 32).forEach(i ->
                 assertFalse(Category.isValidCategoryName(categoryNamePrefix + getCharFromCharCode(i))));

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/category/CategoryTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/category/CategoryTest.java
@@ -4,6 +4,8 @@ import static ay2021s1_cs2103_w16_3.finesse.testutil.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.stream.IntStream;
+
 import org.junit.jupiter.api.Test;
 
 public class CategoryTest {
@@ -39,4 +41,35 @@ public class CategoryTest {
         assertTrue(Category.isValidCategoryName("peter*")); // contains non-alphanumeric characters
     }
 
+    @Test
+    public void asciiTest() {
+        String categoryNamePrefix = "Test: ";
+
+        // Check that the category name prefix is valid. It will need to be used to get around the
+        // 'at least one non-whitespace printable ASCII character' restriction.
+        assertTrue(Category.isValidCategoryName(categoryNamePrefix));
+
+        // Check that the ASCII control characters (char codes 0 to 31 inclusive) are invalid.
+        IntStream.range(0, 32).forEach(i ->
+                assertFalse(Category.isValidCategoryName(categoryNamePrefix + getCharFromCharCode(i))));
+
+        // Check that the ASCII printable characters (char codes 32 to 126 inclusive) are valid.
+        IntStream.range(32, 127).forEach(i ->
+                assertTrue(Category.isValidCategoryName(categoryNamePrefix + getCharFromCharCode(i))));
+
+        // Check that the ASCII delete character (char code 127) is invalid.
+        assertFalse(Category.isValidCategoryName(categoryNamePrefix + getCharFromCharCode(127)));
+
+        // Check that extended ASCII characters (char codes 128 to 255 inclusive) are invalid.
+        IntStream.range(128, 256).forEach(i ->
+                assertFalse(Category.isValidCategoryName(categoryNamePrefix + getCharFromCharCode(i))));
+
+        // Check that Unicode characters are invalid.
+        IntStream.iterate(300, i -> i <= 10000, i -> i + 100).forEach(i ->
+                assertFalse(Category.isValidCategoryName(categoryNamePrefix + getCharFromCharCode(i))));
+    }
+
+    private String getCharFromCharCode(int i) {
+        return Character.toString((char) i);
+    }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/TitleTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/TitleTest.java
@@ -49,6 +49,8 @@ public class TitleTest {
         // 'at least one non-whitespace printable ASCII character' restriction.
         assertTrue(Title.isValidTitle(titlePrefix));
 
+        // Each character is its own equivalence partition.
+
         // Check that the ASCII control characters (char codes 0 to 31 inclusive) are invalid.
         IntStream.range(0, 32).forEach(i ->
                 assertFalse(Title.isValidTitle(titlePrefix + getCharFromCharCode(i))));

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/TitleTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/TitleTest.java
@@ -4,6 +4,8 @@ import static ay2021s1_cs2103_w16_3.finesse.testutil.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.stream.IntStream;
+
 import org.junit.jupiter.api.Test;
 
 public class TitleTest {
@@ -37,5 +39,37 @@ public class TitleTest {
         assertTrue(Title.isValidTitle("David Roger Jackson Ray Jr 2nd")); // long title
         assertTrue(Title.isValidTitle("^")); // only non-alphanumeric characters
         assertTrue(Title.isValidTitle("peter*")); // contains non-alphanumeric characters
+    }
+
+    @Test
+    public void asciiTest() {
+        String titlePrefix = "Test: ";
+
+        // Check that the title prefix is valid. It will need to be used to get around the
+        // 'at least one non-whitespace printable ASCII character' restriction.
+        assertTrue(Title.isValidTitle(titlePrefix));
+
+        // Check that the ASCII control characters (char codes 0 to 31 inclusive) are invalid.
+        IntStream.range(0, 32).forEach(i ->
+                assertFalse(Title.isValidTitle(titlePrefix + getCharFromCharCode(i))));
+
+        // Check that the ASCII printable characters (char codes 32 to 126 inclusive) are valid.
+        IntStream.range(32, 127).forEach(i ->
+                assertTrue(Title.isValidTitle(titlePrefix + getCharFromCharCode(i))));
+
+        // Check that the ASCII delete character (char code 127) is invalid.
+        assertFalse(Title.isValidTitle(titlePrefix + getCharFromCharCode(127)));
+
+        // Check that extended ASCII characters (char codes 128 to 255 inclusive) are invalid.
+        IntStream.range(128, 256).forEach(i ->
+                assertFalse(Title.isValidTitle(titlePrefix + getCharFromCharCode(i))));
+
+        // Check that Unicode characters are invalid.
+        IntStream.iterate(300, i -> i <= 10000, i -> i + 100).forEach(i ->
+                assertFalse(Title.isValidTitle(titlePrefix + getCharFromCharCode(i))));
+    }
+
+    private String getCharFromCharCode(int i) {
+        return Character.toString((char) i);
     }
 }


### PR DESCRIPTION
Changes:
- Remove the `abbr` HTML tag.
  - Explicitly list out all printable ASCII characters instead.
- Update constraints messages for `Title` and `Category` to be more informative.
- Add tests to ensure that only printable ASCII characters are allowed for `Title` and `Category`.

Addresses https://github.com/AY2021S1-CS2103T-W16-3/tp/issues/131#issuecomment-719751719.