### PR TITLE
Fix inaccurate date validation

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -17,7 +17,7 @@ Welcome to Fine$$e - your personal finance tracker!
 
 Looking for an all-in-one solution to help you develop good financial habits? Look no further!
 
-Fine\\$\\$e is an integrated platform fully customized for tertiary and university students with the aim of helping you to track your finances effectively.
+Fine\\$\\$e is an integrated platform fully customized for tertiary (including university) students with the aim of helping you to track your finances effectively.
 Fine\\$\\$e allows you to keep track of your incomes, expenses and savings with a few simple commands.
 Furthermore, to help you cultivate good financial habits, Fine$$e allows you to budget your finances by setting an expense limit and savings goal, as well as viewing your past spending and saving trends.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -168,7 +168,10 @@ This section aims to provide you with in-depth details on Fine\$\$e's unique fea
 The formats of the parameters used in the rest of the document are as follows:
 * `TITLE` and `CATEGORY` should consist of <abbr title="Alphanumeric characters, space, and the special characters !&quot;#$%&'()*+,-./:;&lt;=&gt;?@[\]^_`{\|}~">printable ASCII characters</abbr>, and cannot begin with a space.
 * `AMOUNT`, `AMOUNT_FROM` and `AMOUNT_TO` should be non-negative numbers up to 8 digits with 0 or 2 decimal places, with an optional `$` in front.
-* `DATE`, `DATE_FROM` and `DATE_TO` should be in `dd/mm/yyyy` format, and cannot be later than the current date.
+* `DATE`, `DATE_FROM` and `DATE_TO` should be in `dd/mm/yyyy` format, representing date, month, and year respectively.
+  * Single-digit values must be padded with leading zeroes, meaning that a value such as `5` should be written as `05` instead.
+  * Dates cannot be earlier than 1 January 1970 (`01/01/1970`).
+  * Dates cannot be later than the current date.
 * `INDEX` should be a positive integer.
 
 Unless stated otherwise, only one input per parameter is allowed for each command.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -168,8 +168,13 @@ This section aims to provide you with in-depth details on Fine\$\$e's unique fea
 The formats of the parameters used in the rest of the document are as follows:
 * `TITLE` and `CATEGORY` should consist of <abbr title="Alphanumeric characters, space, and the special characters !&quot;#$%&'()*+,-./:;&lt;=&gt;?@[\]^_`{\|}~">printable ASCII characters</abbr>, and cannot begin with a space.
 * `AMOUNT`, `AMOUNT_FROM` and `AMOUNT_TO` should be non-negative numbers up to 8 digits with 0 or 2 decimal places, with an optional `$` in front.
-* `DATE`, `DATE_FROM` and `DATE_TO` should be in `dd/mm/yyyy` format, representing date, month, and year respectively.
-  * Single-digit values must be padded with leading zeroes, meaning that a value such as `5` should be written as `05` instead.
+* `DATE`, `DATE_FROM` and `DATE_TO` should be a valid calendar date in `dd/mm/yyyy` format, representing day, month, and year respectively.
+  * Valid ranges for days and months are governed by the rules of the [Gregorian Calendar](https://en.wikipedia.org/wiki/Gregorian_calendar#Description).
+    * Months should only range from 1 to 12 (inclusive), representing the 12 months of a year.
+    * Days should only range from 1 to 28, 29, 30, or 31 (all inclusive),
+    depending on the number of days in the given month and whether the given year is a leap year.
+  * For day and month values, single-digit values must be padded with leading zeroes, meaning that a value of 5 should be written as `05` instead of `5`.
+  * For year values, it must be written in the standard 4-digit format, so 2019 should be written as `2019` and not just `19`.
   * Dates cannot be earlier than 1 January 1970 (`01/01/1970`).
   * Dates cannot be later than the current date.
 * `INDEX` should be a positive integer.

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Date.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Date.java
@@ -19,7 +19,7 @@ public class Date implements Comparable<Date> {
             + "and cannot be later than the current date";
     public static final DateTimeFormatter VALIDATION_FORMAT = DateTimeFormatter.ofPattern("dd/MM/uuuu")
             .withResolverStyle(ResolverStyle.STRICT);
-    private static final LocalDate EPOCH = LocalDate.parse("01/01/0001", VALIDATION_FORMAT);
+    private static final LocalDate EPOCH = LocalDate.parse("01/01/1970", VALIDATION_FORMAT);
 
     private final LocalDate value;
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Date.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Date.java
@@ -15,11 +15,12 @@ import java.time.format.ResolverStyle;
  */
 public class Date implements Comparable<Date> {
 
-    public static final String MESSAGE_CONSTRAINTS = "Dates should be of the format dd/mm/yyyy "
-            + "and cannot be later than the current date";
+    public static final String EPOCH_STRING = "01/01/1970";
+    public static final String MESSAGE_CONSTRAINTS = "Dates should be of the format dd/mm/yyyy, "
+            + "cannot be earlier than " + EPOCH_STRING + " and cannot be later than the current date";
     public static final DateTimeFormatter VALIDATION_FORMAT = DateTimeFormatter.ofPattern("dd/MM/uuuu")
             .withResolverStyle(ResolverStyle.STRICT);
-    private static final LocalDate EPOCH = LocalDate.parse("01/01/1970", VALIDATION_FORMAT);
+    private static final LocalDate EPOCH = LocalDate.parse(EPOCH_STRING, VALIDATION_FORMAT);
 
     private final LocalDate value;
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Date.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Date.java
@@ -7,6 +7,7 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 
 /**
  * Represents a Transaction's date in the finance tracker.
@@ -16,7 +17,9 @@ public class Date implements Comparable<Date> {
 
     public static final String MESSAGE_CONSTRAINTS = "Dates should be of the format dd/mm/yyyy "
             + "and cannot be later than the current date";
-    public static final DateTimeFormatter VALIDATION_FORMAT = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+    public static final DateTimeFormatter VALIDATION_FORMAT = DateTimeFormatter.ofPattern("dd/MM/uuuu")
+            .withResolverStyle(ResolverStyle.STRICT);
+    private static final LocalDate EPOCH = LocalDate.parse("01/01/0001", VALIDATION_FORMAT);
 
     private final LocalDate value;
 
@@ -50,7 +53,8 @@ public class Date implements Comparable<Date> {
         try {
             LocalDate value = LocalDate.parse(test, VALIDATION_FORMAT);
             LocalDate today = LocalDate.now(currentTime);
-            return value.isEqual(today) || value.isBefore(today);
+            return (value.isBefore(today) || value.isEqual(today))
+                    && (value.isAfter(EPOCH) || value.isEqual(EPOCH));
         } catch (DateTimeParseException e) {
             return false;
         }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Date.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Date.java
@@ -16,8 +16,8 @@ import java.time.format.ResolverStyle;
 public class Date implements Comparable<Date> {
 
     public static final String EPOCH_STRING = "01/01/1970";
-    public static final String MESSAGE_CONSTRAINTS = "Dates should be of the format dd/mm/yyyy, "
-            + "cannot be earlier than " + EPOCH_STRING + " and cannot be later than the current date";
+    public static final String MESSAGE_CONSTRAINTS = "Dates should be a valid calendar date of the format dd/mm/yyyy, "
+            + "cannot be earlier than " + EPOCH_STRING + ", and cannot be later than the current date";
     public static final DateTimeFormatter VALIDATION_FORMAT = DateTimeFormatter.ofPattern("dd/MM/uuuu")
             .withResolverStyle(ResolverStyle.STRICT);
     private static final LocalDate EPOCH = LocalDate.parse(EPOCH_STRING, VALIDATION_FORMAT);

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/DateTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/DateTest.java
@@ -49,13 +49,16 @@ public class DateTest {
         assertFalse(Date.isValidDate("03/13/2020")); // month is not valid
         assertFalse(Date.isValidDate("01/01/0000")); // year is not valid
 
+        // last invalid date
+        assertFalse(Date.isValidDate("31/12/1969"));
+
         // date from the future is not allowed
         LocalDate pastDate = LocalDate.of(2020, 10, 16);
         assertFalse(Date.isValidDate("17/10/2020", Clock.fixed(
                 pastDate.atStartOfDay(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault())));
 
         // valid date
-        assertTrue(Date.isValidDate("01/01/0001")); // earliest allowed date
+        assertTrue(Date.isValidDate("01/01/1970")); // earliest allowed date
         assertTrue(Date.isValidDate("06/10/2020")); // 6 October 2020
     }
 

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/DateTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/DateTest.java
@@ -45,6 +45,7 @@ public class DateTest {
         assertFalse(Date.isValidDate("6/10/2020")); // leading zeroes are required
         assertFalse(Date.isValidDate("06/10/20")); // year must be 4 digits
         assertFalse(Date.isValidDate("32/09/2020")); // day is not valid
+        assertFalse(Date.isValidDate("30/02/2019")); // day is not valid
         assertFalse(Date.isValidDate("03/13/2020")); // month is not valid
         assertFalse(Date.isValidDate("01/01/0000")); // year is not valid
 
@@ -54,6 +55,7 @@ public class DateTest {
                 pastDate.atStartOfDay(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault())));
 
         // valid date
+        assertTrue(Date.isValidDate("01/01/0001")); // earliest allowed date
         assertTrue(Date.isValidDate("06/10/2020")); // 6 October 2020
     }
 


### PR DESCRIPTION
Fixes #250, resolves #259 

As stated in the original issue #250, the `DateTimeFormatter` by default uses `ResolverStyle.SMART` instead of `STRICT`. This has been remedied.
- As a result of using `ResolverStyle.STRICT`, the year format code `yyyy` is no longer usable without an era `G`. Year has thus been updated to `uuuu` which is independent of era.
- `uuuu` now accepts negative years to represent BCE era, but a negative year may be unintuitive to the user, so a lower bound check has been put in place. Based on the old behavior, the lower bound should be `01/01/0001`, but it has been changed (see below).

At the same time, #259 has been addressed and the lower bound has been revised from `01/01/0001` to `01/01/1970`.
- From a business logic perspective, since we are targeting tertiary students, it makes little sense for transactions to go beyond this date.
- We also do not want it to be overly restrictive, in the event a mature candidate for whatever reason wishes to backdate their transaction history.

Lastly, a minor adjustment was made to the introduction of the user guide. University students are a subset of [tertiary students](https://www.worldbank.org/en/topic/tertiaryeducation#what_why), so conjoining the two terms is slightly unintuitive.