### PR TITLE
Add clear command confirmation

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -92,6 +92,11 @@ The Fine$$e GUI should appear in a few seconds, with sample data included, simil
 
    * `exit`: Exits the app.
 
+1. Once you are comfortable with the various features of Fine\\$\\$e, [clear the sample data](#410-clear-data-clear) by typing `clear`, pressing Enter,
+typing `clear` again, and pressing Enter again.
+
+1. Start tracking your own finances with Fine\\$\\$e!
+
 ### 2.2 Layout of Fine$$e's Interface
 
 The user interface of Fine$$e is divided into 4 tabs, each serving a specific purpose.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -907,13 +907,64 @@ There are three bar charts that show the following data over the past three mont
 The data in the bar charts is automatically updated to include any recent modifications you have made in the finance tracker every time you switch to the [Analytics Tab](#224-analytics-tab).
 This ensures that you will always see the latest information about your spending and saving trends.
 
-### 4.10 Exiting the Program: `exit`
+### 4.10 Clear Data: `clear`
+
+Ready to start using Fine\\$\\$e?
+This command allows you to clear *all* existing data inside the finance tracker. That includes:
+* Expenses and incomes
+* Bookmark expenses and bookmark incomes
+* Expense limit
+* Savings goal
+
+Format: `clear`
+
+> :warning: &nbsp; This is a powerful command. You might lose your precious data if you are not careful with it.
+
+> :bulb: &nbsp; If there is any data you would like to keep before clearing, write it down somewhere so that you can re-enter it later.
+
+To protect against accidental usage, this command needs to be entered **twice in succession** before it takes effect.
+A single `clear` command is nullified when not followed by another `clear` command.
+
+Here are some example scenarios to illustrate:
+* Scenario A: Enter `clear`.
+  * The finance tracker data is unchanged.
+  * Fine\\$\\$e requests for a second `clear` command as confirmation.
+* Scenario B: Enter `clear`, then enter `clear` again.
+  * The finance tracker data is cleared.
+* Scenario C: Enter `clear`, then enter `lsi`, then enter `clear` again.
+  * The finance tracker data is unchanged.
+  * Since the first `clear` command was nullified, Fine\\$\\$e requests for a second `clear` command as confirmation.
+* Scenario D: Enter `clear`, then enter `lsi`, then enter `clear` again, then enter `clear` again.
+  * The finance tracker data is cleared.
+
+Example Usage:
+```
+clear
+```
+
+Expected Outcome:
+```
+Please enter 'clear' again to confirm your decision.
+```
+
+Example Usage (continued):
+```
+clear
+```
+
+Expected Outcome:
+```
+Finance tracker has been cleared!
+```
+All data in the finance tracker is cleared.
+
+### 4.11 Exiting the Program: `exit`
 
 Exits the program.
 
 Format: `exit`
 
-### 4.11 Command History
+### 4.12 Command History
 
 Accidentally entered the wrong command and wish to modify it without typing it out again fully?
 Simply press the ↑ or ↓ arrow keys on your keyboard to navigate through your command history.
@@ -929,7 +980,7 @@ Simply press the ↑ or ↓ arrow keys on your keyboard to navigate through your
 
 > :warning: &nbsp; Pressing either the ↑ or ↓ arrow keys will cause whatever text is currently in the command box to be overwritten.
 
-### 4.12 Saving the Data
+### 4.13 Saving the Data
 
 Fine$$e data is saved in the hard disk automatically after any command that changes the data.
 There is no need to save manually.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -931,10 +931,13 @@ Here are some example scenarios to illustrate:
   * Fine\\$\\$e requests for a second `clear` command as confirmation.
 * Scenario B: Enter `clear`, then enter `clear` again.
   * The finance tracker data is cleared.
-* Scenario C: Enter `clear`, then enter `lsi`, then enter `clear` again.
+* Scenario C: Enter `clear`, then enter `lsi` (a valid command), then enter `clear` again.
   * The finance tracker data is unchanged.
-  * Since the first `clear` command was nullified, Fine\\$\\$e requests for a second `clear` command as confirmation.
-* Scenario D: Enter `clear`, then enter `lsi`, then enter `clear` again, then enter `clear` again.
+  * The first `clear` command has been nullified, so Fine\\$\\$e requests for a second `clear` command as confirmation.
+* Scenario D: Enter `clear`, then enter `foo` (an invalid command), then enter `clear` again.
+  * The finance tracker data is unchanged.
+  * The first `clear` command has been nullified, so Fine\\$\\$e requests for a second `clear` command as confirmation.
+* Scenario E: Enter `clear`, then enter `lsi`, then enter `clear` again, then enter `clear` again.
   * The finance tracker data is cleared.
 
 Example Usage:

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/MainApp.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/MainApp.java
@@ -70,7 +70,7 @@ public class MainApp extends Application {
 
         uiState = new UiState();
 
-        ui = new UiManager(logic, uiState);
+        ui = new UiManager(model, logic, uiState);
     }
 
     /**

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ClearCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ClearCommand.java
@@ -2,8 +2,13 @@ package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.List;
+
+import ay2021s1_cs2103_w16_3.finesse.logic.parser.FinanceTrackerParser;
+import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
 import ay2021s1_cs2103_w16_3.finesse.model.FinanceTracker;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState;
 
 /**
  * Clears the finance tracker.
@@ -14,23 +19,22 @@ public class ClearCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Finance tracker has been cleared!";
     public static final String MESSAGE_PRIMED = "Please enter 'clear' again to confirm your decision.";
 
-    // maintains whether or not
-    private static boolean isPrimed = false;
-
-    public static void resetPrimed() {
-        isPrimed = false;
-    }
-
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        if (isPrimed) {
+        List<String> recentCommands = model.getCommandHistory().recentCommands(20);
+        boolean isPrimed;
+        try {
+            isPrimed = recentCommands.size() >= 2 && new FinanceTrackerParser()
+                    .parseCommand(recentCommands.get(1), new UiState()) instanceof ClearCommand;
+        } catch (ParseException e) {
             isPrimed = false;
+        }
+        if (isPrimed) {
             model.setFinanceTracker(new FinanceTracker());
             return new CommandResult(MESSAGE_SUCCESS, true);
         } else {
             // set primed
-            isPrimed = true;
             return new CommandResult(MESSAGE_PRIMED);
         }
     }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ClearCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ClearCommand.java
@@ -12,12 +12,26 @@ public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "Finance tracker has been cleared!";
+    public static final String MESSAGE_PRIMED = "Please enter 'clear' again to confirm your decision.";
 
+    // maintains whether or not
+    private static boolean isPrimed = false;
+
+    public static void resetPrimed() {
+        isPrimed = false;
+    }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.setFinanceTracker(new FinanceTracker());
-        return new CommandResult(MESSAGE_SUCCESS, true);
+        if (isPrimed) {
+            isPrimed = false;
+            model.setFinanceTracker(new FinanceTracker());
+            return new CommandResult(MESSAGE_SUCCESS, true);
+        } else {
+            // set primed
+            isPrimed = true;
+            return new CommandResult(MESSAGE_PRIMED);
+        }
     }
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
@@ -93,6 +93,12 @@ public class FinanceTrackerParser {
 
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
+
+        // a command other than 'clear' will reset the primed status
+        if (!ClearCommand.COMMAND_WORD.equals(commandWord)) {
+            ClearCommand.resetPrimed();
+        }
+
         switch (commandWord) {
 
         case ADD_COMMAND_COMMAND_WORD:

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
@@ -93,12 +93,6 @@ public class FinanceTrackerParser {
 
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
-
-        // a command other than 'clear' will reset the primed status
-        if (!ClearCommand.COMMAND_WORD.equals(commandWord)) {
-            ClearCommand.resetPrimed();
-        }
-
         switch (commandWord) {
 
         case ADD_COMMAND_COMMAND_WORD:

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/Model.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/Model.java
@@ -8,6 +8,7 @@ import ay2021s1_cs2103_w16_3.finesse.commons.core.GuiSettings;
 import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkExpense;
 import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkIncome;
 import ay2021s1_cs2103_w16_3.finesse.model.budget.MonthlyBudget;
+import ay2021s1_cs2103_w16_3.finesse.model.command.history.CommandHistory;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
@@ -61,6 +62,11 @@ public interface Model {
      * Sets the user prefs' finance tracker file path.
      */
     void setFinanceTrackerFilePath(Path financeTrackerFilePath);
+
+    /**
+     * Returns the command history.
+     */
+    CommandHistory getCommandHistory();
 
     /**
      * Replaces finance tracker data with the data in {@code financeTracker}.

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/ModelManager.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/ModelManager.java
@@ -14,6 +14,7 @@ import ay2021s1_cs2103_w16_3.finesse.commons.core.LogsCenter;
 import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkExpense;
 import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkIncome;
 import ay2021s1_cs2103_w16_3.finesse.model.budget.MonthlyBudget;
+import ay2021s1_cs2103_w16_3.finesse.model.command.history.CommandHistory;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
@@ -27,9 +28,11 @@ import javafx.collections.transformation.FilteredList;
  */
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
+    private static final int COMMAND_HISTORY_SIZE = 50;
 
     private final FinanceTracker financeTracker;
     private final UserPrefs userPrefs;
+    private final CommandHistory commandHistory;
     private final FilteredList<Transaction> filteredTransactions;
     private final FilteredList<Transaction> filteredExpenses;
     private final FilteredList<Transaction> filteredIncomes;
@@ -50,6 +53,7 @@ public class ModelManager implements Model {
 
         this.financeTracker = new FinanceTracker(financeTracker);
         this.userPrefs = new UserPrefs(userPrefs);
+        commandHistory = new CommandHistory(COMMAND_HISTORY_SIZE);
         filteredTransactions = new FilteredList<>(this.financeTracker.getTransactionList());
         filteredExpenses = new FilteredList<>(this.financeTracker.getTransactionList(), PREDICATE_SHOW_ALL_EXPENSES);
         filteredIncomes = new FilteredList<>(this.financeTracker.getTransactionList(), PREDICATE_SHOW_ALL_INCOMES);
@@ -98,6 +102,14 @@ public class ModelManager implements Model {
         requireNonNull(financeTrackerFilePath);
         userPrefs.setFinanceTrackerFilePath(financeTrackerFilePath);
     }
+
+    //=========== Command History ================================================================================
+
+    @Override
+    public CommandHistory getCommandHistory() {
+        return commandHistory;
+    }
+
 
     //=========== FinanceTracker ================================================================================
 
@@ -346,6 +358,7 @@ public class ModelManager implements Model {
         ModelManager other = (ModelManager) obj;
         return financeTracker.equals(other.financeTracker)
                 && userPrefs.equals(other.userPrefs)
+                && commandHistory.equals(other.commandHistory)
                 && filteredTransactions.equals(other.filteredTransactions)
                 && filteredExpenses.equals(other.filteredExpenses)
                 && filteredIncomes.equals(other.filteredIncomes);

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/command/history/CommandHistory.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/command/history/CommandHistory.java
@@ -1,5 +1,10 @@
 package ay2021s1_cs2103_w16_3.finesse.model.command.history;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 /**
  * Keeps track of the user input history as well as the command history navigation state.
  */
@@ -66,5 +71,51 @@ public class CommandHistory {
             return null;
         }
         return currentNode.getValue();
+    }
+
+    /**
+     * Returns a list of the most recent commands, up to a specified limit.
+     * The list is ordered such that the first element is the most recently entered command,
+     * and the last element is the least recently entered command.
+     * If there are fewer commands stored in the command history than the specified limit,
+     * the returned list will be smaller than the specified limit.
+     *
+     * @param range The maximum number of commands to be retrieved.
+     * @return A list of the most recent commands, limited by {@code range} and the
+     * number of commands stored in the command history.
+     */
+    public List<String> recentCommands(int range) {
+        assert range >= 0;
+        return stream().limit(range).collect(Collectors.toUnmodifiableList());
+    }
+
+    /**
+     * Returns a stream of command strings, from most recent to least recent.
+     * Note that due to the lazy nature of streams, undefined behavior may occur
+     * if the stream is not consumed immediately.
+     *
+     * @return A stream of command strings, from most recent to least recent.
+     */
+    private Stream<String> stream() {
+        return Stream.iterate(commandHistory.getTopNode(), Objects::nonNull, Node::getPreviousNode).map(Node::getValue);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        // short circuit if same object
+        if (obj == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(obj instanceof CommandHistory)) {
+            return false;
+        }
+
+        // state check
+        CommandHistory other = (CommandHistory) obj;
+        List<String> myCommands = this.stream().collect(Collectors.toUnmodifiableList());
+        List<String> otherCommands = other.stream().collect(Collectors.toUnmodifiableList());
+        return myCommands.equals(otherCommands);
     }
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/CommandBox.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/CommandBox.java
@@ -17,7 +17,6 @@ import javafx.scene.layout.Region;
  */
 public class CommandBox extends UiPart<Region> {
     private static final String FXML = "CommandBox.fxml";
-    private static final int COMMAND_HISTORY_SIZE = 50;
 
     private final CommandExecutor commandExecutor;
     private final CommandHistory commandHistory;
@@ -34,11 +33,10 @@ public class CommandBox extends UiPart<Region> {
     /**
      * Creates a {@code CommandBox} with the given {@code CommandExecutor}.
      */
-    public CommandBox(CommandExecutor commandExecutor) {
+    public CommandBox(CommandExecutor commandExecutor, CommandHistory commandHistory) {
         super(FXML);
         this.commandExecutor = commandExecutor;
-
-        commandHistory = new CommandHistory(COMMAND_HISTORY_SIZE);
+        this.commandHistory = commandHistory;
 
         // Set up cycling through command history.
         commandTextField.setOnKeyPressed(keyEvent -> {

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/MainWindow.java
@@ -11,6 +11,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.Logic;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
+import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.ui.tabs.AnalyticsTabPane;
 import ay2021s1_cs2103_w16_3.finesse.ui.tabs.ExpenseTabPane;
 import ay2021s1_cs2103_w16_3.finesse.ui.tabs.IncomeTabPane;
@@ -43,6 +44,7 @@ public class MainWindow extends UiPart<Stage> {
     private final Logger logger = LogsCenter.getLogger(getClass());
 
     private final Stage primaryStage;
+    private final Model model;
     private final Logic logic;
     private final UiState uiState;
 
@@ -81,11 +83,12 @@ public class MainWindow extends UiPart<Stage> {
     /**
      * Creates a {@code MainWindow} with the given {@code Stage}, {@code Logic} and {@code UiState}.
      */
-    public MainWindow(Stage primaryStage, Logic logic, UiState uiState) {
+    public MainWindow(Stage primaryStage, Model model, Logic logic, UiState uiState) {
         super(FXML, primaryStage);
 
         // Set dependencies
         this.primaryStage = primaryStage;
+        this.model = model;
         this.logic = logic;
         this.uiState = uiState;
 
@@ -108,7 +111,7 @@ public class MainWindow extends UiPart<Stage> {
         resultDisplay.setFeedbackToUser(WELCOME_MESSAGE);
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
-        CommandBox commandBox = new CommandBox(this::executeCommand);
+        CommandBox commandBox = new CommandBox(this::executeCommand, model.getCommandHistory());
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
     }
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/UiManager.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/ui/UiManager.java
@@ -6,6 +6,7 @@ import ay2021s1_cs2103_w16_3.finesse.MainApp;
 import ay2021s1_cs2103_w16_3.finesse.commons.core.LogsCenter;
 import ay2021s1_cs2103_w16_3.finesse.commons.util.StringUtil;
 import ay2021s1_cs2103_w16_3.finesse.logic.Logic;
+import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import javafx.application.Platform;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
@@ -23,6 +24,7 @@ public class UiManager implements Ui {
     private static final Logger logger = LogsCenter.getLogger(UiManager.class);
     private static final String APPLICATION_ICON = "/images/SavingsImage.png";
 
+    private Model model;
     private Logic logic;
     private MainWindow mainWindow;
     private UiState uiState;
@@ -30,8 +32,9 @@ public class UiManager implements Ui {
     /**
      * Creates a {@code UiManager} with the given {@code Logic}.
      */
-    public UiManager(Logic logic, UiState uiState) {
+    public UiManager(Model model, Logic logic, UiState uiState) {
         super();
+        this.model = model;
         this.logic = logic;
         this.uiState = uiState;
     }
@@ -45,7 +48,7 @@ public class UiManager implements Ui {
 
         try {
             loadCustomFonts();
-            mainWindow = new MainWindow(primaryStage, logic, uiState);
+            mainWindow = new MainWindow(primaryStage, model, logic, uiState);
             mainWindow.show(); // This should be called before creating other UI parts.
             mainWindow.fillInnerParts();
             mainWindow.initializeTabs();

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ClearCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ClearCommandTest.java
@@ -19,7 +19,11 @@ public class ClearCommandTest {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
 
+        model.getCommandHistory().addCommand("clear");
+        expectedModel.getCommandHistory().addCommand("clear");
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_PRIMED, expectedModel, false);
+        model.getCommandHistory().addCommand("clear");
+        expectedModel.getCommandHistory().addCommand("clear");
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel, true);
     }
 
@@ -29,9 +33,13 @@ public class ClearCommandTest {
         Model expectedModel = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
 
         // 1st run - command is primed (model is unchanged)
+        model.getCommandHistory().addCommand("clear");
+        expectedModel.getCommandHistory().addCommand("clear");
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_PRIMED, expectedModel, false);
         // 2nd run - command clears data
         expectedModel.setFinanceTracker(new FinanceTracker());
+        model.getCommandHistory().addCommand("clear");
+        expectedModel.getCommandHistory().addCommand("clear");
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel, true);
     }
 
@@ -48,19 +56,61 @@ public class ClearCommandTest {
         uiState.setCurrentTab(UiState.Tab.INCOME);
 
         // 1st run - command is primed (model is unchanged)
+        model.getCommandHistory().addCommand("clear");
+        expectedModel.getCommandHistory().addCommand("clear");
         assertCommandSuccess(cmdParser.parseCommand("clear", uiState), model,
                 ClearCommand.MESSAGE_PRIMED, expectedModel, false);
 
         // intermediate command 'lsi' - prime is reset
-        assertCommandSuccess(cmdParser.parseCommand("lsi", uiState), model,
-                new ListIncomeCommand().execute(model), expectedModel);
+        model.getCommandHistory().addCommand("lsi");
+        expectedModel.getCommandHistory().addCommand("lsi");
 
         // 2nd run - command is primed (model is unchanged)
+        model.getCommandHistory().addCommand("clear");
+        expectedModel.getCommandHistory().addCommand("clear");
         assertCommandSuccess(cmdParser.parseCommand("clear", uiState), model,
                 ClearCommand.MESSAGE_PRIMED, expectedModel, false);
 
         // 3rd run - command clears data
         expectedModel.setFinanceTracker(new FinanceTracker());
+        model.getCommandHistory().addCommand("clear");
+        expectedModel.getCommandHistory().addCommand("clear");
+        assertCommandSuccess(cmdParser.parseCommand("clear", uiState), model,
+                ClearCommand.MESSAGE_SUCCESS, expectedModel, true);
+    }
+
+    @Test
+    public void execute_nonEmptyFinanceTracker_invalidIntermediateCommand() throws Exception {
+        // test to check if the clear command works across multiple uses,
+        // when another (invalid) command is injected in between
+
+        Model model = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
+        Model expectedModel = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
+
+        FinanceTrackerParser cmdParser = new FinanceTrackerParser();
+        UiState uiState = new UiState();
+        uiState.setCurrentTab(UiState.Tab.INCOME);
+
+        // 1st run - command is primed (model is unchanged)
+        model.getCommandHistory().addCommand("clear");
+        expectedModel.getCommandHistory().addCommand("clear");
+        assertCommandSuccess(cmdParser.parseCommand("clear", uiState), model,
+                ClearCommand.MESSAGE_PRIMED, expectedModel, false);
+
+        // invalid intermediate command 'foo' - prime is reset
+        model.getCommandHistory().addCommand("foo");
+        expectedModel.getCommandHistory().addCommand("foo");
+
+        // 2nd run - command is primed (model is unchanged)
+        model.getCommandHistory().addCommand("clear");
+        expectedModel.getCommandHistory().addCommand("clear");
+        assertCommandSuccess(cmdParser.parseCommand("clear", uiState), model,
+                ClearCommand.MESSAGE_PRIMED, expectedModel, false);
+
+        // 3rd run - command clears data
+        expectedModel.setFinanceTracker(new FinanceTracker());
+        model.getCommandHistory().addCommand("clear");
+        expectedModel.getCommandHistory().addCommand("clear");
         assertCommandSuccess(cmdParser.parseCommand("clear", uiState), model,
                 ClearCommand.MESSAGE_SUCCESS, expectedModel, true);
     }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ClearCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ClearCommandTest.java
@@ -5,10 +5,12 @@ import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.getTypi
 
 import org.junit.jupiter.api.Test;
 
+import ay2021s1_cs2103_w16_3.finesse.logic.parser.FinanceTrackerParser;
 import ay2021s1_cs2103_w16_3.finesse.model.FinanceTracker;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.ModelManager;
 import ay2021s1_cs2103_w16_3.finesse.model.UserPrefs;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState;
 
 public class ClearCommandTest {
 
@@ -17,6 +19,7 @@ public class ClearCommandTest {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
 
+        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_PRIMED, expectedModel, false);
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel, true);
     }
 
@@ -24,9 +27,42 @@ public class ClearCommandTest {
     public void execute_nonEmptyFinanceTracker_success() {
         Model model = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
         Model expectedModel = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
-        expectedModel.setFinanceTracker(new FinanceTracker());
 
+        // 1st run - command is primed (model is unchanged)
+        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_PRIMED, expectedModel, false);
+        // 2nd run - command clears data
+        expectedModel.setFinanceTracker(new FinanceTracker());
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel, true);
+    }
+
+    @Test
+    public void execute_nonEmptyFinanceTracker_intermediateCommand() throws Exception {
+        // test to check if the clear command works across multiple uses,
+        // when another command is injected in between
+
+        Model model = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
+        Model expectedModel = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
+
+        FinanceTrackerParser cmdParser = new FinanceTrackerParser();
+        UiState uiState = new UiState();
+        uiState.setCurrentTab(UiState.Tab.INCOME);
+
+        // 1st run - command is primed (model is unchanged)
+        assertCommandSuccess(cmdParser.parseCommand("clear", uiState), model,
+                ClearCommand.MESSAGE_PRIMED, expectedModel, false);
+
+        // intermediate command 'lsi' - prime is reset
+        assertCommandSuccess(cmdParser.parseCommand("lsi", uiState), model,
+                new ListIncomeCommand().execute(model), expectedModel);
+
+        // 2nd run - command is primed (model is unchanged)
+        assertCommandSuccess(cmdParser.parseCommand("clear", uiState), model,
+                ClearCommand.MESSAGE_PRIMED, expectedModel, false);
+
+        // 3rd run - command clears data
+        expectedModel.setFinanceTracker(new FinanceTracker());
+        assertCommandSuccess(cmdParser.parseCommand("clear", uiState), model,
+                ClearCommand.MESSAGE_SUCCESS, expectedModel, true);
     }
 
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/stubs/ModelStub.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/stubs/ModelStub.java
@@ -11,6 +11,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.ReadOnlyUserPrefs;
 import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkExpense;
 import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkIncome;
 import ay2021s1_cs2103_w16_3.finesse.model.budget.MonthlyBudget;
+import ay2021s1_cs2103_w16_3.finesse.model.command.history.CommandHistory;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
@@ -48,6 +49,11 @@ public class ModelStub implements Model {
 
     @Override
     public void setFinanceTrackerFilePath(Path financeTrackerFilePath) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public CommandHistory getCommandHistory() {
         throw new AssertionError("This method should not be called.");
     }
 


### PR DESCRIPTION
Resolves #221 

This is accomplished by first migrating `CommandHistory` from `CommandBox` to `ModelManager`, then querying the command history from `ClearCommand`, where the model is readily available as a parameter to `execute`.

Note that since a new section has been inserted into the UG, the numbering for subsequent sections has been bumped. As far as I'm aware, there should be no existing references (link) to these sections, other than the table of contents (which is automatically updated).

Pitest: https://ay2021s1-cs2103t-w16-3.github.io/reports/pitest/202011020417/
- Coverage may have decreased for [`CommandHistory`](https://ay2021s1-cs2103t-w16-3.github.io/reports/pitest/202011020417/ay2021s1_cs2103_w16_3.finesse.model.command.history/CommandHistory.java.html) as a nontrivial equals method is now required. Raising coverage here is likely to be beyond the scope of this PR, as it requires more helper methods solely for the purpose of testing (such as comparing the capacities of the stacks).
- However, [`ClearCommand`](https://ay2021s1-cs2103t-w16-3.github.io/reports/pitest/202011020417/ay2021s1_cs2103_w16_3.finesse.logic.commands/ClearCommand.java.html) is fully covered.