### PR TITLE
Refactor editing of bookmark transactions

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -602,6 +602,9 @@ Edits a bookmark expense in the finance tracker.
 
 > :warning: &nbsp; This command can only be executed on the [Expenses tab](#223-expenses-tab).
 
+> :warning: &nbsp; Editing a bookmark expense to contain a title that already exists in the bookmark expense list is not allowed.
+> 
+
 Format: `edit-bookmark INDEX [t/TITLE] [a/AMOUNT] [c/CATEGORY...]`
 
 * `INDEX` allows you to choose which bookmark expense to edit by specifying its position in the bookmark expenses list.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -602,8 +602,9 @@ Edits a bookmark expense in the finance tracker.
 
 > :warning: &nbsp; This command can only be executed on the [Expenses tab](#223-expenses-tab).
 
-> :warning: &nbsp; Editing a bookmark expense to contain a title that already exists in the bookmark expense list is not allowed.
-> 
+> :warning: &nbsp; Bookmark expenses with same titles are considered to be duplicates of each other.
+> Therefore, editing the title of a bookmark expense to an already existing title in the bookmark expenses list is not allowed.
+> Contiguous whitespace characters between words in the title will be treated as a single whitespace character.
 
 Format: `edit-bookmark INDEX [t/TITLE] [a/AMOUNT] [c/CATEGORY...]`
 
@@ -746,6 +747,10 @@ Adds a bookmark income titled `Part Time` with amount `$400.00` and one category
 Edits a bookmark income in the finance tracker.
 
 > :warning: &nbsp; This command can only be executed on the [Incomes tab](#222-incomes-tab).
+
+> :warning: &nbsp; Bookmark incomes with same titles are considered to be duplicates of each other.
+> Therefore, editing the title of a bookmark income to an already existing title in the bookmark incomes list is not allowed.
+> Contiguous whitespace characters between words in the title will be treated as a single whitespace character.
 
 Format: `edit-bookmark INDEX [t/TITLE] [a/AMOUNT] [c/CATEGORY...]`
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/EditBookmarkExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/EditBookmarkExpenseCommand.java
@@ -15,6 +15,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkExpense;
+import ay2021s1_cs2103_w16_3.finesse.model.bookmark.exceptions.DuplicateBookmarkTransactionException;
 import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
@@ -65,8 +66,11 @@ public class EditBookmarkExpenseCommand extends EditBookmarkCommand {
         BookmarkExpense bookmarkExpenseToEdit = lastShownList.get(targetIndex.getZeroBased());
         BookmarkExpense editedBookmarkExpense = createEditedBookmarkExpense(bookmarkExpenseToEdit,
                 editBookmarkExpenseDescriptor);
-
-        model.setBookmarkExpense(bookmarkExpenseToEdit, editedBookmarkExpense);
+        try {
+            model.setBookmarkExpense(bookmarkExpenseToEdit, editedBookmarkExpense);
+        } catch (DuplicateBookmarkTransactionException e) {
+            throw new CommandException(e.getMessage());
+        }
         model.updateFilteredBookmarkExpenseList(PREDICATE_SHOW_ALL_BOOKMARK_EXPENSES);
         return new CommandResult(String.format(MESSAGE_EDIT_BOOKMARK_EXPENSE_SUCCESS, editedBookmarkExpense));
     }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/EditBookmarkIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmark/EditBookmarkIncomeCommand.java
@@ -15,6 +15,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkIncome;
+import ay2021s1_cs2103_w16_3.finesse.model.bookmark.exceptions.DuplicateBookmarkTransactionException;
 import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
@@ -65,8 +66,11 @@ public class EditBookmarkIncomeCommand extends EditBookmarkCommand {
         BookmarkIncome bookmarkIncomeToEdit = lastShownList.get(targetIndex.getZeroBased());
         BookmarkIncome editedBookmarkIncome = createdEditedBookmarkIncome(bookmarkIncomeToEdit,
                 editBookmarkIncomeDescriptor);
-
-        model.setBookmarkIncome(bookmarkIncomeToEdit, editedBookmarkIncome);
+        try {
+            model.setBookmarkIncome(bookmarkIncomeToEdit, editedBookmarkIncome);
+        } catch (DuplicateBookmarkTransactionException e) {
+            throw new CommandException(e.getMessage());
+        }
         model.updateFilteredBookmarkIncomeList(PREDICATE_SHOW_ALL_BOOKMARK_INCOMES);
         return new CommandResult(String.format(MESSAGE_EDIT_BOOKMARK_INCOME_SUCCESS, editedBookmarkIncome));
     }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtil.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtil.java
@@ -56,7 +56,7 @@ public class ParserUtil {
      *
      * @throws ParseException if the given {@code title} is invalid.
      */
-    public static Title parseTitleWithAdditionalWhitespace(String title) throws ParseException {
+    public static Title parseTitleAndTrimBetweenWords(String title) throws ParseException {
         requireNonNull(title);
         String removedExtraWhitespaceTitle = title.replaceAll("\\s{2,}", " ");
         return parseTitle(removedExtraWhitespaceTitle);

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/AddBookmarkExpenseCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/AddBookmarkExpenseCommandParser.java
@@ -48,7 +48,7 @@ public class AddBookmarkExpenseCommandParser implements Parser<AddBookmarkExpens
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_AMOUNT_CONSTRAINTS));
         }
 
-        Title title = ParserUtil.parseTitleWithAdditionalWhitespace(argMultimap.getValue(PREFIX_TITLE).get());
+        Title title = ParserUtil.parseTitleAndTrimBetweenWords(argMultimap.getValue(PREFIX_TITLE).get());
         Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
         Set<Category> categoryList = ParserUtil.parseCategories(argMultimap.getAllValues(PREFIX_CATEGORY));
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/AddBookmarkIncomeCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/AddBookmarkIncomeCommandParser.java
@@ -45,7 +45,7 @@ public class AddBookmarkIncomeCommandParser implements Parser<AddBookmarkIncomeC
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, BookmarkTransaction.MESSAGE_AMOUNT_CONSTRAINTS));
         }
 
-        Title title = ParserUtil.parseTitleWithAdditionalWhitespace(argMultimap.getValue(PREFIX_TITLE).get());
+        Title title = ParserUtil.parseTitleAndTrimBetweenWords(argMultimap.getValue(PREFIX_TITLE).get());
         Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
         Set<Category> categoryList = ParserUtil.parseCategories(argMultimap.getAllValues(PREFIX_CATEGORY));
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/EditBookmarkExpenseCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/EditBookmarkExpenseCommandParser.java
@@ -58,7 +58,7 @@ public class EditBookmarkExpenseCommandParser implements Parser<EditBookmarkExpe
 
         if (argMultimap.getValue(PREFIX_TITLE).isPresent()) {
             editBookmarkExpenseDescriptor.setTitle(ParserUtil
-                    .parseTitleWithAdditionalWhitespace(argMultimap.getValue(PREFIX_TITLE).get()));
+                    .parseTitleAndTrimBetweenWords(argMultimap.getValue(PREFIX_TITLE).get()));
         }
         if (argMultimap.getValue(PREFIX_AMOUNT).isPresent()) {
             editBookmarkExpenseDescriptor.setAmount(ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get()));

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/EditBookmarkExpenseCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/EditBookmarkExpenseCommandParser.java
@@ -57,7 +57,8 @@ public class EditBookmarkExpenseCommandParser implements Parser<EditBookmarkExpe
         EditBookmarkTransactionDescriptor editBookmarkExpenseDescriptor = new EditBookmarkTransactionDescriptor();
 
         if (argMultimap.getValue(PREFIX_TITLE).isPresent()) {
-            editBookmarkExpenseDescriptor.setTitle(ParserUtil.parseTitle(argMultimap.getValue(PREFIX_TITLE).get()));
+            editBookmarkExpenseDescriptor.setTitle(ParserUtil
+                    .parseTitleWithAdditionalWhitespace(argMultimap.getValue(PREFIX_TITLE).get()));
         }
         if (argMultimap.getValue(PREFIX_AMOUNT).isPresent()) {
             editBookmarkExpenseDescriptor.setAmount(ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get()));

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/EditBookmarkIncomeCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/EditBookmarkIncomeCommandParser.java
@@ -57,7 +57,8 @@ public class EditBookmarkIncomeCommandParser implements Parser<EditBookmarkIncom
         EditBookmarkTransactionDescriptor editBookmarkIncomeDescriptor = new EditBookmarkTransactionDescriptor();
 
         if (argMultimap.getValue(PREFIX_TITLE).isPresent()) {
-            editBookmarkIncomeDescriptor.setTitle(ParserUtil.parseTitle(argMultimap.getValue(PREFIX_TITLE).get()));
+            editBookmarkIncomeDescriptor.setTitle(ParserUtil
+                    .parseTitleWithAdditionalWhitespace(argMultimap.getValue(PREFIX_TITLE).get()));
         }
         if (argMultimap.getValue(PREFIX_AMOUNT).isPresent()) {
             editBookmarkIncomeDescriptor.setAmount(ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get()));

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/EditBookmarkIncomeCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/EditBookmarkIncomeCommandParser.java
@@ -58,7 +58,7 @@ public class EditBookmarkIncomeCommandParser implements Parser<EditBookmarkIncom
 
         if (argMultimap.getValue(PREFIX_TITLE).isPresent()) {
             editBookmarkIncomeDescriptor.setTitle(ParserUtil
-                    .parseTitleWithAdditionalWhitespace(argMultimap.getValue(PREFIX_TITLE).get()));
+                    .parseTitleAndTrimBetweenWords(argMultimap.getValue(PREFIX_TITLE).get()));
         }
         if (argMultimap.getValue(PREFIX_AMOUNT).isPresent()) {
             editBookmarkIncomeDescriptor.setAmount(ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get()));

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/FinanceTracker.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/FinanceTracker.java
@@ -129,7 +129,7 @@ public class FinanceTracker implements ReadOnlyFinanceTracker {
     public void setBookmarkExpense(BookmarkExpense target, BookmarkExpense editedBookmarkExpense) {
         requireNonNull(editedBookmarkExpense);
 
-        bookmarkExpenses.setBookmark(target, editedBookmarkExpense);
+        bookmarkExpenses.setBookmarkExpense(target, editedBookmarkExpense);
     }
 
     /**

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/bookmark/BookmarkExpenseList.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/bookmark/BookmarkExpenseList.java
@@ -48,7 +48,7 @@ public class BookmarkExpenseList implements Iterable<BookmarkExpense> {
      * The bookmark expense identity of {@code editedBookmarkExpense} must not be the same as another existing
      * bookmark expense in the list.
      */
-    public void setBookmark(BookmarkExpense target, BookmarkExpense editedBookmarkExpense) {
+    public void setBookmarkExpense(BookmarkExpense target, BookmarkExpense editedBookmarkExpense) {
         requireAllNonNull(target, editedBookmarkExpense);
 
         int index = internalBookmarkExpenseList.indexOf(target);
@@ -56,7 +56,7 @@ public class BookmarkExpenseList implements Iterable<BookmarkExpense> {
             throw new BookmarkTransactionNotFoundException();
         }
 
-        if (contains(editedBookmarkExpense)) {
+        if (contains(editedBookmarkExpense) && !(target.getTitle().equals(editedBookmarkExpense.getTitle()))) {
             throw new DuplicateBookmarkTransactionException("expense");
         }
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/bookmark/BookmarkExpenseList.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/bookmark/BookmarkExpenseList.java
@@ -56,6 +56,10 @@ public class BookmarkExpenseList implements Iterable<BookmarkExpense> {
             throw new BookmarkTransactionNotFoundException();
         }
 
+        if (contains(editedBookmarkExpense)) {
+            throw new DuplicateBookmarkTransactionException("expense");
+        }
+
         internalBookmarkExpenseList.set(index, editedBookmarkExpense);
     }
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/bookmark/BookmarkIncomeList.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/bookmark/BookmarkIncomeList.java
@@ -56,6 +56,10 @@ public class BookmarkIncomeList implements Iterable<BookmarkIncome> {
             throw new BookmarkTransactionNotFoundException();
         }
 
+        if (contains(editedBookmarkIncome)) {
+            throw new DuplicateBookmarkTransactionException("income");
+        }
+
         internalBookmarkIncomeList.set(index, editedBookmarkIncome);
     }
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/bookmark/BookmarkIncomeList.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/bookmark/BookmarkIncomeList.java
@@ -56,7 +56,7 @@ public class BookmarkIncomeList implements Iterable<BookmarkIncome> {
             throw new BookmarkTransactionNotFoundException();
         }
 
-        if (contains(editedBookmarkIncome)) {
+        if (contains(editedBookmarkIncome) && !(target.getTitle().equals(editedBookmarkIncome.getTitle()))) {
             throw new DuplicateBookmarkTransactionException("income");
         }
 

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmarkcommands/EditBookmarkExpenseCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmarkcommands/EditBookmarkExpenseCommandTest.java
@@ -3,8 +3,10 @@ package ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmarkcommands;
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_BOOKMARK_EXPENSE_DISPLAYED_INDEX;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DESC_PHONE_BILL;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DESC_SPOTIFY_SUBSCRIPTION;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_AMOUNT_BUBBLE_TEA;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_AMOUNT_SPOTIFY_SUBSCRIPTION;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_CATEGORY_MISCELLANEOUS;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_TITLE_BUBBLE_TEA;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_TITLE_SPOTIFY_SUBSCRIPTION;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandFailure;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandSuccess;
@@ -34,7 +36,9 @@ public class EditBookmarkExpenseCommandTest {
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
-        BookmarkExpense editedBookmarkExpense = new BookmarkTransactionBuilder().buildBookmarkExpense();
+        BookmarkExpense editedBookmarkExpense = new BookmarkTransactionBuilder()
+                .withTitle(VALID_TITLE_BUBBLE_TEA).withAmount(VALID_AMOUNT_SPOTIFY_SUBSCRIPTION)
+                .buildBookmarkExpense();
         EditBookmarkTransactionDescriptor descriptor =
                 new EditBookmarkTransactionDescriptorBuilder(editedBookmarkExpense).build();
         EditBookmarkExpenseCommand editBookmarkExpenseCommand =
@@ -55,12 +59,12 @@ public class EditBookmarkExpenseCommandTest {
         BookmarkExpense lastExpense = model.getFilteredBookmarkExpenseList().get(indexLastExpense.getZeroBased());
 
         BookmarkTransactionBuilder expenseInList = new BookmarkTransactionBuilder(lastExpense);
-        BookmarkExpense editedExpense = expenseInList.withTitle(VALID_TITLE_SPOTIFY_SUBSCRIPTION)
-                .withAmount(VALID_AMOUNT_SPOTIFY_SUBSCRIPTION)
+        BookmarkExpense editedExpense = expenseInList.withTitle(VALID_TITLE_BUBBLE_TEA)
+                .withAmount(VALID_AMOUNT_BUBBLE_TEA)
                 .withCategories(VALID_CATEGORY_MISCELLANEOUS).buildBookmarkExpense();
 
         EditBookmarkTransactionDescriptor descriptor = new EditBookmarkTransactionDescriptorBuilder()
-                .withTitle(VALID_TITLE_SPOTIFY_SUBSCRIPTION).withAmount(VALID_AMOUNT_SPOTIFY_SUBSCRIPTION)
+                .withTitle(VALID_TITLE_BUBBLE_TEA).withAmount(VALID_AMOUNT_BUBBLE_TEA)
                 .withCategories(VALID_CATEGORY_MISCELLANEOUS).build();
         EditBookmarkExpenseCommand editBookmarkExpenseCommand =
                 new EditBookmarkExpenseCommand(indexLastExpense, descriptor);

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmarkcommands/EditBookmarkIncomeCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/bookmarkcommands/EditBookmarkIncomeCommandTest.java
@@ -5,6 +5,7 @@ import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DESC_
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DESC_SPOTIFY_SUBSCRIPTION;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_AMOUNT_PART_TIME;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_CATEGORY_WORK;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_TITLE_INTERNSHIP;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_TITLE_PART_TIME;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandFailure;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandSuccess;
@@ -55,12 +56,12 @@ public class EditBookmarkIncomeCommandTest {
         BookmarkIncome lastIncome = model.getFilteredBookmarkIncomeList().get(indexLastIncome.getZeroBased());
 
         BookmarkTransactionBuilder incomeInList = new BookmarkTransactionBuilder(lastIncome);
-        BookmarkIncome editedIncome = incomeInList.withTitle(VALID_TITLE_PART_TIME)
+        BookmarkIncome editedIncome = incomeInList.withTitle(VALID_TITLE_INTERNSHIP)
                 .withAmount(VALID_AMOUNT_PART_TIME)
                 .withCategories(VALID_CATEGORY_WORK).buildBookmarkIncome();
 
         EditBookmarkTransactionDescriptor descriptor = new EditBookmarkTransactionDescriptorBuilder()
-                .withTitle(VALID_TITLE_PART_TIME).withAmount(VALID_AMOUNT_PART_TIME)
+                .withTitle(VALID_TITLE_INTERNSHIP).withAmount(VALID_AMOUNT_PART_TIME)
                 .withCategories(VALID_CATEGORY_WORK).build();
         EditBookmarkIncomeCommand editBookmarkIncomeCommand =
                 new EditBookmarkIncomeCommand(indexLastIncome, descriptor);

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtilTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtilTest.java
@@ -82,7 +82,7 @@ public class ParserUtilTest {
         String titleWithExtraWhitespaceBetweenWords = VALID_TITLE.replaceAll(WHITESPACE, moreThanOneWhitespace);
         Title expectedTitle = new Title(VALID_TITLE);
         assertEquals(expectedTitle,
-                ParserUtil.parseTitleWithAdditionalWhitespace(titleWithExtraWhitespaceBetweenWords));
+                ParserUtil.parseTitleAndTrimBetweenWords(titleWithExtraWhitespaceBetweenWords));
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/bookmark/BookmarkExpenseListTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/bookmark/BookmarkExpenseListTest.java
@@ -42,25 +42,25 @@ public class BookmarkExpenseListTest {
     @Test
     public void setBookmarkExpense_nullTargetBookmarkExpense_throwsNullPointerException() {
         assertThrows(NullPointerException.class, ()
-            -> bookmarkExpenseList.setBookmark(null, PHONE_BILL));
+            -> bookmarkExpenseList.setBookmarkExpense(null, PHONE_BILL));
     }
 
     @Test
     public void setBookmarkExpense_nullEditedBookmarkExpense_throwsNullPointerException() {
         assertThrows(NullPointerException.class, ()
-            -> bookmarkExpenseList.setBookmark(PHONE_BILL, null));
+            -> bookmarkExpenseList.setBookmarkExpense(PHONE_BILL, null));
     }
 
     @Test
     public void setBookmarkExpense_targetBookmarkExpenseNotInList_throwsTransactionNotFoundException() {
         assertThrows(BookmarkTransactionNotFoundException.class, ()
-            -> bookmarkExpenseList.setBookmark(PHONE_BILL, PHONE_BILL));
+            -> bookmarkExpenseList.setBookmarkExpense(PHONE_BILL, PHONE_BILL));
     }
 
     @Test
     public void setBookmarkExpense_editedBookmarkExpenseIsSameBookmarkExpense_success() {
         bookmarkExpenseList.add(PHONE_BILL);
-        bookmarkExpenseList.setBookmark(PHONE_BILL, PHONE_BILL);
+        bookmarkExpenseList.setBookmarkExpense(PHONE_BILL, PHONE_BILL);
         BookmarkExpenseList expectedTransactionList = new BookmarkExpenseList();
         expectedTransactionList.add(PHONE_BILL);
         assertEquals(expectedTransactionList, bookmarkExpenseList);
@@ -71,16 +71,26 @@ public class BookmarkExpenseListTest {
         bookmarkExpenseList.add(PHONE_BILL);
         BookmarkExpense editedPhone = new BookmarkTransactionBuilder(PHONE_BILL)
                 .withCategories(VALID_CATEGORY_UTILITIES).buildBookmarkExpense();
-        bookmarkExpenseList.setBookmark(PHONE_BILL, editedPhone);
+        bookmarkExpenseList.setBookmarkExpense(PHONE_BILL, editedPhone);
         BookmarkExpenseList expectedTransactionList = new BookmarkExpenseList();
         expectedTransactionList.add(editedPhone);
         assertEquals(expectedTransactionList, bookmarkExpenseList);
     }
 
     @Test
+    public void setBookmarkExpense_editedBookmarkExpenseIsDuplicateOfAnotherBookmarkExpense() {
+        bookmarkExpenseList.add(PHONE_BILL);
+        bookmarkExpenseList.add(SPOTIFY_SUBSCRIPTION);
+        BookmarkExpense editedPhoneBill = new BookmarkTransactionBuilder(PHONE_BILL)
+                .withTitle(SPOTIFY_SUBSCRIPTION.getTitle().toString()).buildBookmarkExpense();
+        assertThrows(DuplicateBookmarkTransactionException.class, ()
+            -> bookmarkExpenseList.setBookmarkExpense(PHONE_BILL, editedPhoneBill));
+    }
+
+    @Test
     public void setBookmarkExpense_editedBookmarkExpenseHasDifferentIdentity_success() {
         bookmarkExpenseList.add(PHONE_BILL);
-        bookmarkExpenseList.setBookmark(PHONE_BILL, SPOTIFY_SUBSCRIPTION);
+        bookmarkExpenseList.setBookmarkExpense(PHONE_BILL, SPOTIFY_SUBSCRIPTION);
         BookmarkExpenseList expectedTransactionList = new BookmarkExpenseList();
         expectedTransactionList.add(SPOTIFY_SUBSCRIPTION);
         assertEquals(expectedTransactionList, bookmarkExpenseList);

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/bookmark/BookmarkIncomeListTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/bookmark/BookmarkIncomeListTest.java
@@ -77,6 +77,16 @@ public class BookmarkIncomeListTest {
     }
 
     @Test
+    public void setBookmarkIncome_editedBookmarkIncomeIsDuplicateOfAnotherBookmarkIncome() {
+        bookmarkIncomeList.add(PART_TIME);
+        bookmarkIncomeList.add(INVESTING);
+        BookmarkIncome editedPartTime = new BookmarkTransactionBuilder(PART_TIME)
+                .withTitle(INVESTING.getTitle().toString()).buildBookmarkIncome();
+        assertThrows(DuplicateBookmarkTransactionException.class, ()
+            -> bookmarkIncomeList.setBookmarkIncome(PART_TIME, editedPartTime));
+    }
+
+    @Test
     public void setBookmarkIncome_editedBookmarkIncomeHasDifferentIdentity_success() {
         bookmarkIncomeList.add(PART_TIME);
         bookmarkIncomeList.setBookmarkIncome(PART_TIME, INVESTING);


### PR DESCRIPTION
Resolves #245.

Added an additional check when setting edited `Bookmark Income` and `Bookmark Expense` to prevent the bookmark income and bookmark expense list from containing duplicate bookmark incomes and bookmark expenses respectively. Added unit tests to test the additional check when setting the edited `Bookmark Income` and `Bookmark Expense`.

Updated the user guide to include a clear description of what duplicate `Bookmark Incomes` and `Bookmark Expenses` are and also to tell users that editing a title of a bookmark income/expense to an already existing title in the bookmark income/expense list is not allowed.