### PR TITLE
Replace non-breaking spaces with regular spaces

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
@@ -80,7 +80,10 @@ public class FinanceTrackerParser {
      * @throws ParseException If the user input does not conform the expected format.
      */
     public Command parseCommand(String userInput, UiState uiState) throws ParseException {
-        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        // Replace non-breaking spaces with regular spaces and trim.
+        String trimmedUserInput = userInput.replaceAll("\u00A0", " ").trim();
+
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(trimmedUserInput);
         if (!matcher.matches()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }


### PR DESCRIPTION
This is a pre-emptive change to counter possible bug reports stemming from the use of non-breaking space characters. The user guide makes use of non-breaking spaces in some sections because regular spaces can get broken at, and cannot be chained in Markdown.

Resolves #262.