### PR TITLE
Modify base commands to throw exception on execute

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/commons/core/Messages.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/commons/core/Messages.java
@@ -8,8 +8,6 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_TAB_FORMAT = "'%s' command can only be used in the following tabs: %s";
-    public static final String MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX =
-            "The transaction index provided is invalid.";
     public static final String MESSAGE_INVALID_BOOKMARK_EXPENSE_DISPLAYED_INDEX =
             "The bookmark expense index provided is invalid";
     public static final String MESSAGE_INVALID_BOOKMARK_INCOME_DISPLAYED_INDEX =
@@ -21,5 +19,6 @@ public class Messages {
     public static final String MESSAGE_TRANSACTIONS_LISTED_OVERVIEW = "%1$d transactions listed!";
     public static final String MESSAGE_EXPENSES_LISTED_OVERVIEW = "%1$d expenses listed!";
     public static final String MESSAGE_INCOMES_LISTED_OVERVIEW = "%1$d incomes listed!";
+    public static final String MESSAGE_METHOD_SHOULD_NOT_BE_CALLED = "This method should not be called.";
 
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/DeleteCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/DeleteCommand.java
@@ -1,5 +1,7 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 
+import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_METHOD_SHOULD_NOT_BE_CALLED;
+
 import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
@@ -36,7 +38,7 @@ public class DeleteCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        throw new CommandException("This method should not be called.");
+        throw new CommandException(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/DeleteCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/DeleteCommand.java
@@ -24,8 +24,6 @@ public class DeleteCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_TRANSACTION_SUCCESS = "Deleted Transaction: %1$s";
-
     private final Index targetIndex;
 
     public DeleteCommand(Index targetIndex) {

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/DeleteCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/DeleteCommand.java
@@ -1,14 +1,8 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 
-import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX;
-import static java.util.Objects.requireNonNull;
-
-import java.util.List;
-
 import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
-import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 
 /**
  * Deletes a transaction identified using its displayed index from the finance tracker
@@ -42,16 +36,7 @@ public class DeleteCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        requireNonNull(model);
-        List<Transaction> lastShownList = model.getFilteredTransactionList();
-
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
-        }
-
-        Transaction transactionToDelete = lastShownList.get(targetIndex.getZeroBased());
-        model.deleteTransaction(transactionToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_TRANSACTION_SUCCESS, transactionToDelete));
+        throw new CommandException("This method should not be called.");
     }
 
     @Override

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditCommand.java
@@ -18,10 +18,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
-import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
-import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
-import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 
 /**
  * Edits the details of an existing transaction using its displayed index from the finance tracker
@@ -80,28 +77,6 @@ public class EditCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         throw new CommandException("This method should not be called.");
-    }
-
-    /**
-     * Creates and returns a {@code Transaction} with the details of {@code transactionToEdit}
-     * edited with {@code editTransactionDescriptor}.
-     */
-    private static Transaction createEditedTransaction(Transaction transactionToEdit,
-                                                       EditTransactionDescriptor editTransactionDescriptor) {
-        assert transactionToEdit != null;
-
-        Title updatedTitle = editTransactionDescriptor.getTitle().orElse(transactionToEdit.getTitle());
-        Amount updatedAmount = editTransactionDescriptor.getAmount().orElse(transactionToEdit.getAmount());
-        Date updatedDate = editTransactionDescriptor.getDate().orElse(transactionToEdit.getDate());
-        Set<Category> updatedCategories = editTransactionDescriptor.getCategories()
-                .orElse(transactionToEdit.getCategories());
-
-        if (transactionToEdit instanceof Expense) {
-            return new Expense(updatedTitle, updatedAmount, updatedDate, updatedCategories);
-        } else {
-            assert transactionToEdit instanceof Income;
-            return new Income(updatedTitle, updatedAmount, updatedDate, updatedCategories);
-        }
     }
 
     @Override

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditCommand.java
@@ -1,16 +1,13 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 
-import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_DATE;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_TITLE;
-import static ay2021s1_cs2103_w16_3.finesse.model.Model.PREDICATE_SHOW_ALL_TRANSACTIONS;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -82,20 +79,7 @@ public class EditCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        requireNonNull(model);
-        List<Transaction> lastShownList = model.getFilteredTransactionList();
-
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
-        }
-
-        Transaction transactionToEdit = lastShownList.get(targetIndex.getZeroBased());
-        Transaction editedTransaction = createEditedTransaction(transactionToEdit, editTransactionDescriptor);
-
-        model.setTransaction(transactionToEdit, editedTransaction);
-        model.updateFilteredTransactionList(PREDICATE_SHOW_ALL_TRANSACTIONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_TRANSACTION_SUCCESS, editedTransaction),
-                isAmountOrDateEdited());
+        throw new CommandException("This method should not be called.");
     }
 
     /**

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditCommand.java
@@ -1,5 +1,6 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 
+import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_METHOD_SHOULD_NOT_BE_CALLED;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_DATE;
@@ -76,7 +77,7 @@ public class EditCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        throw new CommandException("This method should not be called.");
+        throw new CommandException(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditCommand.java
@@ -45,7 +45,6 @@ public class EditCommand extends Command {
             + PREFIX_AMOUNT + "5 "
             + PREFIX_DATE + "22/09/2020";
 
-    public static final String MESSAGE_EDIT_TRANSACTION_SUCCESS = "Edited Transaction: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
 
     private final Index targetIndex;

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/FindCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/FindCommand.java
@@ -1,6 +1,5 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 
-
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT_FROM;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT_TO;
@@ -9,12 +8,11 @@ import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_DATE;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_DATE_FROM;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_DATE_TO;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_TITLE;
-import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 import java.util.function.Predicate;
 
-import ay2021s1_cs2103_w16_3.finesse.commons.core.Messages;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 
@@ -61,12 +59,8 @@ public class FindCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model) {
-        requireNonNull(model);
-        model.updateFilteredTransactionList(predicates);
-        return new CommandResult(
-                String.format(Messages.MESSAGE_TRANSACTIONS_LISTED_OVERVIEW,
-                        model.getFilteredTransactionList().size()));
+    public CommandResult execute(Model model) throws CommandException {
+        throw new CommandException("This method should not be called.");
     }
 
     @Override

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/FindCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/FindCommand.java
@@ -1,5 +1,6 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 
+import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_METHOD_SHOULD_NOT_BE_CALLED;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT_FROM;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT_TO;
@@ -60,7 +61,7 @@ public class FindCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        throw new CommandException("This method should not be called.");
+        throw new CommandException(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListCommand.java
@@ -14,7 +14,6 @@ public class ListCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Listed all transactions";
 
-
     @Override
     public CommandResult execute(Model model) throws CommandException {
         throw new CommandException(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListCommand.java
@@ -1,5 +1,7 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 
+import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_METHOD_SHOULD_NOT_BE_CALLED;
+
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 
@@ -15,6 +17,6 @@ public class ListCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        throw new CommandException("This method should not be called.");
+        throw new CommandException(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListCommand.java
@@ -1,8 +1,6 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 
-import static ay2021s1_cs2103_w16_3.finesse.model.Model.PREDICATE_SHOW_ALL_TRANSACTIONS;
-import static java.util.Objects.requireNonNull;
-
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.exceptions.CommandException;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 
 /**
@@ -16,9 +14,7 @@ public class ListCommand extends Command {
 
 
     @Override
-    public CommandResult execute(Model model) {
-        requireNonNull(model);
-        model.updateFilteredTransactionList(PREDICATE_SHOW_ALL_TRANSACTIONS);
-        return new CommandResult(MESSAGE_SUCCESS);
+    public CommandResult execute(Model model) throws CommandException {
+        throw new CommandException("This method should not be called.");
     }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/DeleteCommandTest.java
@@ -20,10 +20,9 @@ import ay2021s1_cs2103_w16_3.finesse.model.UserPrefs;
  */
 public class DeleteCommandTest {
 
-    private Model model = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
-
     @Test
     public void execute_throwsCommandException() {
+        Model model = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
         assertCommandFailure(new DeleteCommand(INDEX_FIRST), model, MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/DeleteCommandTest.java
@@ -1,9 +1,6 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 
-import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandFailure;
-import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.showTransactionAtIndex;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalIndexes.INDEX_FIRST;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalIndexes.INDEX_SECOND;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.getTypicalFinanceTracker;
@@ -12,11 +9,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.ModelManager;
 import ay2021s1_cs2103_w16_3.finesse.model.UserPrefs;
-import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 
 /**
  * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for
@@ -27,55 +22,8 @@ public class DeleteCommandTest {
     private Model model = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
 
     @Test
-    public void execute_validIndexUnfilteredList_success() {
-        Transaction transactionToDelete = model.getFilteredTransactionList()
-                .get(INDEX_FIRST.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST);
-
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_TRANSACTION_SUCCESS, transactionToDelete);
-
-        ModelManager expectedModel = new ModelManager(model.getFinanceTracker(), new UserPrefs());
-        expectedModel.deleteTransaction(transactionToDelete);
-
-        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
-    }
-
-    @Test
-    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTransactionList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
-
-        assertCommandFailure(deleteCommand, model, MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
-    }
-
-    @Test
-    public void execute_validIndexFilteredList_success() {
-        showTransactionAtIndex(model, INDEX_FIRST);
-
-        Transaction transactionToDelete = model.getFilteredTransactionList()
-                .get(INDEX_FIRST.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST);
-
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_TRANSACTION_SUCCESS, transactionToDelete);
-
-        Model expectedModel = new ModelManager(model.getFinanceTracker(), new UserPrefs());
-        expectedModel.deleteTransaction(transactionToDelete);
-        showNoTransactions(expectedModel);
-
-        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
-    }
-
-    @Test
-    public void execute_invalidIndexFilteredList_throwsCommandException() {
-        showTransactionAtIndex(model, INDEX_FIRST);
-
-        Index outOfBoundIndex = INDEX_SECOND;
-        // Ensures that outOfBoundIndex is still within the boundaries of the finance tracker's list of transactions.
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getFinanceTracker().getTransactionList().size());
-
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
-
-        assertCommandFailure(deleteCommand, model, MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
+    public void execute_throwsCommandException() {
+        assertCommandFailure(new DeleteCommand(INDEX_FIRST), model, "This method should not be called.");
     }
 
     @Test
@@ -100,12 +48,4 @@ public class DeleteCommandTest {
         assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
     }
 
-    /**
-     * Updates {@code model}'s filtered list to show no transactions.
-     */
-    private void showNoTransactions(Model model) {
-        model.updateFilteredTransactionList(p -> false);
-
-        assertTrue(model.getFilteredTransactionList().isEmpty());
-    }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/DeleteCommandTest.java
@@ -1,5 +1,6 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 
+import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_METHOD_SHOULD_NOT_BE_CALLED;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandFailure;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalIndexes.INDEX_FIRST;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalIndexes.INDEX_SECOND;
@@ -23,7 +24,7 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_throwsCommandException() {
-        assertCommandFailure(new DeleteCommand(INDEX_FIRST), model, "This method should not be called.");
+        assertCommandFailure(new DeleteCommand(INDEX_FIRST), model, MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditCommandTest.java
@@ -1,14 +1,8 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 
-import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DESC_BUBBLE_TEA;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DESC_INTERNSHIP;
-import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_AMOUNT_INTERNSHIP;
-import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_CATEGORY_WORK;
-import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_TITLE_INTERNSHIP;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandFailure;
-import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.showTransactionAtIndex;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalIndexes.INDEX_FIRST;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalIndexes.INDEX_SECOND;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.getTypicalFinanceTracker;
@@ -17,17 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.EditCommand.EditTransactionDescriptor;
-import ay2021s1_cs2103_w16_3.finesse.model.FinanceTracker;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.ModelManager;
 import ay2021s1_cs2103_w16_3.finesse.model.UserPrefs;
-import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
-import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
-import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
-import ay2021s1_cs2103_w16_3.finesse.testutil.EditTransactionDescriptorBuilder;
-import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
 
 /**
  * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for EditCommand.
@@ -37,130 +24,9 @@ public class EditCommandTest {
     private Model model = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
 
     @Test
-    public void execute_allFieldsSpecifiedUnfilteredList_success() {
-        Transaction transactionToEdit = model.getFilteredTransactionList().get(0);
-
-        TransactionBuilder editedTransactionBuilder = new TransactionBuilder();
-        Transaction editedTransaction;
-        if (transactionToEdit instanceof Expense) {
-            editedTransaction = editedTransactionBuilder.buildExpense();
-        } else {
-            assertTrue(transactionToEdit instanceof Income);
-            editedTransaction = editedTransactionBuilder.buildIncome();
-        }
-
-        EditCommand.EditTransactionDescriptor descriptor =
-                new EditTransactionDescriptorBuilder(editedTransaction).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST, descriptor);
-
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS, editedTransaction);
-
-        Model expectedModel = new ModelManager(new FinanceTracker(model.getFinanceTracker()), new UserPrefs());
-        expectedModel.setTransaction(transactionToEdit, editedTransaction);
-        if (descriptor.isAmountOrDateEdited()) {
-            expectedModel.calculateBudgetInfo();
-        }
-
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel, descriptor.isAmountOrDateEdited());
-    }
-
-    @Test
-    public void execute_someFieldsSpecifiedUnfilteredList_success() {
-        Index indexLastTransaction = Index.fromOneBased(model.getFilteredTransactionList().size());
-        Transaction lastTransaction = model.getFilteredTransactionList().get(indexLastTransaction.getZeroBased());
-
-        TransactionBuilder editedTransactionBuilder = new TransactionBuilder(lastTransaction)
-                .withTitle(VALID_TITLE_INTERNSHIP).withAmount(VALID_AMOUNT_INTERNSHIP)
-                .withCategories(VALID_CATEGORY_WORK);
-        Transaction editedTransaction;
-        if (lastTransaction instanceof Expense) {
-            editedTransaction = editedTransactionBuilder.buildExpense();
-        } else {
-            assertTrue(lastTransaction instanceof Income);
-            editedTransaction = editedTransactionBuilder.buildIncome();
-        }
-
-        EditCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder()
-                .withTitle(VALID_TITLE_INTERNSHIP).withAmount(VALID_AMOUNT_INTERNSHIP)
-                .withCategories(VALID_CATEGORY_WORK).build();
-        EditCommand editCommand = new EditCommand(indexLastTransaction, descriptor);
-
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS, editedTransaction);
-
-        Model expectedModel = new ModelManager(new FinanceTracker(model.getFinanceTracker()), new UserPrefs());
-        expectedModel.setTransaction(lastTransaction, editedTransaction);
-        if (descriptor.isAmountOrDateEdited()) {
-            expectedModel.calculateBudgetInfo();
-        }
-
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel, descriptor.isAmountOrDateEdited());
-    }
-
-    @Test
-    public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditCommand(INDEX_FIRST, new EditTransactionDescriptor());
-        Transaction editedTransaction = model.getFilteredTransactionList().get(INDEX_FIRST.getZeroBased());
-
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS, editedTransaction);
-
-        Model expectedModel = new ModelManager(new FinanceTracker(model.getFinanceTracker()), new UserPrefs());
-
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
-    }
-
-    @Test
-    public void execute_filteredList_success() {
-        showTransactionAtIndex(model, INDEX_FIRST);
-
-        Transaction transactionInFilteredList = model.getFilteredTransactionList()
-                .get(INDEX_FIRST.getZeroBased());
-
-        TransactionBuilder editedTransactionBuilder =
-                new TransactionBuilder(transactionInFilteredList).withTitle(VALID_TITLE_INTERNSHIP);
-        Transaction editedTransaction;
-        if (transactionInFilteredList instanceof Expense) {
-            editedTransaction = editedTransactionBuilder.buildExpense();
-        } else {
-            assertTrue(transactionInFilteredList instanceof Income);
-            editedTransaction = editedTransactionBuilder.buildIncome();
-        }
-
-        EditCommand editCommand = new EditCommand(INDEX_FIRST,
-                new EditTransactionDescriptorBuilder().withTitle(VALID_TITLE_INTERNSHIP).build());
-
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS, editedTransaction);
-
-        Model expectedModel = new ModelManager(new FinanceTracker(model.getFinanceTracker()), new UserPrefs());
-        expectedModel.setTransaction(transactionInFilteredList, editedTransaction);
-
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
-    }
-
-    @Test
-    public void execute_invalidTransactionIndexUnfilteredList_failure() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTransactionList().size() + 1);
-        EditCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder()
-                .withTitle(VALID_TITLE_INTERNSHIP).build();
-        EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
-
-        assertCommandFailure(editCommand, model, MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
-    }
-
-    /**
-     * Edit filtered list where index is larger than size of filtered list,
-     * but smaller than size of finance tracker
-     */
-    @Test
-    public void execute_invalidTransactionIndexFilteredList_failure() {
-        showTransactionAtIndex(model, INDEX_FIRST);
-        Index outOfBoundIndex = INDEX_SECOND;
-        // Ensures that outOfBoundIndex is still within the boundaries of the finance tracker's list of transactions.
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getFinanceTracker().getTransactionList().size());
-
-        EditCommand editCommand = new EditCommand(outOfBoundIndex,
-                new EditTransactionDescriptorBuilder().withTitle(VALID_TITLE_INTERNSHIP).build());
-
-        assertCommandFailure(editCommand, model, MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
+    public void execute_throwsCommandExcepion() {
+        assertCommandFailure(new EditCommand(INDEX_FIRST, new EditTransactionDescriptor()), model,
+                "This method should not be called.");
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditCommandTest.java
@@ -22,10 +22,9 @@ import ay2021s1_cs2103_w16_3.finesse.model.UserPrefs;
  */
 public class EditCommandTest {
 
-    private Model model = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
-
     @Test
     public void execute_throwsCommandExcepion() {
+        Model model = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
         assertCommandFailure(new EditCommand(INDEX_FIRST, new EditTransactionDescriptor()), model,
                 MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/EditCommandTest.java
@@ -1,5 +1,6 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 
+import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_METHOD_SHOULD_NOT_BE_CALLED;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DESC_BUBBLE_TEA;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DESC_INTERNSHIP;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandFailure;
@@ -26,7 +27,7 @@ public class EditCommandTest {
     @Test
     public void execute_throwsCommandExcepion() {
         assertCommandFailure(new EditCommand(INDEX_FIRST, new EditTransactionDescriptor()), model,
-                "This method should not be called.");
+                MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/FindCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/FindCommandTest.java
@@ -25,11 +25,10 @@ import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
  */
 public class FindCommandTest {
-    private Model model = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
-    private Model expectedModel = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
 
     @Test
     public void execute_throwsCommandException() {
+        Model model = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
         assertCommandFailure(new FindCommand(List.of(preparePredicate(""))), model,
                 MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/FindCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/FindCommandTest.java
@@ -19,7 +19,6 @@ import ay2021s1_cs2103_w16_3.finesse.model.ModelManager;
 import ay2021s1_cs2103_w16_3.finesse.model.UserPrefs;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.predicates.TitleContainsKeyphrasesPredicate;
-import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -65,7 +64,7 @@ public class FindCommandTest {
         // different predicates -> returns false
         assertFalse(findFirstCommand.equals(findSecondCommand));
     }
-    
+
     /**
      * Parses {@code userInput} into a {@code TitleContainsKeyphrasesPredicate}.
      */

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/FindCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/FindCommandTest.java
@@ -1,15 +1,7 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 
-import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_TRANSACTIONS_LISTED_OVERVIEW;
-import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.AIMA;
-import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.CARLS_JR;
-import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.GST_VOUCHER;
-import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.INTERNSHIP;
-import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.PEN_REFILLS;
-import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.TEACHING_ASSISTANT;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandFailure;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.getTypicalFinanceTracker;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -34,6 +26,12 @@ import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
 public class FindCommandTest {
     private Model model = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
     private Model expectedModel = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
+
+    @Test
+    public void execute_throwsCommandException() {
+        assertCommandFailure(new FindCommand(List.of(preparePredicate(""))), model,
+                "This method should not be called.");
+    }
 
     @Test
     public void equals() {
@@ -67,39 +65,7 @@ public class FindCommandTest {
         // different predicates -> returns false
         assertFalse(findFirstCommand.equals(findSecondCommand));
     }
-
-    @Test
-    public void execute_zeroKeywords_noTransactionsFound() {
-        String expectedMessage = String.format(MESSAGE_TRANSACTIONS_LISTED_OVERVIEW, 0);
-        TitleContainsKeyphrasesPredicate predicate = preparePredicate(" ");
-        List<Predicate<Transaction>> predicateList = new ArrayList<>();
-        predicateList.add(predicate);
-        FindCommand command = new FindCommand(predicateList);
-        expectedModel.updateFilteredTransactionList(predicateList);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredTransactionList());
-    }
-
-    @Test
-    public void execute_multipleKeywords_multipleTransactionsFound() {
-        String expectedMessage = String.format(MESSAGE_TRANSACTIONS_LISTED_OVERVIEW, 6);
-        TitleContainsKeyphrasesPredicate predicate = preparePredicate("gst carl's artificial internship pen teaching");
-        List<Predicate<Transaction>> predicateList = new ArrayList<>();
-        predicateList.add(predicate);
-        FindCommand command = new FindCommand(predicateList);
-        expectedModel.updateFilteredTransactionList(predicateList);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        // Ordered by date, then by title.
-        assertEquals(Arrays.asList(
-                new TransactionBuilder(AIMA).buildExpense(),
-                new TransactionBuilder(CARLS_JR).buildExpense(),
-                new TransactionBuilder(GST_VOUCHER).buildIncome(),
-                new TransactionBuilder(INTERNSHIP).buildIncome(),
-                new TransactionBuilder(PEN_REFILLS).buildExpense(),
-                new TransactionBuilder(TEACHING_ASSISTANT).buildIncome()
-        ), model.getFilteredTransactionList());
-    }
-
+    
     /**
      * Parses {@code userInput} into a {@code TitleContainsKeyphrasesPredicate}.
      */

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/FindCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/FindCommandTest.java
@@ -1,5 +1,6 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 
+import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_METHOD_SHOULD_NOT_BE_CALLED;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandFailure;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.getTypicalFinanceTracker;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -30,7 +31,7 @@ public class FindCommandTest {
     @Test
     public void execute_throwsCommandException() {
         assertCommandFailure(new FindCommand(List.of(preparePredicate(""))), model,
-                "This method should not be called.");
+                MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListCommandTest.java
@@ -4,7 +4,6 @@ import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_METHOD
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandFailure;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.getTypicalFinanceTracker;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
@@ -16,17 +15,9 @@ import ay2021s1_cs2103_w16_3.finesse.model.UserPrefs;
  */
 public class ListCommandTest {
 
-    private Model model;
-    private Model expectedModel;
-
-    @BeforeEach
-    public void setUp() {
-        model = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
-        expectedModel = new ModelManager(model.getFinanceTracker(), new UserPrefs());
-    }
-
     @Test
     public void execute_throwsCommandException() {
+        Model model = new ModelManager(getTypicalFinanceTracker(), new UserPrefs());
         assertCommandFailure(new ListCommand(), model, MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListCommandTest.java
@@ -1,5 +1,6 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 
+import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_METHOD_SHOULD_NOT_BE_CALLED;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandFailure;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.getTypicalFinanceTracker;
 
@@ -26,6 +27,6 @@ public class ListCommandTest {
 
     @Test
     public void execute_throwsCommandException() {
-        assertCommandFailure(new ListCommand(), model, "This method should not be called.");
+        assertCommandFailure(new ListCommand(), model, MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/ListCommandTest.java
@@ -1,8 +1,6 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands;
 
-import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.showTransactionAtIndex;
-import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalIndexes.INDEX_FIRST;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandFailure;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.getTypicalFinanceTracker;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -27,13 +25,7 @@ public class ListCommandTest {
     }
 
     @Test
-    public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
-    }
-
-    @Test
-    public void execute_listIsFiltered_showsEverything() {
-        showTransactionAtIndex(model, INDEX_FIRST);
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+    public void execute_throwsCommandException() {
+        assertCommandFailure(new ListCommand(), model, "This method should not be called.");
     }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/stubs/DeleteCommandStub.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/stubs/DeleteCommandStub.java
@@ -1,5 +1,7 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands.stubs;
 
+import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_METHOD_SHOULD_NOT_BE_CALLED;
+
 import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.DeleteCommand;
@@ -30,11 +32,11 @@ public class DeleteCommandStub extends DeleteCommand {
 
     @Override
     public CommandResult execute(Model model) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public boolean equals(Object other) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/stubs/EditCommandStub.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/stubs/EditCommandStub.java
@@ -1,5 +1,7 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands.stubs;
 
+import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_METHOD_SHOULD_NOT_BE_CALLED;
+
 import ay2021s1_cs2103_w16_3.finesse.commons.core.index.Index;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.EditCommand;
@@ -42,11 +44,11 @@ public class EditCommandStub extends EditCommand {
 
     @Override
     public CommandResult execute(Model model) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public boolean equals(Object other) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/stubs/FindCommandStub.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/stubs/FindCommandStub.java
@@ -1,5 +1,7 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands.stubs;
 
+import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_METHOD_SHOULD_NOT_BE_CALLED;
+
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -33,11 +35,11 @@ public class FindCommandStub extends FindCommand {
 
     @Override
     public CommandResult execute(Model model) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public boolean equals(Object other) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/stubs/ModelStub.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/stubs/ModelStub.java
@@ -1,5 +1,7 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands.stubs;
 
+import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_METHOD_SHOULD_NOT_BE_CALLED;
+
 import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Predicate;
@@ -23,176 +25,176 @@ import javafx.collections.ObservableList;
 public class ModelStub implements Model {
     @Override
     public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public ReadOnlyUserPrefs getUserPrefs() {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public GuiSettings getGuiSettings() {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void setGuiSettings(GuiSettings guiSettings) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public Path getFinanceTrackerFilePath() {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void setFinanceTrackerFilePath(Path financeTrackerFilePath) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void addExpense(Expense expense) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void addIncome(Income income) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void addBookmarkExpense(BookmarkExpense bookmarkExpense) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void addBookmarkIncome(BookmarkIncome bookmarkIncome) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void setFinanceTracker(ReadOnlyFinanceTracker newData) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public ReadOnlyFinanceTracker getFinanceTracker() {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void deleteTransaction(Transaction target) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void deleteBookmarkExpense(BookmarkExpense target) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void deleteBookmarkIncome(BookmarkIncome target) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void setTransaction(Transaction target, Transaction editedTransaction) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void setBookmarkExpense(BookmarkExpense target, BookmarkExpense editedBookmarkExpense) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void setBookmarkIncome(BookmarkIncome target, BookmarkIncome editedBookmarkIncome) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public MonthlyBudget getMonthlyBudget() {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void setExpenseLimit(Amount limit) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void setSavingsGoal(Amount goal) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void calculateBudgetInfo() {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public ObservableList<Transaction> getFilteredTransactionList() {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public ObservableList<Expense> getFilteredExpenseList() {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public ObservableList<Income> getFilteredIncomeList() {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public ObservableList<BookmarkExpense> getFilteredBookmarkExpenseList() {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public ObservableList<BookmarkIncome> getFilteredBookmarkIncomeList() {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void updateFilteredTransactionList(Predicate<Transaction> predicate) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void updateFilteredTransactionList(List<Predicate<Transaction>> predicates) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void updateFilteredExpenseList(Predicate<Transaction> predicate) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void updateFilteredExpenseList(List<Predicate<Transaction>> predicates) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void updateFilteredIncomeList(Predicate<Transaction> predicate) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void updateFilteredIncomeList(List<Predicate<Transaction>> predicates) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void updateFilteredBookmarkExpenseList(Predicate<BookmarkExpense> predicate) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 
     @Override
     public void updateFilteredBookmarkIncomeList(Predicate<BookmarkIncome> predicate) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
     }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
@@ -1,6 +1,7 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.parser;
 
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_METHOD_SHOULD_NOT_BE_CALLED;
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.Assert.assertThrows;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalIndexes.INDEX_FIRST;
@@ -545,12 +546,12 @@ public class FinanceTrackerParserTest {
     private static class UiStateStub extends UiState {
         @Override
         public Tab getCurrentTab() {
-            throw new AssertionError("This method should not be called.");
+            throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
         }
 
         @Override
         public void setCurrentTab(Tab currentTab) {
-            throw new AssertionError("This method should not be called.");
+            throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
         }
     }
 


### PR DESCRIPTION
Resolves #125.

Changes:
* Update `execute` methods in `DeleteCommand`, `EditCommand`, `FindCommand` and `ListCommand` to throw `CommandException`
* Replace all tests on the method `execute` in `DeleteCommandTest`, `EditCommandTest`, `FindCommandTest` and `ListCommandTest` with a single test each `execute_throwsCommandException`
* Replace all string values `"This method should not be called."` with the constant `MESSAGE_METHOD_SHOULD_NOT_BE_CALLED` in `Messages`