### PR TITLE
Enforce no arguments for single-word commands

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -165,6 +165,8 @@ This section aims to provide you with in-depth details on Fine\$\$e's unique fea
 * Parameters can be in any order.<br>
   e.g. if the command specifies `t/TITLE a/AMOUNT`, `a/AMOUNT t/TITLE` is also acceptable.
 
+* Any leading/trailing whitespaces for the user input as a whole will be ignored. e.g. `   find t/Bubble Tea   ` will be treated as `find t/Bubble Tea`.
+
 </div>
 
 <div markdown="block" class="alert alert-info">

--- a/docs/team/wltan.md
+++ b/docs/team/wltan.md
@@ -12,7 +12,7 @@ Fine$$e is a desktop finance tracker that allows tertiary students to better man
 ### Summary of Contributions
 
 * **New feature**: Overhauled the validation rules for data models.
-  * What it does: Transforms the data model from the base Address Book project to one that is more suitable for the needs of Fine\$\$e. 
+  * What it does: Transforms the data model from the base Address Book project to one that is more suitable for the needs of Fine\$\$e.
   * Justification: Previously, the project contained data models such as `Name` and `Email`.
   In the initial stages of the project, to minimize the amount of development work needed we decided to map some of the existing models over to Fine\$\$e.
   However, the existing models had some existing validation rules which do not make sense in Fine\$\$e.
@@ -20,7 +20,7 @@ Fine$$e is a desktop finance tracker that allows tertiary students to better man
   However, a layer of abstraction is maintained such that other components do not need to depend on the underlying data types.
   This includes converting the internal data from `public` to `private`, and using accessors to retrieve the data.
 
-* **New feature**: Drafted the initial design for UI-dependent commands. 
+* **New feature**: Drafted the initial design for UI-dependent commands.
   * What it does: Allows the user to use commands with different behavior based on the current state of the user interface (in particular, which tab is currently active).
   * Justification: This streamlines the user experience, as they only need to remember a small set of intuitive commands.
   * Highlights: The existing commands were reused as much as possible, while complying with the standard OOP principles.
@@ -47,7 +47,7 @@ Fine$$e is a desktop finance tracker that allows tertiary students to better man
     * Fixed some user guide bugs between v1.3 and v1.3.1. (Pull request [#206](https://github.com/AY2021S1-CS2103T-W16-3/tp/pull/206))
   * Developer Guide:
     * Elaborated on the `Model` component documentation, and added Pitest to the DevOps guide. (Pull request [#140](https://github.com/AY2021S1-CS2103T-W16-3/tp/pull/140))
-  
+
 * **Community**:
   * PRs reviewed (with non-trivial review comments):
   [#123](https://github.com/AY2021S1-CS2103T-W16-3/tp/pull/123),
@@ -63,4 +63,4 @@ Fine$$e is a desktop finance tracker that allows tertiary students to better man
   * Updated Gradle from `5.2.1` to `6.6.1`. (Pull request [#3](https://github.com/AY2021S1-CS2103T-W16-3/tp/pull/3))
   * Set up [PIT mutation testing](http://pitest.org/) as a test coverage tool, as an alternative to JaCoCo and CodeCov.
   (Pull request [#6](https://github.com/AY2021S1-CS2103T-W16-3/tp/pull/6))
-  
+

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/commons/core/Messages.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/commons/core/Messages.java
@@ -5,13 +5,13 @@ package ay2021s1_cs2103_w16_3.finesse.commons.core;
  */
 public class Messages {
 
-    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
-    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_TAB_FORMAT = "'%s' command can only be used in the following tabs: %s";
+    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command.";
+    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s.";
+    public static final String MESSAGE_INVALID_TAB_FORMAT = "'%s' command can only be used in the following tabs: %s.";
     public static final String MESSAGE_INVALID_BOOKMARK_EXPENSE_DISPLAYED_INDEX =
-            "The bookmark expense index provided is invalid";
+            "The bookmark expense index provided is invalid.";
     public static final String MESSAGE_INVALID_BOOKMARK_INCOME_DISPLAYED_INDEX =
-            "The bookmark income index provided is invalid";
+            "The bookmark income index provided is invalid.";
     public static final String MESSAGE_INVALID_EXPENSE_DISPLAYED_INDEX =
             "The expense index provided is invalid.";
     public static final String MESSAGE_INVALID_INCOME_DISPLAYED_INDEX =
@@ -20,5 +20,6 @@ public class Messages {
     public static final String MESSAGE_EXPENSES_LISTED_OVERVIEW = "%1$d expenses listed!";
     public static final String MESSAGE_INCOMES_LISTED_OVERVIEW = "%1$d incomes listed!";
     public static final String MESSAGE_METHOD_SHOULD_NOT_BE_CALLED = "This method should not be called.";
+    public static final String MESSAGE_NO_ARGUMENTS_COMMAND_FORMAT = "'%s' command cannot have any arguments.";
 
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
@@ -2,7 +2,9 @@ package ay2021s1_cs2103_w16_3.finesse.logic.parser;
 
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_TAB_FORMAT;
+import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_NO_ARGUMENTS_COMMAND_FORMAT;
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static java.util.Objects.requireNonNull;
 
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -179,6 +181,7 @@ public class FinanceTrackerParser {
             }
 
         case ClearCommand.COMMAND_WORD:
+            enforceNoArguments(ClearCommand.COMMAND_WORD, arguments);
             return new ClearCommand();
 
         case FindCommand.COMMAND_WORD:
@@ -203,6 +206,7 @@ public class FinanceTrackerParser {
             return new SetSavingsGoalCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
+            enforceNoArguments(ListCommand.COMMAND_WORD, arguments);
             switch (uiCurrentTab) {
             case OVERVIEW:
                 return new ListTransactionCommand();
@@ -217,20 +221,25 @@ public class FinanceTrackerParser {
 
         case ListTransactionCommand.COMMAND_WORD:
         case ListTransactionCommand.COMMAND_ALIAS:
+            enforceNoArguments(ListTransactionCommand.COMMAND_WORD, arguments);
             return new ListTransactionCommand();
 
         case ListExpenseCommand.COMMAND_WORD:
         case ListExpenseCommand.COMMAND_ALIAS:
+            enforceNoArguments(ListExpenseCommand.COMMAND_WORD, arguments);
             return new ListExpenseCommand();
 
         case ListIncomeCommand.COMMAND_WORD:
         case ListIncomeCommand.COMMAND_ALIAS:
+            enforceNoArguments(ListIncomeCommand.COMMAND_WORD, arguments);
             return new ListIncomeCommand();
 
         case ExitCommand.COMMAND_WORD:
+            enforceNoArguments(ExitCommand.COMMAND_WORD, arguments);
             return new ExitCommand();
 
         case HelpCommand.COMMAND_WORD:
+            enforceNoArguments(HelpCommand.COMMAND_WORD, arguments);
             return new HelpCommand();
 
         case TabCommand.COMMAND_WORD:
@@ -252,4 +261,18 @@ public class FinanceTrackerParser {
                 Stream.of(tabs).map(Tab::toString).collect(Collectors.joining(", ")));
     }
 
+    /**
+     * Enforces that no arguments are input for commands that take in no arguments.
+     *
+     * @param command The command word that was used.
+     * @param args The arguments that the user input.
+     * @throws ParseException If {@code args} is not the empty string.
+     */
+    private void enforceNoArguments(String command, String args) throws ParseException {
+        requireNonNull(command);
+        requireNonNull(args);
+        if (!args.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_NO_ARGUMENTS_COMMAND_FORMAT, command));
+        }
+    }
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/AddBookmarkIncomeCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/AddBookmarkIncomeCommandParser.java
@@ -19,6 +19,9 @@ import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
 
+/**
+ * Parses input arguments and creates a new AddBookmarkIncomeCommand object
+ */
 public class AddBookmarkIncomeCommandParser implements Parser<AddBookmarkIncomeCommand> {
 
     /**

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/ConvertBookmarkExpenseCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/ConvertBookmarkExpenseCommandParser.java
@@ -18,7 +18,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 
 /**
- * Parser input arguments and creates a new ConvertBookmarkExpenseCommand object
+ * Parses input arguments and creates a new ConvertBookmarkExpenseCommand object
  */
 public class ConvertBookmarkExpenseCommandParser implements Parser<ConvertBookmarkExpenseCommand> {
     /**

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/ConvertBookmarkIncomeCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/ConvertBookmarkIncomeCommandParser.java
@@ -18,7 +18,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 
 /**
- * Parser input arguments and creates a new ConvertBookmarkIncomeCommand object
+ * Parses input arguments and creates a new ConvertBookmarkIncomeCommand object
  */
 public class ConvertBookmarkIncomeCommandParser implements Parser<ConvertBookmarkIncomeCommand> {
     /**

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/DeleteBookmarkExpenseCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/DeleteBookmarkExpenseCommandParser.java
@@ -9,7 +9,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.parser.ParserUtil;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
 
 /**
- * Parser input arguments and creates a new DeleteBookmarkExpenseCommand object
+ * Parses input arguments and creates a new DeleteBookmarkExpenseCommand object
  */
 public class DeleteBookmarkExpenseCommandParser implements Parser<DeleteBookmarkExpenseCommand> {
     /**

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/DeleteBookmarkIncomeCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/DeleteBookmarkIncomeCommandParser.java
@@ -9,7 +9,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.parser.ParserUtil;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
 
 /**
- * Parser input arguments and creates a new DeleteBookmarkIncomeCommand object
+ * Parses input arguments and creates a new DeleteBookmarkIncomeCommand object
  */
 public class DeleteBookmarkIncomeCommandParser implements Parser<DeleteBookmarkIncomeCommand> {
     /**

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
@@ -245,29 +245,21 @@ public class FinanceTrackerParserTest {
     @Test
     public void parseCommand_clearWhenOverviewTab() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, overviewUiStateStub) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD,
-                overviewUiStateStub) instanceof ClearCommand);
     }
 
     @Test
     public void parseCommand_clearWhenIncomeTab() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, incomeUiStateStub) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD,
-                incomeUiStateStub) instanceof ClearCommand);
     }
 
     @Test
     public void parseCommand_clearWhenExpensesTab() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, expensesUiStateStub) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD,
-                expensesUiStateStub) instanceof ClearCommand);
     }
 
     @Test
     public void parseCommand_clearWhenAnalyticsTab() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, analyticsUiStateStub) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD,
-                analyticsUiStateStub) instanceof ClearCommand);
     }
 
     @Test
@@ -468,29 +460,21 @@ public class FinanceTrackerParserTest {
     @Test
     public void parseCommand_exitWhenOverviewTab() throws Exception {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, overviewUiStateStub) instanceof ExitCommand);
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD,
-                overviewUiStateStub) instanceof ExitCommand);
     }
 
     @Test
     public void parseCommand_exitWhenIncomeTab() throws Exception {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, incomeUiStateStub) instanceof ExitCommand);
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD,
-                incomeUiStateStub) instanceof ExitCommand);
     }
 
     @Test
     public void parseCommand_exitWhenExpensesTab() throws Exception {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, expensesUiStateStub) instanceof ExitCommand);
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD,
-                expensesUiStateStub) instanceof ExitCommand);
     }
 
     @Test
     public void parseCommand_exitWhenAnalyticsTab() throws Exception {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, analyticsUiStateStub) instanceof ExitCommand);
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD,
-                analyticsUiStateStub) instanceof ExitCommand);
     }
 
     @Test
@@ -561,29 +545,21 @@ public class FinanceTrackerParserTest {
     @Test
     public void parseCommand_helpWhenOverviewTab() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, overviewUiStateStub) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD,
-                overviewUiStateStub) instanceof HelpCommand);
     }
 
     @Test
     public void parseCommand_helpWhenIncomeTab() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, incomeUiStateStub) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD,
-                incomeUiStateStub) instanceof HelpCommand);
     }
 
     @Test
     public void parseCommand_helpWhenExpensesTab() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, expensesUiStateStub) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD,
-                expensesUiStateStub) instanceof HelpCommand);
     }
 
     @Test
     public void parseCommand_helpWhenAnalyticsTab() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, analyticsUiStateStub) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD,
-                analyticsUiStateStub) instanceof HelpCommand);
     }
 
     @Test
@@ -614,24 +590,18 @@ public class FinanceTrackerParserTest {
     public void parseCommand_listWhenOverviewTab() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, overviewUiStateStub)
                 instanceof ListTransactionCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD,
-                overviewUiStateStub) instanceof ListTransactionCommand);
     }
 
     @Test
     public void parseCommand_listWhenIncomeTab() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, incomeUiStateStub)
                 instanceof ListIncomeCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD,
-                incomeUiStateStub) instanceof ListIncomeCommand);
     }
 
     @Test
     public void parseCommand_listWhenExpensesTab() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, expensesUiStateStub)
                 instanceof ListExpenseCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD,
-                expensesUiStateStub) instanceof ListExpenseCommand);
     }
 
     @Test
@@ -667,32 +637,24 @@ public class FinanceTrackerParserTest {
     public void parseCommand_listTransactionWhenOverviewTab() throws Exception {
         assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD, overviewUiStateStub)
                 instanceof ListTransactionCommand);
-        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD,
-                overviewUiStateStub) instanceof ListTransactionCommand);
     }
 
     @Test
     public void parseCommand_listTransactionWhenIncomeTab() throws Exception {
         assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD, incomeUiStateStub)
                 instanceof ListTransactionCommand);
-        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD,
-                incomeUiStateStub) instanceof ListTransactionCommand);
     }
 
     @Test
     public void parseCommand_listTransactionWhenExpensesTab() throws Exception {
         assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD, expensesUiStateStub)
                 instanceof ListTransactionCommand);
-        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD,
-                expensesUiStateStub) instanceof ListTransactionCommand);
     }
 
     @Test
     public void parseCommand_listTransactionWhenAnalyticsTab() throws Exception {
         assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD, analyticsUiStateStub)
                 instanceof ListTransactionCommand);
-        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD,
-                analyticsUiStateStub) instanceof ListTransactionCommand);
     }
 
     @Test
@@ -723,32 +685,24 @@ public class FinanceTrackerParserTest {
     public void parseCommand_listExpenseWhenOverviewTab() throws Exception {
         assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD, overviewUiStateStub)
                 instanceof ListExpenseCommand);
-        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD,
-                overviewUiStateStub) instanceof ListExpenseCommand);
     }
 
     @Test
     public void parseCommand_listExpenseWhenIncomeTab() throws Exception {
         assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD, incomeUiStateStub)
                 instanceof ListExpenseCommand);
-        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD,
-                incomeUiStateStub) instanceof ListExpenseCommand);
     }
 
     @Test
     public void parseCommand_listExpenseWhenExpensesTab() throws Exception {
         assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD, expensesUiStateStub)
                 instanceof ListExpenseCommand);
-        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD,
-                expensesUiStateStub) instanceof ListExpenseCommand);
     }
 
     @Test
     public void parseCommand_listExpenseWhenAnalyticsTab() throws Exception {
         assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD, analyticsUiStateStub)
                 instanceof ListExpenseCommand);
-        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD,
-                analyticsUiStateStub) instanceof ListExpenseCommand);
     }
 
     @Test
@@ -779,32 +733,24 @@ public class FinanceTrackerParserTest {
     public void parseCommand_listIncomeWhenOverviewTab() throws Exception {
         assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD, overviewUiStateStub)
                 instanceof ListIncomeCommand);
-        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD,
-                overviewUiStateStub) instanceof ListIncomeCommand);
     }
 
     @Test
     public void parseCommand_listIncomeWhenIncomeTab() throws Exception {
         assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD, incomeUiStateStub)
                 instanceof ListIncomeCommand);
-        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD,
-                incomeUiStateStub) instanceof ListIncomeCommand);
     }
 
     @Test
     public void parseCommand_listIncomeWhenExpensesTab() throws Exception {
         assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD, expensesUiStateStub)
                 instanceof ListIncomeCommand);
-        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD,
-                expensesUiStateStub) instanceof ListIncomeCommand);
     }
 
     @Test
     public void parseCommand_listIncomeWhenAnalyticsTab() throws Exception {
         assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD, analyticsUiStateStub)
                 instanceof ListIncomeCommand);
-        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD,
-                analyticsUiStateStub) instanceof ListIncomeCommand);
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
@@ -245,29 +245,53 @@ public class FinanceTrackerParserTest {
     @Test
     public void parseCommand_clearWhenOverviewTab() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, overviewUiStateStub) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD,
                 overviewUiStateStub) instanceof ClearCommand);
     }
 
     @Test
     public void parseCommand_clearWhenIncomeTab() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, incomeUiStateStub) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD,
                 incomeUiStateStub) instanceof ClearCommand);
     }
 
     @Test
     public void parseCommand_clearWhenExpensesTab() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, expensesUiStateStub) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD,
                 expensesUiStateStub) instanceof ClearCommand);
     }
 
     @Test
     public void parseCommand_clearWhenAnalyticsTab() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, analyticsUiStateStub) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD,
                 analyticsUiStateStub) instanceof ClearCommand);
+    }
+
+    @Test
+    public void parseCommand_clearWithArgsWhenOverviewTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ClearCommand.COMMAND_WORD + "a", overviewUiStateStub));
+    }
+
+    @Test
+    public void parseCommand_clearWithArgsWhenIncomeTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ClearCommand.COMMAND_WORD + "a", incomeUiStateStub));
+    }
+
+    @Test
+    public void parseCommand_clearWithArgsWhenExpensesTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ClearCommand.COMMAND_WORD + "a", expensesUiStateStub));
+    }
+
+    @Test
+    public void parseCommand_clearWithArgsWhenAnalyticsTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ClearCommand.COMMAND_WORD + "a", analyticsUiStateStub));
     }
 
     @Test
@@ -444,29 +468,53 @@ public class FinanceTrackerParserTest {
     @Test
     public void parseCommand_exitWhenOverviewTab() throws Exception {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, overviewUiStateStub) instanceof ExitCommand);
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD,
                 overviewUiStateStub) instanceof ExitCommand);
     }
 
     @Test
     public void parseCommand_exitWhenIncomeTab() throws Exception {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, incomeUiStateStub) instanceof ExitCommand);
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD,
                 incomeUiStateStub) instanceof ExitCommand);
     }
 
     @Test
     public void parseCommand_exitWhenExpensesTab() throws Exception {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, expensesUiStateStub) instanceof ExitCommand);
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD,
                 expensesUiStateStub) instanceof ExitCommand);
     }
 
     @Test
     public void parseCommand_exitWhenAnalyticsTab() throws Exception {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, analyticsUiStateStub) instanceof ExitCommand);
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD,
                 analyticsUiStateStub) instanceof ExitCommand);
+    }
+
+    @Test
+    public void parseCommand_exitWithArgsWhenOverviewTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ExitCommand.COMMAND_WORD + "a", overviewUiStateStub));
+    }
+
+    @Test
+    public void parseCommand_exitWithArgsWhenIncomeTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ExitCommand.COMMAND_WORD + "a", incomeUiStateStub));
+    }
+
+    @Test
+    public void parseCommand_exitWithArgsWhenExpensesTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ExitCommand.COMMAND_WORD + "a", expensesUiStateStub));
+    }
+
+    @Test
+    public void parseCommand_exitWithArgsWhenAnalyticsTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ExitCommand.COMMAND_WORD + "a", analyticsUiStateStub));
     }
 
     @Test
@@ -513,36 +561,60 @@ public class FinanceTrackerParserTest {
     @Test
     public void parseCommand_helpWhenOverviewTab() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, overviewUiStateStub) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD,
                 overviewUiStateStub) instanceof HelpCommand);
     }
 
     @Test
     public void parseCommand_helpWhenIncomeTab() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, incomeUiStateStub) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD,
                 incomeUiStateStub) instanceof HelpCommand);
     }
 
     @Test
     public void parseCommand_helpWhenExpensesTab() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, expensesUiStateStub) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD,
                 expensesUiStateStub) instanceof HelpCommand);
     }
 
     @Test
     public void parseCommand_helpWhenAnalyticsTab() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, analyticsUiStateStub) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD,
                 analyticsUiStateStub) instanceof HelpCommand);
+    }
+
+    @Test
+    public void parseCommand_helpWithArgsWhenOverviewTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(HelpCommand.COMMAND_WORD + "a", overviewUiStateStub));
+    }
+
+    @Test
+    public void parseCommand_helpWithArgsWhenIncomeTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(HelpCommand.COMMAND_WORD + "a", incomeUiStateStub));
+    }
+
+    @Test
+    public void parseCommand_helpWithArgsWhenExpensesTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(HelpCommand.COMMAND_WORD + "a", expensesUiStateStub));
+    }
+
+    @Test
+    public void parseCommand_helpWithArgsWhenAnalyticsTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(HelpCommand.COMMAND_WORD + "a", analyticsUiStateStub));
     }
 
     @Test
     public void parseCommand_listWhenOverviewTab() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, overviewUiStateStub)
                 instanceof ListTransactionCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD,
                 overviewUiStateStub) instanceof ListTransactionCommand);
     }
 
@@ -550,7 +622,7 @@ public class FinanceTrackerParserTest {
     public void parseCommand_listWhenIncomeTab() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, incomeUiStateStub)
                 instanceof ListIncomeCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD,
                 incomeUiStateStub) instanceof ListIncomeCommand);
     }
 
@@ -558,20 +630,44 @@ public class FinanceTrackerParserTest {
     public void parseCommand_listWhenExpensesTab() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, expensesUiStateStub)
                 instanceof ListExpenseCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD,
                 expensesUiStateStub) instanceof ListExpenseCommand);
     }
 
     @Test
-    public void parseCommand_listWhenAnalyticsTab() throws Exception {
+    public void parseCommand_listWhenAnalyticsTab() {
         assertThrows(ParseException.class, () -> parser.parseCommand(ListCommand.COMMAND_WORD, analyticsUiStateStub));
+    }
+
+    @Test
+    public void parseCommand_listWithArgsWhenOverviewTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ListCommand.COMMAND_WORD + "a", overviewUiStateStub));
+    }
+
+    @Test
+    public void parseCommand_listWithArgsWhenIncomeTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ListCommand.COMMAND_WORD + "a", incomeUiStateStub));
+    }
+
+    @Test
+    public void parseCommand_listWithArgsWhenExpensesTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ListCommand.COMMAND_WORD + "a", expensesUiStateStub));
+    }
+
+    @Test
+    public void parseCommand_listWithArgsWhenAnalyticsTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ListCommand.COMMAND_WORD + "a", analyticsUiStateStub));
     }
 
     @Test
     public void parseCommand_listTransactionWhenOverviewTab() throws Exception {
         assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD, overviewUiStateStub)
                 instanceof ListTransactionCommand);
-        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD,
                 overviewUiStateStub) instanceof ListTransactionCommand);
     }
 
@@ -579,7 +675,7 @@ public class FinanceTrackerParserTest {
     public void parseCommand_listTransactionWhenIncomeTab() throws Exception {
         assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD, incomeUiStateStub)
                 instanceof ListTransactionCommand);
-        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD,
                 incomeUiStateStub) instanceof ListTransactionCommand);
     }
 
@@ -587,7 +683,7 @@ public class FinanceTrackerParserTest {
     public void parseCommand_listTransactionWhenExpensesTab() throws Exception {
         assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD, expensesUiStateStub)
                 instanceof ListTransactionCommand);
-        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD,
                 expensesUiStateStub) instanceof ListTransactionCommand);
     }
 
@@ -595,15 +691,39 @@ public class FinanceTrackerParserTest {
     public void parseCommand_listTransactionWhenAnalyticsTab() throws Exception {
         assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD, analyticsUiStateStub)
                 instanceof ListTransactionCommand);
-        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD,
                 analyticsUiStateStub) instanceof ListTransactionCommand);
+    }
+
+    @Test
+    public void parseCommand_listTransactionWithArgsWhenOverviewTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ListTransactionCommand.COMMAND_WORD + "a", overviewUiStateStub));
+    }
+
+    @Test
+    public void parseCommand_listTransactionWithArgsWhenIncomeTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ListTransactionCommand.COMMAND_WORD + "a", incomeUiStateStub));
+    }
+
+    @Test
+    public void parseCommand_listTransactionWithArgsWhenExpensesTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ListTransactionCommand.COMMAND_WORD + "a", expensesUiStateStub));
+    }
+
+    @Test
+    public void parseCommand_listTransactionWithArgsWhenAnalyticsTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ListTransactionCommand.COMMAND_WORD + "a", analyticsUiStateStub));
     }
 
     @Test
     public void parseCommand_listExpenseWhenOverviewTab() throws Exception {
         assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD, overviewUiStateStub)
                 instanceof ListExpenseCommand);
-        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD,
                 overviewUiStateStub) instanceof ListExpenseCommand);
     }
 
@@ -611,7 +731,7 @@ public class FinanceTrackerParserTest {
     public void parseCommand_listExpenseWhenIncomeTab() throws Exception {
         assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD, incomeUiStateStub)
                 instanceof ListExpenseCommand);
-        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD,
                 incomeUiStateStub) instanceof ListExpenseCommand);
     }
 
@@ -619,7 +739,7 @@ public class FinanceTrackerParserTest {
     public void parseCommand_listExpenseWhenExpensesTab() throws Exception {
         assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD, expensesUiStateStub)
                 instanceof ListExpenseCommand);
-        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD,
                 expensesUiStateStub) instanceof ListExpenseCommand);
     }
 
@@ -627,15 +747,39 @@ public class FinanceTrackerParserTest {
     public void parseCommand_listExpenseWhenAnalyticsTab() throws Exception {
         assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD, analyticsUiStateStub)
                 instanceof ListExpenseCommand);
-        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD,
                 analyticsUiStateStub) instanceof ListExpenseCommand);
+    }
+
+    @Test
+    public void parseCommand_listExpenseWithArgsWhenOverviewTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ListExpenseCommand.COMMAND_WORD + "a", overviewUiStateStub));
+    }
+
+    @Test
+    public void parseCommand_listExpenseWithArgsWhenIncomeTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ListExpenseCommand.COMMAND_WORD + "a", incomeUiStateStub));
+    }
+
+    @Test
+    public void parseCommand_listExpenseWithArgsWhenExpensesTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ListExpenseCommand.COMMAND_WORD + "a", expensesUiStateStub));
+    }
+
+    @Test
+    public void parseCommand_listExpenseWithArgsWhenAnalyticsTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ListExpenseCommand.COMMAND_WORD + "a", analyticsUiStateStub));
     }
 
     @Test
     public void parseCommand_listIncomeWhenOverviewTab() throws Exception {
         assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD, overviewUiStateStub)
                 instanceof ListIncomeCommand);
-        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD,
                 overviewUiStateStub) instanceof ListIncomeCommand);
     }
 
@@ -643,7 +787,7 @@ public class FinanceTrackerParserTest {
     public void parseCommand_listIncomeWhenIncomeTab() throws Exception {
         assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD, incomeUiStateStub)
                 instanceof ListIncomeCommand);
-        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD,
                 incomeUiStateStub) instanceof ListIncomeCommand);
     }
 
@@ -651,7 +795,7 @@ public class FinanceTrackerParserTest {
     public void parseCommand_listIncomeWhenExpensesTab() throws Exception {
         assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD, expensesUiStateStub)
                 instanceof ListIncomeCommand);
-        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD,
                 expensesUiStateStub) instanceof ListIncomeCommand);
     }
 
@@ -659,8 +803,32 @@ public class FinanceTrackerParserTest {
     public void parseCommand_listIncomeWhenAnalyticsTab() throws Exception {
         assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD, analyticsUiStateStub)
                 instanceof ListIncomeCommand);
-        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD + " 3",
+        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD,
                 analyticsUiStateStub) instanceof ListIncomeCommand);
+    }
+
+    @Test
+    public void parseCommand_listIncomeWithArgsWhenOverviewTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ListIncomeCommand.COMMAND_WORD + "a", overviewUiStateStub));
+    }
+
+    @Test
+    public void parseCommand_listIncomeWithArgsWhenIncomeTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ListIncomeCommand.COMMAND_WORD + "a", incomeUiStateStub));
+    }
+
+    @Test
+    public void parseCommand_listIncomeWithArgsWhenExpensesTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ListIncomeCommand.COMMAND_WORD + "a", expensesUiStateStub));
+    }
+
+    @Test
+    public void parseCommand_listIncomeWithArgsWhenAnalyticsTab() {
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ListIncomeCommand.COMMAND_WORD + "a", analyticsUiStateStub));
     }
 
     @Test


### PR DESCRIPTION
Changes:
- Restrict the user from entering arguments for single-word commands.
  - `clear`
  - `exit`
  - `help`
  - `list` (including variants)
- Update tests accordingly.
- Minor spelling/grammar corrections.

Note that I did not end up using the parsers as it would result in a lot of repetitive code. In addition, using the parsers would mean that the error message that is shown cannot be customised to display the entered command, as there would be no way of disambiguating between the various `list` variants.

Fixes #280.