### PR TITLE
Add empty argument error checks

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/commons/core/Messages.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/commons/core/Messages.java
@@ -6,7 +6,7 @@ package ay2021s1_cs2103_w16_3.finesse.commons.core;
 public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command.";
-    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s.";
+    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_TAB_FORMAT = "'%s' command can only be used in the following tabs: %s.";
     public static final String MESSAGE_INVALID_BOOKMARK_EXPENSE_DISPLAYED_INDEX =
             "The bookmark expense index provided is invalid.";

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/commons/util/StringUtil.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/commons/util/StringUtil.java
@@ -24,7 +24,7 @@ public class StringUtil {
      */
     public static boolean containsIgnoreCase(String sentence, String keyphrase) {
         requireNonNull(sentence);
-        checkEmptyString(keyphrase);
+        checkArgument(!isEmptyString(keyphrase), "Keyphrase cannot be empty");
 
         String preppedWord = keyphrase.trim();
         return sentence.toLowerCase().contains(preppedWord.toLowerCase());
@@ -35,9 +35,9 @@ public class StringUtil {
      * A string is considered empty if it is the empty string, or is a string consisting of only whitespaces.
      * @param s cannot be null
      */
-    public static void checkEmptyString(String s) {
+    public static boolean isEmptyString(String s) {
         requireNonNull(s);
-        checkArgument(!s.trim().isEmpty(), "Parameter cannot be empty");
+        return s.trim().isEmpty();
     }
 
     /**

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FindCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FindCommandParser.java
@@ -1,6 +1,7 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.parser;
 
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static ay2021s1_cs2103_w16_3.finesse.commons.util.StringUtil.isEmptyString;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT_FROM;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT_TO;
@@ -9,13 +10,13 @@ import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_DATE;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_DATE_FROM;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_DATE_TO;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_TITLE;
+import static ay2021s1_cs2103_w16_3.finesse.model.category.Category.MESSAGE_EMPTY_CATEGORY;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 
-import ay2021s1_cs2103_w16_3.finesse.commons.util.StringUtil;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.FindCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
@@ -71,9 +72,7 @@ public class FindCommandParser implements Parser<FindCommand> {
     public static final String MESSAGE_DATE_RANGE_CONSTRAINTS =
             "The lower bound for the date range cannot be later than the upper bound.";
 
-    public static final String MESSAGE_EMPTY_TITLE_KEYPHRASE = "The title keyphrase to search cannot be empty.";
-
-    public static final String MESSAGE_EMPTY_CATEGORY = "The category to search cannot be empty.";
+    public static final String MESSAGE_EMPTY_TITLE_KEYPHRASE = "Title keyphrases cannot be empty.";
 
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
@@ -87,33 +86,27 @@ public class FindCommandParser implements Parser<FindCommand> {
         List<Predicate<Transaction>> predicateList = new ArrayList<>();
 
         if (argMultimap.moreThanOneValuePresent(PREFIX_AMOUNT)) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_AMOUNT_CONSTRAINTS));
+            throw new ParseException(MESSAGE_AMOUNT_CONSTRAINTS);
         }
 
         if (argMultimap.moreThanOneValuePresent(PREFIX_DATE)) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_DATE_CONSTRAINTS));
+            throw new ParseException(MESSAGE_DATE_CONSTRAINTS);
         }
 
         if (argMultimap.moreThanOneValuePresent(PREFIX_AMOUNT_FROM)) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_AMOUNT_FROM_CONSTRAINTS));
+            throw new ParseException(MESSAGE_AMOUNT_FROM_CONSTRAINTS);
         }
 
         if (argMultimap.moreThanOneValuePresent(PREFIX_AMOUNT_TO)) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_AMOUNT_TO_CONSTRAINTS));
+            throw new ParseException(MESSAGE_AMOUNT_TO_CONSTRAINTS);
         }
 
         if (argMultimap.moreThanOneValuePresent(PREFIX_DATE_FROM)) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_DATE_FROM_CONSTRAINTS));
+            throw new ParseException(MESSAGE_DATE_FROM_CONSTRAINTS);
         }
 
         if (argMultimap.moreThanOneValuePresent(PREFIX_DATE_TO)) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_DATE_TO_CONSTRAINTS));
+            throw new ParseException(MESSAGE_DATE_TO_CONSTRAINTS);
         }
 
         if (!argMultimap.getPreamble().isEmpty()) {
@@ -122,11 +115,12 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         if (argMultimap.getValue(PREFIX_TITLE).isPresent()) {
             List<String> titleKeyphrases = argMultimap.getAllValues(PREFIX_TITLE);
-            try {
-                titleKeyphrases.forEach(s -> StringUtil.checkEmptyString(s));
-            } catch (Exception e) {
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_EMPTY_TITLE_KEYPHRASE));
+            boolean hasEmptyTitleKeyphrase = false;
+            for (String s: titleKeyphrases) {
+                hasEmptyTitleKeyphrase = isEmptyString(s);
+            }
+            if (hasEmptyTitleKeyphrase) {
+                throw new ParseException(MESSAGE_EMPTY_TITLE_KEYPHRASE);
             }
             predicateList.add(new TitleContainsKeyphrasesPredicate(titleKeyphrases));
         }
@@ -143,11 +137,12 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         if (argMultimap.getValue(PREFIX_CATEGORY).isPresent()) {
             List<String> categories = argMultimap.getAllValues(PREFIX_CATEGORY);
-            try {
-                categories.forEach(s -> StringUtil.checkEmptyString(s));
-            } catch (Exception e) {
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_EMPTY_CATEGORY));
+            boolean hasEmptyCategory = false;
+            for (String s: categories) {
+                hasEmptyCategory = isEmptyString(s);
+            }
+            if (hasEmptyCategory) {
+                throw new ParseException(MESSAGE_EMPTY_CATEGORY);
             }
             predicateList.add(new HasCategoriesPredicate(categories));
         }
@@ -163,8 +158,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                 amountTo = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT_TO).get());
             }
             if (amountFrom != null && amountTo != null && amountFrom.compareTo(amountTo) > 0) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                        MESSAGE_AMOUNT_RANGE_CONSTRAINTS));
+                throw new ParseException(MESSAGE_AMOUNT_RANGE_CONSTRAINTS);
             }
             predicateList.add(new InAmountRangePredicate(Optional.ofNullable(amountFrom),
                     Optional.ofNullable(amountTo)));
@@ -181,8 +175,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                 dateTo = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE_TO).get());
             }
             if (dateFrom != null && dateTo != null && dateFrom.compareTo(dateTo) > 0) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                        MESSAGE_DATE_RANGE_CONSTRAINTS));
+                throw new ParseException(MESSAGE_DATE_RANGE_CONSTRAINTS);
             }
             predicateList.add(new InDateRangePredicate(Optional.ofNullable(dateFrom),
                     Optional.ofNullable(dateTo)));

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FindCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FindCommandParser.java
@@ -136,7 +136,7 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         if (argMultimap.getValue(PREFIX_AMOUNT).isPresent()) {
             if (argMultimap.getValue(PREFIX_AMOUNT_FROM).isPresent()
-                || argMultimap.getValue(PREFIX_AMOUNT_TO).isPresent()) {
+                    || argMultimap.getValue(PREFIX_AMOUNT_TO).isPresent()) {
                 throw new ParseException(MESSAGE_AMOUNT_SEARCH_CONSTRAINTS);
             }
             Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FindCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FindCommandParser.java
@@ -115,12 +115,10 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         if (argMultimap.getValue(PREFIX_TITLE).isPresent()) {
             List<String> titleKeyphrases = argMultimap.getAllValues(PREFIX_TITLE);
-            boolean hasEmptyTitleKeyphrase = false;
             for (String s: titleKeyphrases) {
-                hasEmptyTitleKeyphrase = isEmptyString(s);
-            }
-            if (hasEmptyTitleKeyphrase) {
-                throw new ParseException(MESSAGE_EMPTY_TITLE_KEYPHRASE);
+                if (isEmptyString(s)) {
+                    throw new ParseException(MESSAGE_EMPTY_TITLE_KEYPHRASE);
+                }
             }
             predicateList.add(new TitleContainsKeyphrasesPredicate(titleKeyphrases));
         }
@@ -137,12 +135,10 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         if (argMultimap.getValue(PREFIX_CATEGORY).isPresent()) {
             List<String> categories = argMultimap.getAllValues(PREFIX_CATEGORY);
-            boolean hasEmptyCategory = false;
             for (String s: categories) {
-                hasEmptyCategory = isEmptyString(s);
-            }
-            if (hasEmptyCategory) {
-                throw new ParseException(MESSAGE_EMPTY_CATEGORY);
+                if (isEmptyString(s)) {
+                    throw new ParseException(MESSAGE_EMPTY_CATEGORY);
+                }
             }
             predicateList.add(new HasCategoriesPredicate(categories));
         }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FindCommandParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FindCommandParser.java
@@ -136,7 +136,7 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         if (argMultimap.getValue(PREFIX_AMOUNT).isPresent()) {
             if (argMultimap.getValue(PREFIX_AMOUNT_FROM).isPresent()
-            || argMultimap.getValue(PREFIX_AMOUNT_TO).isPresent()) {
+                || argMultimap.getValue(PREFIX_AMOUNT_TO).isPresent()) {
                 throw new ParseException(MESSAGE_AMOUNT_SEARCH_CONSTRAINTS);
             }
             Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtil.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtil.java
@@ -1,5 +1,10 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.parser;
 
+import static ay2021s1_cs2103_w16_3.finesse.commons.util.StringUtil.isEmptyString;
+import static ay2021s1_cs2103_w16_3.finesse.model.category.Category.MESSAGE_EMPTY_CATEGORY;
+import static ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount.MESSAGE_EMPTY_AMOUNT;
+import static ay2021s1_cs2103_w16_3.finesse.model.transaction.Date.MESSAGE_EMPTY_DATE;
+import static ay2021s1_cs2103_w16_3.finesse.model.transaction.Title.MESSAGE_EMPTY_TITLE;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
@@ -43,6 +48,9 @@ public class ParserUtil {
     public static Title parseTitle(String title) throws ParseException {
         requireNonNull(title);
         String trimmedTitle = title.trim();
+        if (isEmptyString(trimmedTitle)) {
+            throw new ParseException(MESSAGE_EMPTY_TITLE);
+        }
         if (!Title.isValidTitle(trimmedTitle)) {
             throw new ParseException(Title.MESSAGE_CONSTRAINTS);
         }
@@ -71,6 +79,9 @@ public class ParserUtil {
     public static Amount parseAmount(String amount) throws ParseException {
         requireNonNull(amount);
         String trimmedAmount = amount.trim();
+        if (isEmptyString(trimmedAmount)) {
+            throw new ParseException(MESSAGE_EMPTY_AMOUNT);
+        }
         if (!Amount.isValidAmount(trimmedAmount)) {
             throw new ParseException(Amount.MESSAGE_CONSTRAINTS);
         }
@@ -86,6 +97,9 @@ public class ParserUtil {
     public static Date parseDate(String date) throws ParseException {
         requireNonNull(date);
         String trimmedDate = date.trim();
+        if (isEmptyString(trimmedDate)) {
+            throw new ParseException(MESSAGE_EMPTY_DATE);
+        }
         if (!Date.isValidDate(trimmedDate)) {
             throw new ParseException(Date.MESSAGE_CONSTRAINTS);
         }
@@ -101,6 +115,9 @@ public class ParserUtil {
     public static Category parseCategory(String category) throws ParseException {
         requireNonNull(category);
         String trimmedCategory = category.trim();
+        if (isEmptyString(trimmedCategory)) {
+            throw new ParseException(MESSAGE_EMPTY_CATEGORY);
+        }
         if (!Category.isValidCategoryName(trimmedCategory)) {
             throw new ParseException(Category.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/category/Category.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/category/Category.java
@@ -12,6 +12,7 @@ public class Category {
     public static final String MESSAGE_CONSTRAINTS =
             "Category names should contain at least one non-whitespace printable ASCII character "
             + "and cannot contain any characters that are not printable ASCII characters.";
+    public static final String MESSAGE_EMPTY_CATEGORY = "Categories cannot be empty.";
     public static final String VALIDATION_REGEX = "\\p{Graph}\\p{Print}*";
 
     private final String categoryName;

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Amount.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Amount.java
@@ -14,6 +14,7 @@ public class Amount implements Comparable<Amount> {
     public static final Amount ZERO_AMOUNT = new Amount("0");
     public static final String MESSAGE_CONSTRAINTS = "Amounts should only contain non-negative numbers up to 8 digits,"
             + " with an optional 2 decimal places or '$' prefix";
+    public static final String MESSAGE_EMPTY_AMOUNT = "Amounts cannot be empty.";
     public static final String VALIDATION_REGEX = "^\\$?\\d{1,8}(\\.\\d{2})?$";
     private final BigDecimal value;
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Date.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Date.java
@@ -20,6 +20,7 @@ public class Date implements Comparable<Date> {
             + "cannot be earlier than " + EPOCH_STRING + ", and cannot be later than the current date";
     public static final DateTimeFormatter VALIDATION_FORMAT = DateTimeFormatter.ofPattern("dd/MM/uuuu")
             .withResolverStyle(ResolverStyle.STRICT);
+    public static final String MESSAGE_EMPTY_DATE = "Dates cannot be empty.";
     private static final LocalDate EPOCH = LocalDate.parse(EPOCH_STRING, VALIDATION_FORMAT);
 
     private final LocalDate value;

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Title.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/Title.java
@@ -12,6 +12,7 @@ public class Title implements Comparable<Title> {
     public static final String MESSAGE_CONSTRAINTS =
             "Titles should contain at least one non-whitespace printable ASCII character "
             + "and cannot contain any characters that are not printable ASCII characters.";
+    public static final String MESSAGE_EMPTY_TITLE = "Titles cannot be empty.";
     public static final String VALIDATION_REGEX = "\\p{Graph}\\p{Print}*";
 
     private final String fullTitle;

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/commons/util/StringUtilTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/commons/util/StringUtilTest.java
@@ -61,7 +61,7 @@ public class StringUtilTest {
 
     @Test
     public void containsIgnoreCase_emptyWord_throwsIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, "Parameter cannot be empty", ()
+        assertThrows(IllegalArgumentException.class, "Keyphrase cannot be empty", ()
             -> StringUtil.containsIgnoreCase("typical sentence", "  "));
     }
 

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/EditCommandParserTest.java
@@ -87,11 +87,11 @@ public class EditCommandParserTest {
         // while parsing {@code PREFIX_CATEGORY} alone will reset the categories of the {@code Transaction} being
         // edited, parsing it together with a valid category results in error
         assertParseFailure(parser, "1" + CATEGORY_DESC_FOOD_BEVERAGE + CATEGORY_DESC_WORK + CATEGORY_EMPTY,
-                Category.MESSAGE_CONSTRAINTS);
+                Category.MESSAGE_EMPTY_CATEGORY);
         assertParseFailure(parser, "1" + CATEGORY_DESC_FOOD_BEVERAGE + CATEGORY_EMPTY + CATEGORY_DESC_WORK,
-                Category.MESSAGE_CONSTRAINTS);
+                Category.MESSAGE_EMPTY_CATEGORY);
         assertParseFailure(parser, "1" + CATEGORY_EMPTY + CATEGORY_DESC_FOOD_BEVERAGE + CATEGORY_DESC_WORK,
-                Category.MESSAGE_CONSTRAINTS);
+                Category.MESSAGE_EMPTY_CATEGORY);
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_TITLE_DESC + INVALID_DATE_DESC + VALID_AMOUNT_BUBBLE_TEA,

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FindCommandParserTest.java
@@ -1,40 +1,266 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.parser;
 
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUNT_DESC_BUBBLE_TEA;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.AMOUNT_DESC_INTERNSHIP;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.CATEGORY_DESC_FOOD_BEVERAGE;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.CATEGORY_DESC_WORK;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DATE_DESC_BUBBLE_TEA;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.DATE_DESC_INTERNSHIP;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.TITLE_DESC_BUBBLE_TEA;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.TITLE_DESC_INTERNSHIP;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_AMOUNT_BUBBLE_TEA;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_AMOUNT_INTERNSHIP;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_CATEGORY_FOOD_BEVERAGE;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_CATEGORY_WORK;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_DATE_BUBBLE_TEA;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_DATE_INTERNSHIP;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_TITLE_BUBBLE_TEA;
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_TITLE_INTERNSHIP;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT_FROM;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT_TO;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_CATEGORY;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_DATE_FROM;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_DATE_TO;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_TITLE;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.FindCommandParser.MESSAGE_AMOUNT_DUPLICATE_CONSTRAINTS;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.FindCommandParser.MESSAGE_AMOUNT_FROM_CONSTRAINTS;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.FindCommandParser.MESSAGE_AMOUNT_RANGE_CONSTRAINTS;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.FindCommandParser.MESSAGE_AMOUNT_SEARCH_CONSTRAINTS;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.FindCommandParser.MESSAGE_AMOUNT_TO_CONSTRAINTS;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.FindCommandParser.MESSAGE_DATE_DUPLICATE_CONSTRAINTS;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.FindCommandParser.MESSAGE_DATE_FROM_CONSTRAINTS;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.FindCommandParser.MESSAGE_DATE_RANGE_CONSTRAINTS;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.FindCommandParser.MESSAGE_DATE_SEARCH_CONSTRAINTS;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.FindCommandParser.MESSAGE_DATE_TO_CONSTRAINTS;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.FindCommandParser.MESSAGE_EMPTY_TITLE_KEYPHRASE;
+import static ay2021s1_cs2103_w16_3.finesse.model.category.Category.MESSAGE_EMPTY_CATEGORY;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.FindCommand;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.predicates.HasCategoriesPredicate;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.predicates.HasExactAmountPredicate;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.predicates.InAmountRangePredicate;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.predicates.InDateRangePredicate;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.predicates.OnExactDatePredicate;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.predicates.TitleContainsKeyphrasesPredicate;
 
 public class FindCommandParserTest {
 
+    public static final String AMOUNT_FROM_DESC_BUBBLE_TEA = " " + PREFIX_AMOUNT_FROM + VALID_AMOUNT_BUBBLE_TEA;
+    public static final String AMOUNT_TO_DESC_BUBBLE_TEA = " " + PREFIX_AMOUNT_TO + VALID_AMOUNT_BUBBLE_TEA;
+    public static final String AMOUNT_FROM_DESC_INTERNSHIP = " " + PREFIX_AMOUNT_FROM + VALID_AMOUNT_INTERNSHIP;
+    public static final String AMOUNT_TO_DESC_INTERNSHIP = " " + PREFIX_AMOUNT_TO + VALID_AMOUNT_INTERNSHIP;
+    public static final String DATE_FROM_DESC_BUBBLE_TEA = " " + PREFIX_DATE_FROM + VALID_DATE_BUBBLE_TEA;
+    public static final String DATE_TO_DESC_BUBBLE_TEA = " " + PREFIX_DATE_TO + VALID_DATE_BUBBLE_TEA;
+    public static final String DATE_FROM_DESC_INTERNSHIP = " " + PREFIX_DATE_FROM + VALID_DATE_INTERNSHIP;
+    public static final String DATE_TO_DESC_INTERNSHIP = " " + PREFIX_DATE_TO + VALID_DATE_INTERNSHIP;
+
     private FindCommandParser parser = new FindCommandParser();
 
     @Test
-    public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    public void parse_validTitleKeyphrases_success() {
+        List<Predicate<Transaction>> predicateList = new ArrayList<>();
+        // one title keyphrase
+        predicateList.add(new TitleContainsKeyphrasesPredicate(Arrays.asList(VALID_TITLE_BUBBLE_TEA)));
+        FindCommand expectedFindCommand = new FindCommand(predicateList);
+        assertParseSuccess(parser, TITLE_DESC_BUBBLE_TEA, expectedFindCommand);
+
+        // multiple title keyphrases
+        predicateList = new ArrayList<>();
+        predicateList.add(new TitleContainsKeyphrasesPredicate(
+                Arrays.asList(VALID_TITLE_BUBBLE_TEA, VALID_TITLE_INTERNSHIP)));
+        expectedFindCommand = new FindCommand(predicateList);
+        assertParseSuccess(parser, TITLE_DESC_BUBBLE_TEA + TITLE_DESC_INTERNSHIP, expectedFindCommand);
     }
 
     @Test
-    public void parse_validArgs_returnsFindCommand() {
-        // no leading and trailing whitespaces
+    public void parse_validAmount_success() {
         List<Predicate<Transaction>> predicateList = new ArrayList<>();
-        predicateList.add(new TitleContainsKeyphrasesPredicate(Arrays.asList("Damith", "Seth")));
-        FindCommand expectedFindCommand =
-                new FindCommand(predicateList);
-        assertParseSuccess(parser, " t/Damith t/Seth", expectedFindCommand);
+        predicateList.add(new HasExactAmountPredicate(new Amount(VALID_AMOUNT_BUBBLE_TEA)));
+        FindCommand expectedFindCommand = new FindCommand(predicateList);
+        assertParseSuccess(parser, AMOUNT_DESC_BUBBLE_TEA, expectedFindCommand);
+    }
 
-        // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n t/Damith \n \t t/Seth  \t", expectedFindCommand);
+    @Test
+    public void parse_validDate_success() {
+        List<Predicate<Transaction>> predicateList = new ArrayList<>();
+        predicateList.add(new OnExactDatePredicate(new Date(VALID_DATE_BUBBLE_TEA)));
+        FindCommand expectedFindCommand = new FindCommand(predicateList);
+        assertParseSuccess(parser, DATE_DESC_BUBBLE_TEA, expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validCategories_success() {
+        List<Predicate<Transaction>> predicateList = new ArrayList<>();
+        // one category
+        predicateList.add(new HasCategoriesPredicate(Arrays.asList(VALID_CATEGORY_FOOD_BEVERAGE)));
+        FindCommand expectedFindCommand = new FindCommand(predicateList);
+        assertParseSuccess(parser, CATEGORY_DESC_FOOD_BEVERAGE, expectedFindCommand);
+
+        // multiple categories
+        predicateList = new ArrayList<>();
+        predicateList.add(new HasCategoriesPredicate(
+                Arrays.asList(VALID_CATEGORY_FOOD_BEVERAGE, VALID_CATEGORY_WORK)));
+        expectedFindCommand = new FindCommand(predicateList);
+        assertParseSuccess(parser, CATEGORY_DESC_FOOD_BEVERAGE + CATEGORY_DESC_WORK, expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validAmountRange_success() {
+        List<Predicate<Transaction>> predicateList = new ArrayList<>();
+        // VALID_AMOUNT_BUBBLE_TEA is less than VALID_AMOUNT_INTERNSHIP
+        Optional<Amount> lowerBound = Optional.of(new Amount(VALID_AMOUNT_BUBBLE_TEA));
+        Optional<Amount> upperBound = Optional.of(new Amount(VALID_AMOUNT_INTERNSHIP));
+
+        // lower bound only
+        predicateList.add(new InAmountRangePredicate(lowerBound, Optional.empty()));
+        FindCommand expectedFindCommand = new FindCommand(predicateList);
+        assertParseSuccess(parser, AMOUNT_FROM_DESC_BUBBLE_TEA, expectedFindCommand);
+
+        // upper bound only
+        predicateList = new ArrayList<>();
+        predicateList.add(new InAmountRangePredicate(Optional.empty(), upperBound));
+        expectedFindCommand = new FindCommand(predicateList);
+        assertParseSuccess(parser, AMOUNT_TO_DESC_INTERNSHIP, expectedFindCommand);
+
+        // upper and lower bound
+        predicateList = new ArrayList<>();
+        predicateList.add(new InAmountRangePredicate(lowerBound, upperBound));
+        expectedFindCommand = new FindCommand(predicateList);
+        assertParseSuccess(parser, AMOUNT_FROM_DESC_BUBBLE_TEA + AMOUNT_TO_DESC_INTERNSHIP, expectedFindCommand);
+
+        // same upper and lower bound values
+        predicateList = new ArrayList<>();
+        predicateList.add(new InAmountRangePredicate(upperBound, upperBound));
+        expectedFindCommand = new FindCommand(predicateList);
+        assertParseSuccess(parser, AMOUNT_FROM_DESC_INTERNSHIP + AMOUNT_TO_DESC_INTERNSHIP, expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validDateRange_success() {
+        List<Predicate<Transaction>> predicateList = new ArrayList<>();
+        // VALID_DATE_INTERNSHIP is earlier than VALID_DATE_BUBBLE_TEA
+        Optional<Date> lowerBound = Optional.of(new Date(VALID_DATE_INTERNSHIP));
+        Optional<Date> upperBound = Optional.of(new Date(VALID_DATE_BUBBLE_TEA));
+
+        // lower bound only
+        predicateList.add(new InDateRangePredicate(lowerBound, Optional.empty()));
+        FindCommand expectedFindCommand = new FindCommand(predicateList);
+        assertParseSuccess(parser, DATE_FROM_DESC_INTERNSHIP, expectedFindCommand);
+
+        // upper bound only
+        predicateList = new ArrayList<>();
+        predicateList.add(new InDateRangePredicate(Optional.empty(), upperBound));
+        expectedFindCommand = new FindCommand(predicateList);
+        assertParseSuccess(parser, DATE_TO_DESC_BUBBLE_TEA, expectedFindCommand);
+
+        // upper and lower bound
+        predicateList = new ArrayList<>();
+        predicateList.add(new InDateRangePredicate(lowerBound, upperBound));
+        expectedFindCommand = new FindCommand(predicateList);
+        assertParseSuccess(parser, DATE_FROM_DESC_INTERNSHIP + DATE_TO_DESC_BUBBLE_TEA, expectedFindCommand);
+
+        // same upper and lower bound values
+        predicateList = new ArrayList<>();
+        predicateList.add(new InDateRangePredicate(upperBound, upperBound));
+        expectedFindCommand = new FindCommand(predicateList);
+        assertParseSuccess(parser, DATE_FROM_DESC_BUBBLE_TEA + DATE_TO_DESC_BUBBLE_TEA, expectedFindCommand);
+    }
+
+    @Test
+    public void parse_multipleSearchParameters_success() {
+        List<Predicate<Transaction>> predicateList = new ArrayList<>();
+        predicateList.add(new TitleContainsKeyphrasesPredicate(Arrays.asList(VALID_TITLE_BUBBLE_TEA)));
+        predicateList.add(new HasExactAmountPredicate(new Amount(VALID_AMOUNT_BUBBLE_TEA)));
+        FindCommand expectedFindCommand = new FindCommand(predicateList);
+        assertParseSuccess(parser, TITLE_DESC_BUBBLE_TEA + AMOUNT_DESC_BUBBLE_TEA, expectedFindCommand);
+    }
+
+    @Test
+    public void parse_invalidCommandFormat_failure() {
+        assertParseFailure(parser, PREAMBLE_WHITESPACE,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_hasEmptyArgs_failure() {
+        // empty title keyphrase
+        assertParseFailure(parser, " " + PREFIX_TITLE, MESSAGE_EMPTY_TITLE_KEYPHRASE);
+
+        // empty title keyphrase followed by non-empty title keyphrase
+        assertParseFailure(parser, " " + PREFIX_TITLE + TITLE_DESC_BUBBLE_TEA, MESSAGE_EMPTY_TITLE_KEYPHRASE);
+
+        // empty category
+        assertParseFailure(parser, " " + PREFIX_CATEGORY, MESSAGE_EMPTY_CATEGORY);
+
+        // empty category followed by non-empty category
+        assertParseFailure(parser, " " + PREFIX_CATEGORY + CATEGORY_DESC_FOOD_BEVERAGE, MESSAGE_EMPTY_CATEGORY);
+
+        // multiple empty search parameters, first error message thrown
+        assertParseFailure(parser, " " + PREFIX_TITLE + " " + PREFIX_CATEGORY, MESSAGE_EMPTY_TITLE_KEYPHRASE);
+    }
+
+    @Test
+    public void parse_hasDuplicateArgs_failure() {
+        assertParseFailure(parser, PREAMBLE_WHITESPACE,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+
+        // duplicate amount search parameters
+        assertParseFailure(parser, AMOUNT_DESC_BUBBLE_TEA + AMOUNT_DESC_INTERNSHIP,
+                MESSAGE_AMOUNT_DUPLICATE_CONSTRAINTS);
+        assertParseFailure(parser, AMOUNT_FROM_DESC_BUBBLE_TEA + AMOUNT_FROM_DESC_INTERNSHIP,
+                MESSAGE_AMOUNT_FROM_CONSTRAINTS);
+        assertParseFailure(parser, AMOUNT_TO_DESC_BUBBLE_TEA + AMOUNT_TO_DESC_INTERNSHIP,
+                MESSAGE_AMOUNT_TO_CONSTRAINTS);
+
+        // duplicate date search parameters
+        assertParseFailure(parser, DATE_DESC_BUBBLE_TEA + DATE_DESC_INTERNSHIP,
+                MESSAGE_DATE_DUPLICATE_CONSTRAINTS);
+        assertParseFailure(parser, DATE_FROM_DESC_BUBBLE_TEA + DATE_FROM_DESC_INTERNSHIP,
+                MESSAGE_DATE_FROM_CONSTRAINTS);
+        assertParseFailure(parser, DATE_TO_DESC_BUBBLE_TEA + DATE_TO_DESC_INTERNSHIP,
+                MESSAGE_DATE_TO_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_invalidRangeSearch_failure() {
+        // amount cannot be used with amount range
+        assertParseFailure(parser, AMOUNT_DESC_BUBBLE_TEA + AMOUNT_FROM_DESC_INTERNSHIP,
+                MESSAGE_AMOUNT_SEARCH_CONSTRAINTS);
+        assertParseFailure(parser, AMOUNT_DESC_BUBBLE_TEA + AMOUNT_TO_DESC_INTERNSHIP,
+                MESSAGE_AMOUNT_SEARCH_CONSTRAINTS);
+
+        // invalid amount range - VALID_AMOUNT_BUBBLE_TEA is less than VALID_AMOUNT_INTERNSHIP
+        assertParseFailure(parser, AMOUNT_FROM_DESC_INTERNSHIP + AMOUNT_TO_DESC_BUBBLE_TEA,
+                MESSAGE_AMOUNT_RANGE_CONSTRAINTS);
+
+        // date cannot be used with date range
+        assertParseFailure(parser, DATE_DESC_BUBBLE_TEA + DATE_FROM_DESC_INTERNSHIP,
+                MESSAGE_DATE_SEARCH_CONSTRAINTS);
+        assertParseFailure(parser, DATE_DESC_BUBBLE_TEA + DATE_TO_DESC_INTERNSHIP,
+                MESSAGE_DATE_SEARCH_CONSTRAINTS);
+
+        // invalid date range - VALID_DATE_INTERNSHIP is earlier than VALID_DATE_BUBBLE_TEA
+        assertParseFailure(parser, DATE_FROM_DESC_BUBBLE_TEA + DATE_TO_DESC_INTERNSHIP,
+                MESSAGE_DATE_RANGE_CONSTRAINTS);
+
     }
 
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FindCommandParserTest.java
@@ -61,6 +61,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.predicates.TitleContainsK
 
 public class FindCommandParserTest {
 
+    // These strings are only used in FindCommandParserTest, hence are defined here instead of in CommandTestUtil
     public static final String AMOUNT_FROM_DESC_BUBBLE_TEA = " " + PREFIX_AMOUNT_FROM + VALID_AMOUNT_BUBBLE_TEA;
     public static final String AMOUNT_TO_DESC_BUBBLE_TEA = " " + PREFIX_AMOUNT_TO + VALID_AMOUNT_BUBBLE_TEA;
     public static final String AMOUNT_FROM_DESC_INTERNSHIP = " " + PREFIX_AMOUNT_FROM + VALID_AMOUNT_INTERNSHIP;

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtilTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtilTest.java
@@ -59,6 +59,11 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseTitle_emptyValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTitle(WHITESPACE));
+    }
+
+    @Test
     public void parseTitle_invalidValue_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseTitle(INVALID_TITLE));
     }
@@ -91,6 +96,11 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseAmount_emptyValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseAmount(WHITESPACE));
+    }
+
+    @Test
     public void parseAmount_invalidValue_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseAmount(INVALID_AMOUNT));
     }
@@ -114,6 +124,11 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseDate_emptyValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseDate(WHITESPACE));
+    }
+
+    @Test
     public void parseDate_invalidValue_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseDate(INVALID_DATE));
     }
@@ -134,6 +149,11 @@ public class ParserUtilTest {
     @Test
     public void parseCategory_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> ParserUtil.parseCategory(null));
+    }
+
+    @Test
+    public void parseCategory_emptyValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseCategory(WHITESPACE));
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/EditBookmarkExpenseCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/EditBookmarkExpenseCommandParserTest.java
@@ -83,11 +83,11 @@ public class EditBookmarkExpenseCommandParserTest {
         // while parsing {@code PREFIX_CATEGORY} alone will reset the categories of the {@code BookmarkExpense} being
         // edited, parsing it together with a valid category results in error
         assertParseFailure(parser, "1" + CATEGORY_DESC_FOOD_BEVERAGE + CATEGORY_DESC_WORK + CATEGORY_EMPTY,
-                Category.MESSAGE_CONSTRAINTS);
+                Category.MESSAGE_EMPTY_CATEGORY);
         assertParseFailure(parser, "1" + CATEGORY_DESC_FOOD_BEVERAGE + CATEGORY_EMPTY + CATEGORY_DESC_WORK,
-                Category.MESSAGE_CONSTRAINTS);
+                Category.MESSAGE_EMPTY_CATEGORY);
         assertParseFailure(parser, "1" + CATEGORY_EMPTY + CATEGORY_DESC_FOOD_BEVERAGE + CATEGORY_DESC_WORK,
-                Category.MESSAGE_CONSTRAINTS);
+                Category.MESSAGE_EMPTY_CATEGORY);
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_TITLE_DESC + INVALID_AMOUNT_DESC

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/EditBookmarkIncomeCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/EditBookmarkIncomeCommandParserTest.java
@@ -86,11 +86,11 @@ public class EditBookmarkIncomeCommandParserTest {
         // while parsing {@code PREFIX_CATEGORY} alone will reset the categories of the {@code BookmarkIncome} being
         // edited, parsing it together with a valid category results in error
         assertParseFailure(parser, "1" + CATEGORY_DESC_FOOD_BEVERAGE + CATEGORY_DESC_WORK + CATEGORY_EMPTY,
-                Category.MESSAGE_CONSTRAINTS);
+                Category.MESSAGE_EMPTY_CATEGORY);
         assertParseFailure(parser, "1" + CATEGORY_DESC_FOOD_BEVERAGE + CATEGORY_EMPTY + CATEGORY_DESC_WORK,
-                Category.MESSAGE_CONSTRAINTS);
+                Category.MESSAGE_EMPTY_CATEGORY);
         assertParseFailure(parser, "1" + CATEGORY_EMPTY + CATEGORY_DESC_FOOD_BEVERAGE + CATEGORY_DESC_WORK,
-                Category.MESSAGE_CONSTRAINTS);
+                Category.MESSAGE_EMPTY_CATEGORY);
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_TITLE_DESC + INVALID_AMOUNT_DESC

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/predicates/TitleContainsKeyphrasesPredicateTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/model/transaction/predicates/TitleContainsKeyphrasesPredicateTest.java
@@ -48,6 +48,10 @@ public class TitleContainsKeyphrasesPredicateTest {
                 new TitleContainsKeyphrasesPredicate(Collections.singletonList("Damith Seth"));
         assertTrue(predicate.test(new TransactionBuilder().withTitle("Damith Seth").buildExpense()));
 
+        // Partial keyphrase
+        predicate = new TitleContainsKeyphrasesPredicate(Arrays.asList("Dam"));
+        assertTrue(predicate.test(new TransactionBuilder().withTitle("Damith Seth").buildExpense()));
+
         // Multiple keyphrases
         predicate = new TitleContainsKeyphrasesPredicate(Arrays.asList("Damith", "Seth"));
         assertTrue(predicate.test(new TransactionBuilder().withTitle("Damith Seth").buildExpense()));


### PR DESCRIPTION
Resolves #282.

Add empty argument error checks to the parsing of title, amount, date and category so that the error messages displayed are more consistent.

Also added error checks for the concurrent use of exact amount/date search and amount/date range search, and added tests for `ParserUtil` and `FindCommand`.