### PR TITLE
Add switching of tabs when executing add and budget commands

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -877,6 +877,8 @@ New monthly expense limit set: $400.00
 ```
 Sets the monthly expense limit in the finance tracker to be `$400.00`.
 
+> :information_source: &nbsp; After executing this command, the UI will automatically switch to the [Overview tab](#221-overview-tab).
+
 ### 4.8 Savings Goal
 
 Want to save up for the new PlayStation 5 but can't seem to no matter what? Fine$$e has you covered!
@@ -904,6 +906,8 @@ Expected Outcome:
 New monthly savings goal set: $50.00
 ```
 Sets the monthly savings goal in the finance tracker to be `$50.00`.
+
+> :information_source: &nbsp; After executing this command, the UI will automatically switch to the [Overview tab](#221-overview-tab).
 
 ### 4.9 Analytics
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -280,6 +280,8 @@ New expense added: Bubble Tea Amount: $5.00 Date: 03/10/2020 Categories: [Food &
 ```
 Adds a new expense titled `Bubble Tea`, with amount `$5.00`, date `03/10/2020`, and a single category `Food & Beverage`.
 
+> :information_source: &nbsp; After executing this command, the UI will automatically switch to the [Expenses tab](#223-expenses-tab).
+
 #### 4.3.2 Edit Expense: `edit`
 
 Edits an expense in the finance tracker.
@@ -418,7 +420,7 @@ Format: `add-income t/TITLE a/AMOUNT d/DATE [c/CATEGORY...]`
 * `DATE` is optional; if `DATE` is not given, the current date is used.
 * `CATEGORY` is optional. Multiple `c/` prefixes can be used to specify multiple categories.
 
-Shortcuts: `addi`; (when on the [Income tab](#222-incomes-tab)) `add`
+Shortcuts: `addi`; (when on the [Incomes tab](#222-incomes-tab)) `add`
 
 Examples:
 * `add-income t/Waitressing a/80 c/Work`
@@ -435,11 +437,13 @@ New income added: Shopee Internship Amount: $560.00 Date: 03/10/2020 Categories:
 ```
 Adds a new income titled `Shopee Internship`, with amount `$560.00`, date `03/10/2020`, and a single category `Internship`.
 
+> :information_source: &nbsp; After executing this command, the UI will automatically switch to the [Incomes tab](#222-incomes-tab).
+
 #### 4.4.2 Edit Income: `edit`
 
 Edits an expense in the finance tracker.
 
-Format: (when on the [Income tab](#222-incomes-tab)) `edit INDEX [t/TITLE] [a/AMOUNT] [d/DATE] [c/CATEGORY...]`
+Format: (when on the [Incomes tab](#222-incomes-tab)) `edit INDEX [t/TITLE] [a/AMOUNT] [d/DATE] [c/CATEGORY...]`
 
 * `INDEX` allows you to choose which income to edit by specifying its position in the currently displayed incomes list.
 * `TITLE`, `AMOUNT`, `DATE` and `CATEGORY` allow you to specify the updated income information.
@@ -793,7 +797,7 @@ Edits the third bookmark income in the bookmark incomes list to have an amount o
 
 Deletes the bookmark income and all of its information from the bookmark income list in Fine$$e.
 
-> :warning: &nbsp; This command can only be executed on the [Income tab](#222-incomes-tab).
+> :warning: &nbsp; This command can only be executed on the [Incomes tab](#222-incomes-tab).
 
 Format: `delete-bookmark INDEX`
 

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddExpenseCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddExpenseCommand.java
@@ -8,6 +8,7 @@ import static java.util.Objects.requireNonNull;
 
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
 /**
  * Adds an expense to the finance tracker.
@@ -47,7 +48,7 @@ public class AddExpenseCommand extends Command {
         requireNonNull(model);
 
         model.addExpense(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), true);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), true, Tab.EXPENSES);
     }
 
     @Override

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommand.java
@@ -8,6 +8,7 @@ import static java.util.Objects.requireNonNull;
 
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
 /**
  * Adds an income to the finance tracker.
@@ -47,7 +48,7 @@ public class AddIncomeCommand extends Command {
         requireNonNull(model);
 
         model.addIncome(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), true);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), true, Tab.INCOME);
     }
 
     @Override

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandResult.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandResult.java
@@ -30,6 +30,7 @@ public class CommandResult {
      * Constructs a {@code CommandResult} with the specified fields.
      *
      * @param feedbackToUser The feedback to be displayed to the user.
+     * @param calculateBudgetInfo Whether the budget information should be recalculated.
      * @param showHelp Whether the help dialog should be shown to the user.
      * @param exit Whether the application should exit.
      * @param tabToSwitchTo The tab the UI should switch to.
@@ -48,6 +49,7 @@ public class CommandResult {
      * {@code exit}, and other fields set to their default value.
      *
      * @param feedbackToUser The feedback to be displayed to the user.
+     * @param calculateBudgetInfo Whether the budget information should be recalculated.
      * @param showHelp Whether the help dialog should be shown to the user.
      * @param exit Whether the application should exit.
      */
@@ -73,7 +75,7 @@ public class CommandResult {
      * @param feedbackToUser The feedback to be displayed to the user.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false, false);
+        this(feedbackToUser, false, false, false, null);
     }
 
     /**
@@ -84,7 +86,18 @@ public class CommandResult {
      * @param feedbackToUser The feedback to be displayed to the user.
      */
     public CommandResult(String feedbackToUser, boolean calculateBudgetInfo) {
-        this(feedbackToUser, calculateBudgetInfo, false, false);
+        this(feedbackToUser, calculateBudgetInfo, false, false, null);
+    }
+
+    /**
+     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
+     * the specified boolean to determine whether budget information should be recalculated,
+     * and other fields set to their default value.
+     *
+     * @param feedbackToUser The feedback to be displayed to the user.
+     */
+    public CommandResult(String feedbackToUser, boolean calculateBudgetInfo, Tab tabToSwitchTo) {
+        this(feedbackToUser, calculateBudgetInfo, false, false, tabToSwitchTo);
     }
 
     public String getFeedbackToUser() {

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandResult.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandResult.java
@@ -45,8 +45,8 @@ public class CommandResult {
     }
 
     /**
-     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser}, {@code showHelp},
-     * {@code exit}, and other fields set to their default value.
+     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser}, {@code calculateBudgetInfo},
+     * {@code showHelp}, {@code exit}, and other fields set to their default value.
      *
      * @param feedbackToUser The feedback to be displayed to the user.
      * @param calculateBudgetInfo Whether the budget information should be recalculated.
@@ -79,22 +79,23 @@ public class CommandResult {
     }
 
     /**
-     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
-     * the specified boolean to determine whether budget information should be recalculated,
+     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser}, {@code calculateBudgetInfo},
      * and other fields set to their default value.
      *
      * @param feedbackToUser The feedback to be displayed to the user.
+     * @param calculateBudgetInfo Whether the budget information should be recalculated.
      */
     public CommandResult(String feedbackToUser, boolean calculateBudgetInfo) {
         this(feedbackToUser, calculateBudgetInfo, false, false, null);
     }
 
     /**
-     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
-     * the specified boolean to determine whether budget information should be recalculated,
-     * and other fields set to their default value.
+     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser}, {@code calculateBudgetInfo},
+     * {@code tabToSwitchTo}, and other fields set to their default value.
      *
      * @param feedbackToUser The feedback to be displayed to the user.
+     * @param calculateBudgetInfo Whether the budget information should be recalculated.
+     * @param tabToSwitchTo The tab the UI should switch to.
      */
     public CommandResult(String feedbackToUser, boolean calculateBudgetInfo, Tab tabToSwitchTo) {
         this(feedbackToUser, calculateBudgetInfo, false, false, tabToSwitchTo);

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/budget/SetExpenseLimitCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/budget/SetExpenseLimitCommand.java
@@ -7,6 +7,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.commands.Command;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
 /**
  * Sets the monthly expense limit in the finance tracker.
@@ -37,7 +38,7 @@ public class SetExpenseLimitCommand extends Command {
         requireNonNull(model);
 
         model.setExpenseLimit(amount);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, amount), true);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, amount), true, Tab.OVERVIEW);
     }
 
     @Override

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/budget/SetSavingsGoalCommand.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/budget/SetSavingsGoalCommand.java
@@ -7,6 +7,7 @@ import ay2021s1_cs2103_w16_3.finesse.logic.commands.Command;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
 /**
  * Sets the monthly savings goal in the finance tracker.
@@ -37,7 +38,7 @@ public class SetSavingsGoalCommand extends Command {
         requireNonNull(model);
 
         model.setSavingsGoal(amount);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, amount), true);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, amount), true, Tab.OVERVIEW);
     }
 
     @Override

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddExpenseCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddExpenseCommandTest.java
@@ -16,6 +16,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.FinanceTracker;
 import ay2021s1_cs2103_w16_3.finesse.model.ReadOnlyFinanceTracker;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
 import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
 public class AddExpenseCommandTest {
 
@@ -33,6 +34,7 @@ public class AddExpenseCommandTest {
 
         assertEquals(String.format(AddExpenseCommand.MESSAGE_SUCCESS, validExpense), commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validExpense), modelStub.expensesAdded);
+        assertEquals(commandResult.getTabToSwitchTo().get(), Tab.EXPENSES);
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/AddIncomeCommandTest.java
@@ -16,6 +16,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.FinanceTracker;
 import ay2021s1_cs2103_w16_3.finesse.model.ReadOnlyFinanceTracker;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
 public class AddIncomeCommandTest {
 
@@ -33,6 +34,7 @@ public class AddIncomeCommandTest {
 
         assertEquals(String.format(AddIncomeCommand.MESSAGE_SUCCESS, validIncome), commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validIncome), modelStub.incomesAdded);
+        assertEquals(commandResult.getTabToSwitchTo().get(), Tab.INCOME);
     }
 
     @Test

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandTestUtil.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandTestUtil.java
@@ -23,6 +23,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Transaction;
 import ay2021s1_cs2103_w16_3.finesse.testutil.EditBookmarkTransactionDescriptorBuilder;
 import ay2021s1_cs2103_w16_3.finesse.testutil.EditTransactionDescriptorBuilder;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
 /**
  * Contains helper methods for testing commands.
@@ -117,6 +118,16 @@ public class CommandTestUtil {
      * that takes a string {@code expectedMessage}.
      */
     public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
+                                            Model expectedModel) {
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage);
+        assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
+    }
+
+    /**
+     * Convenience wrapper to {@link #assertCommandSuccess(Command, Model, CommandResult, Model)}
+     * that takes a string {@code expectedMessage} and a boolean {@code isCalculateBudgetInfo}.
+     */
+    public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
                                             Model expectedModel, boolean isCalculateBudgetInfo) {
         CommandResult expectedCommandResult = new CommandResult(expectedMessage, isCalculateBudgetInfo);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
@@ -124,11 +135,12 @@ public class CommandTestUtil {
 
     /**
      * Convenience wrapper to {@link #assertCommandSuccess(Command, Model, CommandResult, Model)}
-     * that takes a string {@code expectedMessage}.
+     * that takes a string {@code expectedMessage}, a boolean {@code isCalculateBudgetInfo}
+     * and a Tab {@code tabToSwitchTo}.
      */
     public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
-            Model expectedModel) {
-        CommandResult expectedCommandResult = new CommandResult(expectedMessage);
+                                            Model expectedModel, boolean isCalculateBudgetInfo, Tab tabToSwitchTo) {
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, isCalculateBudgetInfo, tabToSwitchTo);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
     }
 

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandTestUtil.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/CommandTestUtil.java
@@ -118,7 +118,7 @@ public class CommandTestUtil {
      * that takes a string {@code expectedMessage}.
      */
     public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
-                                            Model expectedModel) {
+            Model expectedModel) {
         CommandResult expectedCommandResult = new CommandResult(expectedMessage);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
     }
@@ -128,7 +128,7 @@ public class CommandTestUtil {
      * that takes a string {@code expectedMessage} and a boolean {@code isCalculateBudgetInfo}.
      */
     public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
-                                            Model expectedModel, boolean isCalculateBudgetInfo) {
+            Model expectedModel, boolean isCalculateBudgetInfo) {
         CommandResult expectedCommandResult = new CommandResult(expectedMessage, isCalculateBudgetInfo);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
     }
@@ -139,7 +139,7 @@ public class CommandTestUtil {
      * and a Tab {@code tabToSwitchTo}.
      */
     public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
-                                            Model expectedModel, boolean isCalculateBudgetInfo, Tab tabToSwitchTo) {
+            Model expectedModel, boolean isCalculateBudgetInfo, Tab tabToSwitchTo) {
         CommandResult expectedCommandResult = new CommandResult(expectedMessage, isCalculateBudgetInfo, tabToSwitchTo);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
     }
@@ -165,19 +165,6 @@ public class CommandTestUtil {
         assertEquals(expectedFinanceTracker, actualModel.getFinanceTracker());
         assertEquals(expectedFilteredList, actualModel.getFilteredTransactionList());
         assertEquals(expectedFilteredBookmarkExpenseList, actualModel.getFilteredBookmarkExpenseList());
-    }
-    /**
-     * Updates {@code model}'s filtered list to show only the transaction at the given {@code targetIndex} in the
-     * {@code model}'s finance tracker.
-     */
-    public static void showTransactionAtIndex(Model model, Index targetIndex) {
-        assertTrue(targetIndex.getZeroBased() < model.getFilteredTransactionList().size());
-
-        Transaction transaction = model.getFilteredTransactionList().get(targetIndex.getZeroBased());
-        final String[] splitTitle = transaction.getTitle().toString().split("\\s+");
-        model.updateFilteredTransactionList(t -> t == transaction);
-
-        assertEquals(1, model.getFilteredTransactionList().size());
     }
 
     /**

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/budget/SetExpenseLimitCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/budget/SetExpenseLimitCommandTest.java
@@ -1,15 +1,17 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands.budget;
 
-import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.Assert.assertThrows;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.getTypicalFinanceTracker;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.ModelManager;
 import ay2021s1_cs2103_w16_3.finesse.model.UserPrefs;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
 public class SetExpenseLimitCommandTest {
 
@@ -23,13 +25,13 @@ public class SetExpenseLimitCommandTest {
     @Test
     public void execute_validAmount_success() {
         Amount amountToSet = new Amount("500");
-        SetExpenseLimitCommand setExpenseLimitCommand = new SetExpenseLimitCommand(amountToSet);
 
-        String expectedMessage = String.format(SetExpenseLimitCommand.MESSAGE_SUCCESS, amountToSet);
+        CommandResult commandResult = new SetExpenseLimitCommand(amountToSet).execute(model);
 
-        ModelManager expectedModel = new ModelManager(model.getFinanceTracker(), new UserPrefs());
-        expectedModel.setExpenseLimit(amountToSet);
-
-        assertCommandSuccess(setExpenseLimitCommand, model, expectedMessage, expectedModel, true);
+        assertEquals(String.format(SetExpenseLimitCommand.MESSAGE_SUCCESS, amountToSet),
+                commandResult.getFeedbackToUser());
+        assertEquals(amountToSet, model.getMonthlyBudget().getMonthlyExpenseLimit().getValue());
+        assertEquals(commandResult.getTabToSwitchTo().get(), Tab.OVERVIEW);
     }
+
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/budget/SetExpenseLimitCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/budget/SetExpenseLimitCommandTest.java
@@ -1,12 +1,11 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands.budget;
 
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.Assert.assertThrows;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.getTypicalFinanceTracker;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.ModelManager;
 import ay2021s1_cs2103_w16_3.finesse.model.UserPrefs;
@@ -26,12 +25,14 @@ public class SetExpenseLimitCommandTest {
     public void execute_validAmount_success() {
         Amount amountToSet = new Amount("500");
 
-        CommandResult commandResult = new SetExpenseLimitCommand(amountToSet).execute(model);
+        SetExpenseLimitCommand setExpenseLimitCommand = new SetExpenseLimitCommand(amountToSet);
 
-        assertEquals(String.format(SetExpenseLimitCommand.MESSAGE_SUCCESS, amountToSet),
-                commandResult.getFeedbackToUser());
-        assertEquals(amountToSet, model.getMonthlyBudget().getMonthlyExpenseLimit().getValue());
-        assertEquals(commandResult.getTabToSwitchTo().get(), Tab.OVERVIEW);
+        String expectedMessage = String.format(SetExpenseLimitCommand.MESSAGE_SUCCESS, amountToSet);
+
+        ModelManager expectedModel = new ModelManager(model.getFinanceTracker(), new UserPrefs());
+        expectedModel.setExpenseLimit(amountToSet);
+
+        assertCommandSuccess(setExpenseLimitCommand, model, expectedMessage, expectedModel, true, Tab.OVERVIEW);
     }
 
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/budget/SetSavingsGoalCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/budget/SetSavingsGoalCommandTest.java
@@ -1,12 +1,11 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands.budget;
 
+import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.Assert.assertThrows;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.getTypicalFinanceTracker;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.ModelManager;
 import ay2021s1_cs2103_w16_3.finesse.model.UserPrefs;
@@ -25,12 +24,13 @@ public class SetSavingsGoalCommandTest {
     @Test
     public void execute_validAmount_success() {
         Amount amountToSet = new Amount("500");
+        SetSavingsGoalCommand setSavingsGoalCommand = new SetSavingsGoalCommand(amountToSet);
 
-        CommandResult commandResult = new SetSavingsGoalCommand(amountToSet).execute(model);
+        String expectedMessage = String.format(SetSavingsGoalCommand.MESSAGE_SUCCESS, amountToSet);
 
-        assertEquals(String.format(SetSavingsGoalCommand.MESSAGE_SUCCESS, amountToSet),
-                commandResult.getFeedbackToUser());
-        assertEquals(amountToSet, model.getMonthlyBudget().getMonthlySavingsGoal().getValue());
-        assertEquals(commandResult.getTabToSwitchTo().get(), Tab.OVERVIEW);
+        ModelManager expectedModel = new ModelManager(model.getFinanceTracker(), new UserPrefs());
+        expectedModel.setSavingsGoal(amountToSet);
+
+        assertCommandSuccess(setSavingsGoalCommand, model, expectedMessage, expectedModel, true, Tab.OVERVIEW);
     }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/budget/SetSavingsGoalCommandTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/commands/budget/SetSavingsGoalCommandTest.java
@@ -1,15 +1,17 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.commands.budget;
 
-import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.Assert.assertThrows;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalTransactions.getTypicalFinanceTracker;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandResult;
 import ay2021s1_cs2103_w16_3.finesse.model.Model;
 import ay2021s1_cs2103_w16_3.finesse.model.ModelManager;
 import ay2021s1_cs2103_w16_3.finesse.model.UserPrefs;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
+import ay2021s1_cs2103_w16_3.finesse.ui.UiState.Tab;
 
 public class SetSavingsGoalCommandTest {
 
@@ -23,13 +25,12 @@ public class SetSavingsGoalCommandTest {
     @Test
     public void execute_validAmount_success() {
         Amount amountToSet = new Amount("500");
-        SetSavingsGoalCommand setSavingsGoalCommand = new SetSavingsGoalCommand(amountToSet);
 
-        String expectedMessage = String.format(SetSavingsGoalCommand.MESSAGE_SUCCESS, amountToSet);
+        CommandResult commandResult = new SetSavingsGoalCommand(amountToSet).execute(model);
 
-        ModelManager expectedModel = new ModelManager(model.getFinanceTracker(), new UserPrefs());
-        expectedModel.setSavingsGoal(amountToSet);
-
-        assertCommandSuccess(setSavingsGoalCommand, model, expectedMessage, expectedModel, true);
+        assertEquals(String.format(SetSavingsGoalCommand.MESSAGE_SUCCESS, amountToSet),
+                commandResult.getFeedbackToUser());
+        assertEquals(amountToSet, model.getMonthlyBudget().getMonthlySavingsGoal().getValue());
+        assertEquals(commandResult.getTabToSwitchTo().get(), Tab.OVERVIEW);
     }
 }


### PR DESCRIPTION
Resolves #270.

Executing `add-expense` or `add-income` commands now switches the UI to the Expenses and Incomes tab respectively.

Executing `set-expense-limit` or `set-savings-goal` now switches the UI to the Overview tab.

This behaviour is now also documented in the user guide.