### PR TITLE
Fix coding standard violation

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParser.java
@@ -252,6 +252,7 @@ public class FinanceTrackerParser {
 
     /**
      * Error message to be used when a command is not applicable to the user's current tab.
+     *
      * @param command The command word that was used incorrectly.
      * @param tabs The tabs that the command is applicable to.
      * @return The error message to be displayed to the user.


### PR DESCRIPTION
According to the [Java coding standard](https://se-education.org/guides/conventions/java/intermediate.html#comments), Javadoc comments require an empty line between description and parameters.