### PR TITLE
Add Pitest as CI with artifact

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -43,3 +43,41 @@ jobs:
         with:
           file: ${{ github.workspace }}/build/reports/jacoco/coverage/coverage.xml
           fail_ci_if_error: true
+
+  pitest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@master
+
+      - name: Set up repository
+        uses: actions/checkout@master
+        with:
+          ref: master
+
+      - name: Merge to master
+        run: git checkout --progress --force ${{ github.sha }}
+
+      - name: Run repository-wide tests
+        if: runner.os == 'Linux'
+        working-directory:  ${{ github.workspace }}/.github
+        run: ./run-checks.sh
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Setup JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+          java-package: jdk+fx
+
+      - name: Run Pitest
+        run: ./gradlew pitest
+
+      - name: Upload Pitest report
+        uses: actions/upload-artifact@v2
+        with:
+          name: pitest
+          path: build/reports/pitest/


### PR DESCRIPTION
Pitest is a resource intensive operation when run locally. This allows reports to be generated remotely.
- On every push (e.g. to ~~master~~ main), this job maintains a reference report as a basis for comparison when reviewing pull requests.
- On every pull request, this job generates the latest report for reviewers to download.
  - You can find it under the 'Checks' tab here:
![image](https://user-images.githubusercontent.com/53135010/98447113-53690a00-215d-11eb-8111-6d08835d0d34.png)

It is run as a separate job, so as not to slow down the other verification jobs.

Test run for pushing: https://github.com/wltan/tp/runs/1368073912
Test run for pull request: (this PR, under 'Checks')