### PR TITLE
Increase code coverage for parsers

### DIFF
--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ArgumentTokenizer.java
@@ -14,6 +14,10 @@ import java.util.stream.Collectors;
  *    in the above example.<br>
  */
 public class ArgumentTokenizer {
+    /**
+     * Prevents instantiation of this class.
+     */
+    private ArgumentTokenizer() {}
 
     /**
      * Tokenizes an arguments string and returns an {@code ArgumentMultimap} object that maps prefixes to their

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/CliSyntax.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/CliSyntax.java
@@ -15,4 +15,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_DATE_FROM = new Prefix("df/");
     public static final Prefix PREFIX_DATE_TO = new Prefix("dt/");
 
+    /**
+     * Prevents instantiation of this class.
+     */
+    private CliSyntax() {}
 }

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/Prefix.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/Prefix.java
@@ -1,5 +1,7 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.parser;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * A prefix that marks the beginning of an argument in an arguments string.
  * E.g. 't/' in 'add James t/ friend'.
@@ -7,7 +9,14 @@ package ay2021s1_cs2103_w16_3.finesse.logic.parser;
 public class Prefix {
     private final String prefix;
 
+    /**
+     * Constructs a new {@code Prefix} object with the specified prefix.
+     * Note that the prefix cannot be {@code null}.
+     *
+     * @param prefix The specified prefix.
+     */
     public Prefix(String prefix) {
+        requireNonNull(prefix);
         this.prefix = prefix;
     }
 
@@ -21,7 +30,7 @@ public class Prefix {
 
     @Override
     public int hashCode() {
-        return prefix == null ? 0 : prefix.hashCode();
+        return prefix.hashCode();
     }
 
     @Override

--- a/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/BookmarkTransactionBuilder.java
+++ b/src/main/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmarkparsers/BookmarkTransactionBuilder.java
@@ -83,4 +83,21 @@ public class BookmarkTransactionBuilder {
         return new BookmarkIncome(title, amount, categories);
     }
 
+    @Override
+    public boolean equals(Object other) {
+        // Short circuit if same object.
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls.
+        if (!(other instanceof BookmarkTransactionBuilder)) {
+            return false;
+        }
+
+        BookmarkTransactionBuilder otherBookmarkTransactionBuilder = (BookmarkTransactionBuilder) other;
+        return title.equals(otherBookmarkTransactionBuilder.title)
+                && amount.equals(otherBookmarkTransactionBuilder.amount)
+                && categories.equals(otherBookmarkTransactionBuilder.categories);
+    }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/DeleteCommandParserTest.java
@@ -28,5 +28,6 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "-1", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/FinanceTrackerParserTest.java
@@ -4,7 +4,9 @@ import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_INVALI
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_METHOD_SHOULD_NOT_BE_CALLED;
 import static ay2021s1_cs2103_w16_3.finesse.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static ay2021s1_cs2103_w16_3.finesse.logic.commands.CommandTestUtil.VALID_DATE_INTERNSHIP;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_DATE;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_TITLE;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.Assert.assertThrows;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalIndexes.INDEX_FIRST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -38,10 +40,13 @@ import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.ConvertBookmarkComm
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.DeleteBookmarkCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.EditBookmarkCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.commands.bookmark.EditBookmarkTransactionDescriptor;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.budget.SetExpenseLimitCommand;
+import ay2021s1_cs2103_w16_3.finesse.logic.commands.budget.SetSavingsGoalCommand;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.bookmarkparsers.BookmarkTransactionBuilder;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
 import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkExpense;
 import ay2021s1_cs2103_w16_3.finesse.model.bookmark.BookmarkIncome;
+import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Expense;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Income;
@@ -54,31 +59,41 @@ import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionBuilder;
 import ay2021s1_cs2103_w16_3.finesse.testutil.TransactionUtil;
 import ay2021s1_cs2103_w16_3.finesse.ui.UiState;
 
+/**
+ * Tests the result of parsing each command within each tab. Note that each tab is its own
+ * equivalence partition.
+ */
 public class FinanceTrackerParserTest {
 
     private final FinanceTrackerParser parser = new FinanceTrackerParser();
     private final OverviewUiStateStub overviewUiStateStub = new OverviewUiStateStub();
-    private final IncomeUiStateStub incomeUiStateStub = new IncomeUiStateStub();
+    private final IncomesUiStateStub incomesUiStateStub = new IncomesUiStateStub();
     private final ExpensesUiStateStub expensesUiStateStub = new ExpensesUiStateStub();
     private final AnalyticsUiStateStub analyticsUiStateStub = new AnalyticsUiStateStub();
+    private final UserGuideUiStateStub userGuideUiStateStub = new UserGuideUiStateStub();
 
-    @Test
-    public void parseCommand_addWhenOverviewTab() {
+    private void parseCommand_addCommandOnInvalidTab_throwsParseException(UiStateStub uiStateStub) {
+        // Similar result as using an Income object instead.
         Expense expense = new TransactionBuilder().buildExpense();
         assertThrows(ParseException.class, () -> parser.parseCommand(
-                TransactionUtil.getAddCommand(expense), overviewUiStateStub));
+                TransactionUtil.getAddCommand(expense), uiStateStub));
     }
 
     @Test
-    public void parseCommand_addWhenIncomeTab() throws Exception {
+    public void parseCommand_addCommandOnOverviewTab_throwsParseException() {
+        parseCommand_addCommandOnInvalidTab_throwsParseException(overviewUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_addCommandOnIncomesTab_returnsAddIncomeCommand() throws ParseException {
         Income income = new TransactionBuilder().buildIncome();
         AddIncomeCommand command =
-                (AddIncomeCommand) parser.parseCommand(TransactionUtil.getAddCommand(income), incomeUiStateStub);
+                (AddIncomeCommand) parser.parseCommand(TransactionUtil.getAddCommand(income), incomesUiStateStub);
         assertEquals(new AddIncomeCommand(income), command);
     }
 
     @Test
-    public void parseCommand_addWhenExpensesTab() throws Exception {
+    public void parseCommand_addCommandOnExpensesTab_returnsAddExpenseCommand() throws ParseException {
         Expense expense = new TransactionBuilder().buildExpense();
         AddExpenseCommand command =
                 (AddExpenseCommand) parser.parseCommand(TransactionUtil.getAddCommand(expense), expensesUiStateStub);
@@ -86,273 +101,320 @@ public class FinanceTrackerParserTest {
     }
 
     @Test
-    public void parseCommand_addWhenAnalyticsTab() {
-        Expense expense = new TransactionBuilder().buildExpense();
-        assertThrows(ParseException.class, () -> parser.parseCommand(
-                TransactionUtil.getAddCommand(expense), analyticsUiStateStub));
+    public void parseCommand_addCommandOnAnalyticsTab_throwsParseException() {
+        parseCommand_addCommandOnInvalidTab_throwsParseException(analyticsUiStateStub);
     }
 
     @Test
-    public void parseCommand_addExpenseWhenOverviewTab() throws Exception {
-        Expense expense = new TransactionBuilder().buildExpense();
-        AddExpenseCommand command =
-            (AddExpenseCommand) parser.parseCommand(TransactionUtil.getAddExpenseCommand(expense),
-            overviewUiStateStub);
-        assertEquals(new AddExpenseCommand(expense), command);
+    public void parseCommand_addCommandOnUserGuideTab_throwsParseException() {
+        parseCommand_addCommandOnInvalidTab_throwsParseException(userGuideUiStateStub);
     }
 
-    @Test
-    public void parseCommand_addExpenseWhenIncomeTab() throws Exception {
+    private void parseCommand_addExpenseCommandOnValidTab_returnsAddExpenseCommand(UiStateStub uiStateStub)
+            throws ParseException {
         Expense expense = new TransactionBuilder().buildExpense();
         AddExpenseCommand command =
                 (AddExpenseCommand) parser.parseCommand(TransactionUtil.getAddExpenseCommand(expense),
-                        incomeUiStateStub);
+                        uiStateStub);
         assertEquals(new AddExpenseCommand(expense), command);
     }
 
     @Test
-    public void parseCommand_addExpenseWhenExpensesTab() throws Exception {
-        Expense expense = new TransactionBuilder().buildExpense();
-        AddExpenseCommand command =
-                (AddExpenseCommand) parser.parseCommand(TransactionUtil.getAddExpenseCommand(expense),
-                        expensesUiStateStub);
-        assertEquals(new AddExpenseCommand(expense), command);
+    public void parseCommand_addExpenseCommandOnOverviewTab_returnsAddExpenseCommand() throws ParseException {
+        parseCommand_addExpenseCommandOnValidTab_returnsAddExpenseCommand(overviewUiStateStub);
     }
 
     @Test
-    public void parseCommand_addExpenseWhenAnalyticsTab() throws Exception {
-        Expense expense = new TransactionBuilder().buildExpense();
-        AddExpenseCommand command =
-                (AddExpenseCommand) parser.parseCommand(TransactionUtil.getAddExpenseCommand(expense),
-                        analyticsUiStateStub);
-        assertEquals(new AddExpenseCommand(expense), command);
+    public void parseCommand_addExpenseCommandOnIncomesTab_returnsAddExpenseCommand() throws ParseException {
+        parseCommand_addExpenseCommandOnValidTab_returnsAddExpenseCommand(incomesUiStateStub);
     }
 
     @Test
-    public void parseCommand_addIncomeWhenOverviewTab() throws Exception {
+    public void parseCommand_addExpenseCommandOnExpensesTab_returnsAddExpenseCommand() throws ParseException {
+        parseCommand_addExpenseCommandOnValidTab_returnsAddExpenseCommand(expensesUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_addExpenseCommandOnAnalyticsTab_returnsAddExpenseCommand() throws ParseException {
+        parseCommand_addExpenseCommandOnValidTab_returnsAddExpenseCommand(analyticsUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_addExpenseCommandOnUserGuideTab_returnsAddExpenseCommand() throws ParseException {
+        parseCommand_addExpenseCommandOnValidTab_returnsAddExpenseCommand(userGuideUiStateStub);
+    }
+
+    private void parseCommand_addIncomeCommandOnValidTab_returnsAddIncomeCommand(UiStateStub uiStateStub)
+            throws ParseException {
         Income income = new TransactionBuilder().buildIncome();
         AddIncomeCommand command =
                 (AddIncomeCommand) parser.parseCommand(TransactionUtil.getAddIncomeCommand(income),
-                overviewUiStateStub);
+                        uiStateStub);
         assertEquals(new AddIncomeCommand(income), command);
     }
 
     @Test
-    public void parseCommand_addIncomeWhenIncomeTab() throws Exception {
-        Income income = new TransactionBuilder().buildIncome();
-        AddIncomeCommand command =
-                (AddIncomeCommand) parser.parseCommand(TransactionUtil.getAddIncomeCommand(income),
-                        incomeUiStateStub);
-        assertEquals(new AddIncomeCommand(income), command);
+    public void parseCommand_addIncomeCommandOnOverviewTab_returnsAddIncomeCommand() throws ParseException {
+        parseCommand_addIncomeCommandOnValidTab_returnsAddIncomeCommand(overviewUiStateStub);
     }
 
     @Test
-    public void parseCommand_addIncomeWhenExpensesTab() throws Exception {
-        Income income = new TransactionBuilder().buildIncome();
-        AddIncomeCommand command =
-                (AddIncomeCommand) parser.parseCommand(TransactionUtil.getAddIncomeCommand(income),
-                        expensesUiStateStub);
-        assertEquals(new AddIncomeCommand(income), command);
+    public void parseCommand_addIncomeCommandOnIncomesTab_returnsAddIncomeCommand() throws ParseException {
+        parseCommand_addIncomeCommandOnValidTab_returnsAddIncomeCommand(incomesUiStateStub);
     }
 
     @Test
-    public void parseCommand_addIncomeWhenAnalyticsTab() throws Exception {
-        Income income = new TransactionBuilder().buildIncome();
-        AddIncomeCommand command =
-                (AddIncomeCommand) parser.parseCommand(TransactionUtil.getAddIncomeCommand(income),
-                        analyticsUiStateStub);
-        assertEquals(new AddIncomeCommand(income), command);
+    public void parseCommand_addIncomeCommandOnExpensesTab_returnsAddIncomeCommand() throws ParseException {
+        parseCommand_addIncomeCommandOnValidTab_returnsAddIncomeCommand(expensesUiStateStub);
     }
 
     @Test
-    public void parseCommand_addBookmarkIncomeWhenOverviewTab() throws Exception {
+    public void parseCommand_addIncomeCommandOnAnalyticsTab_returnsAddIncomeCommand() throws ParseException {
+        parseCommand_addIncomeCommandOnValidTab_returnsAddIncomeCommand(analyticsUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_addIncomeCommandOnUserGuideTab_returnsAddIncomeCommand() throws ParseException {
+        parseCommand_addIncomeCommandOnValidTab_returnsAddIncomeCommand(userGuideUiStateStub);
+    }
+
+    private void parseCommand_addBookmarkIncomeCommandOnValidTab_returnsAddBookmarkIncomeCommand(
+            UiStateStub uiStateStub) throws ParseException {
         BookmarkIncome bookmarkIncome = new BookmarkTransactionBuilder().buildBookmarkIncome();
         AddBookmarkIncomeCommand command =
                 (AddBookmarkIncomeCommand) parser.parseCommand(BookmarkTransactionUtil
-                        .getAddBookmarkIncomeCommand(bookmarkIncome), overviewUiStateStub);
+                        .getAddBookmarkIncomeCommand(bookmarkIncome), uiStateStub);
         assertEquals(new AddBookmarkIncomeCommand(bookmarkIncome), command);
     }
 
     @Test
-    public void parseCommand_addBookmarkIncomeWhenIncomesTab() throws Exception {
-        BookmarkIncome bookmarkIncome = new BookmarkTransactionBuilder().buildBookmarkIncome();
-        AddBookmarkIncomeCommand command =
-                (AddBookmarkIncomeCommand) parser.parseCommand(BookmarkTransactionUtil
-                        .getAddBookmarkIncomeCommand(bookmarkIncome), incomeUiStateStub);
-        assertEquals(new AddBookmarkIncomeCommand(bookmarkIncome), command);
+    public void parseCommand_addBookmarkIncomeCommandOnOverviewTab_returnsAddBookmarkIncomeCommand()
+            throws ParseException {
+        parseCommand_addBookmarkIncomeCommandOnValidTab_returnsAddBookmarkIncomeCommand(overviewUiStateStub);
     }
 
     @Test
-    public void parseCommand_addBookmarkIncomeWhenExpensesTab() throws Exception {
-        BookmarkIncome bookmarkIncome = new BookmarkTransactionBuilder().buildBookmarkIncome();
-        AddBookmarkIncomeCommand command =
-                (AddBookmarkIncomeCommand) parser.parseCommand(BookmarkTransactionUtil
-                        .getAddBookmarkIncomeCommand(bookmarkIncome), expensesUiStateStub);
-        assertEquals(new AddBookmarkIncomeCommand(bookmarkIncome), command);
+    public void parseCommand_addBookmarkIncomeCommandOnIncomesTab_returnsAddBookmarkIncomeCommand()
+            throws ParseException {
+        parseCommand_addBookmarkIncomeCommandOnValidTab_returnsAddBookmarkIncomeCommand(incomesUiStateStub);
     }
 
     @Test
-    public void parseCommand_addBookmarkIncomeWhenAnalyticsTab() throws Exception {
-        BookmarkIncome bookmarkIncome = new BookmarkTransactionBuilder().buildBookmarkIncome();
-        AddBookmarkIncomeCommand command =
-                (AddBookmarkIncomeCommand) parser.parseCommand(BookmarkTransactionUtil
-                        .getAddBookmarkIncomeCommand(bookmarkIncome), analyticsUiStateStub);
-        assertEquals(new AddBookmarkIncomeCommand(bookmarkIncome), command);
+    public void parseCommand_addBookmarkIncomeCommandOnExpensesTab_returnsAddBookmarkIncomeCommand()
+            throws ParseException {
+        parseCommand_addBookmarkIncomeCommandOnValidTab_returnsAddBookmarkIncomeCommand(expensesUiStateStub);
     }
 
     @Test
-    public void parseCommand_addBookmarkExpenseWhenOverviewTab() throws Exception {
+    public void parseCommand_addBookmarkIncomeCommandOnAnalyticsTab_returnsAddBookmarkIncomeCommand()
+            throws ParseException {
+        parseCommand_addBookmarkIncomeCommandOnValidTab_returnsAddBookmarkIncomeCommand(analyticsUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_addBookmarkIncomeCommandOnUserGuideTab_returnsAddBookmarkIncomeCommand()
+            throws ParseException {
+        parseCommand_addBookmarkIncomeCommandOnValidTab_returnsAddBookmarkIncomeCommand(userGuideUiStateStub);
+    }
+
+    private void parseCommand_addBookmarkExpenseCommandOnValidTab_returnsAddBookmarkExpenseCommand(
+            UiStateStub uiStateStub) throws ParseException {
         BookmarkExpense bookmarkExpense = new BookmarkTransactionBuilder().buildBookmarkExpense();
         AddBookmarkExpenseCommand command =
                 (AddBookmarkExpenseCommand) parser.parseCommand(BookmarkTransactionUtil
-                        .getAddBookmarkExpenseCommand(bookmarkExpense), overviewUiStateStub);
+                        .getAddBookmarkExpenseCommand(bookmarkExpense), uiStateStub);
         assertEquals(new AddBookmarkExpenseCommand(bookmarkExpense), command);
     }
 
     @Test
-    public void parseCommand_addBookmarkExpenseWhenIncomesTab() throws Exception {
-        BookmarkExpense bookmarkExpense = new BookmarkTransactionBuilder().buildBookmarkExpense();
-        AddBookmarkExpenseCommand command =
-                (AddBookmarkExpenseCommand) parser.parseCommand(BookmarkTransactionUtil
-                        .getAddBookmarkExpenseCommand(bookmarkExpense), incomeUiStateStub);
-        assertEquals(new AddBookmarkExpenseCommand(bookmarkExpense), command);
+    public void parseCommand_addBookmarkExpenseCommandOnOverviewTab_returnsAddBookmarkExpenseCommand()
+            throws ParseException {
+        parseCommand_addBookmarkExpenseCommandOnValidTab_returnsAddBookmarkExpenseCommand(overviewUiStateStub);
     }
 
     @Test
-    public void parseCommand_addBookmarkExpenseWhenExpensesTab() throws Exception {
-        BookmarkExpense bookmarkExpense = new BookmarkTransactionBuilder().buildBookmarkExpense();
-        AddBookmarkExpenseCommand command =
-                (AddBookmarkExpenseCommand) parser.parseCommand(BookmarkTransactionUtil
-                        .getAddBookmarkExpenseCommand(bookmarkExpense), expensesUiStateStub);
-        assertEquals(new AddBookmarkExpenseCommand(bookmarkExpense), command);
+    public void parseCommand_addBookmarkExpenseCommandOnIncomesTab_returnsAddBookmarkExpenseCommand()
+            throws ParseException {
+        parseCommand_addBookmarkExpenseCommandOnValidTab_returnsAddBookmarkExpenseCommand(incomesUiStateStub);
     }
 
     @Test
-    public void parseCommand_addBookmarkExpenseWhenAnalyticsTab() throws Exception {
-        BookmarkExpense bookmarkExpense = new BookmarkTransactionBuilder().buildBookmarkExpense();
-        AddBookmarkExpenseCommand command =
-                (AddBookmarkExpenseCommand) parser.parseCommand(BookmarkTransactionUtil
-                        .getAddBookmarkExpenseCommand(bookmarkExpense), analyticsUiStateStub);
-        assertEquals(new AddBookmarkExpenseCommand(bookmarkExpense), command);
+    public void parseCommand_addBookmarkExpenseCommandOnExpensesTab_returnsAddBookmarkExpenseCommand()
+            throws ParseException {
+        parseCommand_addBookmarkExpenseCommandOnValidTab_returnsAddBookmarkExpenseCommand(expensesUiStateStub);
     }
 
     @Test
-    public void parseCommand_clearWhenOverviewTab() throws Exception {
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, overviewUiStateStub) instanceof ClearCommand);
+    public void parseCommand_addBookmarkExpenseCommandOnAnalyticsTab_returnsAddBookmarkExpenseCommand()
+            throws ParseException {
+        parseCommand_addBookmarkExpenseCommandOnValidTab_returnsAddBookmarkExpenseCommand(analyticsUiStateStub);
     }
 
     @Test
-    public void parseCommand_clearWhenIncomeTab() throws Exception {
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, incomeUiStateStub) instanceof ClearCommand);
+    public void parseCommand_addBookmarkExpenseCommandOnUserGuideTab_returnsAddBookmarkExpenseCommand()
+            throws ParseException {
+        parseCommand_addBookmarkExpenseCommandOnValidTab_returnsAddBookmarkExpenseCommand(userGuideUiStateStub);
+    }
+
+    private void parseCommand_clearCommandOnValidTab_returnsClearCommand(UiStateStub uiStateStub)
+            throws ParseException {
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, uiStateStub) instanceof ClearCommand);
     }
 
     @Test
-    public void parseCommand_clearWhenExpensesTab() throws Exception {
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, expensesUiStateStub) instanceof ClearCommand);
+    public void parseCommand_clearCommandOnOverviewTab_returnsClearCommand() throws ParseException {
+        parseCommand_clearCommandOnValidTab_returnsClearCommand(overviewUiStateStub);
     }
 
     @Test
-    public void parseCommand_clearWhenAnalyticsTab() throws Exception {
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, analyticsUiStateStub) instanceof ClearCommand);
+    public void parseCommand_clearCommandOnIncomesTab_returnsClearCommand() throws ParseException {
+        parseCommand_clearCommandOnValidTab_returnsClearCommand(incomesUiStateStub);
     }
 
     @Test
-    public void parseCommand_clearWithArgsWhenOverviewTab() {
+    public void parseCommand_clearCommandOnExpensesTab_returnsClearCommand() throws ParseException {
+        parseCommand_clearCommandOnValidTab_returnsClearCommand(expensesUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_clearCommandOnAnalyticsTab_returnsClearCommand() throws ParseException {
+        parseCommand_clearCommandOnValidTab_returnsClearCommand(analyticsUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_clearCommandOnUserGuideTab_returnsClearCommand() throws ParseException {
+        parseCommand_clearCommandOnValidTab_returnsClearCommand(userGuideUiStateStub);
+    }
+
+    private void parseCommand_clearCommandWithArgsOnValidTab_throwsParseException(UiStateStub uiStateStub) {
         assertThrows(ParseException.class, () ->
-                parser.parseCommand(ClearCommand.COMMAND_WORD + "a", overviewUiStateStub));
+                parser.parseCommand(ClearCommand.COMMAND_WORD + " a", uiStateStub));
     }
 
     @Test
-    public void parseCommand_clearWithArgsWhenIncomeTab() {
-        assertThrows(ParseException.class, () ->
-                parser.parseCommand(ClearCommand.COMMAND_WORD + "a", incomeUiStateStub));
+    public void parseCommand_clearCommandWithArgsOnOverviewTab_throwsParseException() {
+        parseCommand_clearCommandWithArgsOnValidTab_throwsParseException(overviewUiStateStub);
     }
 
     @Test
-    public void parseCommand_clearWithArgsWhenExpensesTab() {
-        assertThrows(ParseException.class, () ->
-                parser.parseCommand(ClearCommand.COMMAND_WORD + "a", expensesUiStateStub));
+    public void parseCommand_clearCommandWithArgsOnIncomesTab_throwsParseException() {
+        parseCommand_clearCommandWithArgsOnValidTab_throwsParseException(incomesUiStateStub);
     }
 
     @Test
-    public void parseCommand_clearWithArgsWhenAnalyticsTab() {
-        assertThrows(ParseException.class, () ->
-                parser.parseCommand(ClearCommand.COMMAND_WORD + "a", analyticsUiStateStub));
+    public void parseCommand_clearCommandWithArgsOnExpensesTab_throwsParseException() {
+        parseCommand_clearCommandWithArgsOnValidTab_throwsParseException(expensesUiStateStub);
     }
 
     @Test
-    public void parseCommand_deleteWhenOverviewTab() {
-        assertThrows(ParseException.class, () -> parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased(), overviewUiStateStub));
+    public void parseCommand_clearCommandWithArgsOnAnalyticsTab_throwsParseException() {
+        parseCommand_clearCommandWithArgsOnValidTab_throwsParseException(analyticsUiStateStub);
     }
 
     @Test
-    public void parseCommand_deleteWhenIncomeTab() throws Exception {
+    public void parseCommand_clearCommandWithArgsOnUserGuideTab_throwsParseException() {
+        parseCommand_clearCommandWithArgsOnValidTab_throwsParseException(userGuideUiStateStub);
+    }
+
+    private void parseCommand_deleteCommandOnValidTab_returnsDeleteCommand(UiStateStub uiStateStub)
+            throws ParseException {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased(), incomeUiStateStub);
+                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased(), uiStateStub);
         assertEquals(new DeleteCommand(INDEX_FIRST), command);
     }
 
-    @Test
-    public void parseCommand_deleteWhenExpensesTab() throws Exception {
-        DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased(), expensesUiStateStub);
-        assertEquals(new DeleteCommand(INDEX_FIRST), command);
-    }
-
-    @Test
-    public void parseCommand_deleteWhenAnalyticsTab() {
+    private void parseCommand_deleteCommandOnInvalidTab_throwsParseException(UiStateStub uiStateStub) {
         assertThrows(ParseException.class, () -> parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased(), analyticsUiStateStub));
+                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased(), uiStateStub));
     }
 
     @Test
-    public void parseCommand_deleteBookmarkWhenOverviewTab() {
-        assertThrows(ParseException.class, () -> parser.parseCommand(
-                DeleteBookmarkCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased(), overviewUiStateStub));
+    public void parseCommand_deleteCommandOnOverviewTab_throwsParseException() {
+        parseCommand_deleteCommandOnInvalidTab_throwsParseException(overviewUiStateStub);
     }
 
     @Test
-    public void parseCommand_deleteBookmarkWhenIncomesTab() throws Exception {
+    public void parseCommand_deleteCommandOnIncomesTab_returnsDeleteCommand() throws ParseException {
+        parseCommand_deleteCommandOnValidTab_returnsDeleteCommand(incomesUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_deleteCommandOnExpensesTab_returnsDeleteCommand() throws ParseException {
+        parseCommand_deleteCommandOnValidTab_returnsDeleteCommand(expensesUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_deleteCommandOnAnalyticsTab_throwsParseException() {
+        parseCommand_deleteCommandOnInvalidTab_throwsParseException(analyticsUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_deleteCommandOnUserGuideTab_throwsParseException() {
+        parseCommand_deleteCommandOnInvalidTab_throwsParseException(userGuideUiStateStub);
+    }
+
+    private void parseCommand_deleteBookmarkCommandOnValidTab_returnsDeleteBookmarkCommand(UiStateStub uiStateStub)
+            throws ParseException {
         DeleteBookmarkCommand command = (DeleteBookmarkCommand) parser.parseCommand(
-                DeleteBookmarkCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased(), incomeUiStateStub);
+                DeleteBookmarkCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased(), uiStateStub);
         assertEquals(new DeleteBookmarkCommand(INDEX_FIRST), command);
     }
 
-    @Test
-    public void parseCommand_deleteBookmarkWhenExpensesTab() throws Exception {
-        DeleteBookmarkCommand command = (DeleteBookmarkCommand) parser.parseCommand(
-                DeleteBookmarkCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased(), expensesUiStateStub);
-        assertEquals(new DeleteBookmarkCommand(INDEX_FIRST), command);
-    }
-
-    @Test
-    public void parseCommand_deleteBookmarkWhenAnalyticsTab() {
+    private void parseCommand_deleteBookmarkCommandOnInvalidTab_throwsParseException(UiStateStub uiStateStub) {
         assertThrows(ParseException.class, () -> parser.parseCommand(
-                DeleteBookmarkCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased(), analyticsUiStateStub));
+                DeleteBookmarkCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased(), uiStateStub));
     }
 
     @Test
-    public void parseCommand_editWhenOverviewTab() throws Exception {
+    public void parseCommand_deleteBookmarkCommandOnOverviewTab_throwsParseException() {
+        parseCommand_deleteBookmarkCommandOnInvalidTab_throwsParseException(overviewUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_deleteBookmarkCommandOnIncomesTab_returnsDeleteBookmarkCommand() throws ParseException {
+        parseCommand_deleteBookmarkCommandOnValidTab_returnsDeleteBookmarkCommand(incomesUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_deleteBookmarkCommandOnExpensesTab_returnsDeleteBookmarkCommand() throws ParseException {
+        parseCommand_deleteBookmarkCommandOnValidTab_returnsDeleteBookmarkCommand(expensesUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_deleteBookmarkCommandOnAnalyticsTab_throwsParseException() {
+        parseCommand_deleteBookmarkCommandOnInvalidTab_throwsParseException(analyticsUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_deleteBookmarkCommandOnUserGuideTab_throwsParseException() {
+        parseCommand_deleteBookmarkCommandOnInvalidTab_throwsParseException(userGuideUiStateStub);
+    }
+
+    private void parseCommand_editCommandOnInvalidTab_throwsParseException(UiStateStub uiStateStub) {
         Expense expense = new TransactionBuilder().buildExpense();
         EditCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder(expense).build();
         assertThrows(ParseException.class, () -> parser.parseCommand(EditCommand.COMMAND_WORD + " "
                 + INDEX_FIRST.getOneBased() + " "
-                + TransactionUtil.getEditTransactionDescriptorDetails(descriptor), overviewUiStateStub));
+                + TransactionUtil.getEditTransactionDescriptorDetails(descriptor), uiStateStub));
     }
 
     @Test
-    public void parseCommand_editWhenIncomeTab() throws Exception {
+    public void parseCommand_editCommandOnOverviewTab_throwsParseException() {
+        parseCommand_editCommandOnInvalidTab_throwsParseException(overviewUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_editCommandOnIncomesTab_returnsEditCommand() throws ParseException {
         Income income = new TransactionBuilder().buildIncome();
         EditCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder(income).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
                 + INDEX_FIRST.getOneBased() + " "
-                + TransactionUtil.getEditTransactionDescriptorDetails(descriptor), incomeUiStateStub);
+                + TransactionUtil.getEditTransactionDescriptorDetails(descriptor), incomesUiStateStub);
         assertEquals(new EditCommand(INDEX_FIRST, descriptor), command);
     }
 
     @Test
-    public void parseCommand_editWhenExpensesTab() throws Exception {
+    public void parseCommand_editCommandOnExpensesTab_returnsEditCommand() throws ParseException {
         Expense expense = new TransactionBuilder().buildExpense();
         EditCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder(expense).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
@@ -362,40 +424,44 @@ public class FinanceTrackerParserTest {
     }
 
     @Test
-    public void parseCommand_editWhenAnalyticsTab() throws Exception {
-        Expense expense = new TransactionBuilder().buildExpense();
-        EditCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder(expense).build();
-        assertThrows(ParseException.class, () -> parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST.getOneBased() + " "
-                + TransactionUtil.getEditTransactionDescriptorDetails(descriptor), analyticsUiStateStub));
+    public void parseCommand_editCommandOnAnalyticsTab_throwsParseException() {
+        parseCommand_editCommandOnInvalidTab_throwsParseException(analyticsUiStateStub);
     }
 
     @Test
-    public void parseCommand_editBookmarkWhenOverviewTab() {
+    public void parseCommand_editCommandOnUserGuideTab_throwsParseException() {
+        parseCommand_editCommandOnInvalidTab_throwsParseException(userGuideUiStateStub);
+    }
+
+    private void parseCommand_editBookmarkCommandOnInvalidTab_throwsParseException(UiStateStub uiStateStub) {
         BookmarkExpense bookmarkExpense = new BookmarkTransactionBuilder().buildBookmarkExpense();
         EditBookmarkTransactionDescriptor descriptor = new EditBookmarkTransactionDescriptorBuilder(bookmarkExpense)
                 .build();
         assertThrows(ParseException.class, () -> parser.parseCommand(EditBookmarkCommand.COMMAND_WORD + " "
                 + INDEX_FIRST.getOneBased() + " "
                 + BookmarkTransactionUtil
-                .getEditBookmarkTransactionDescriptorDetails(descriptor), overviewUiStateStub));
-
+                .getEditBookmarkTransactionDescriptorDetails(descriptor), uiStateStub));
     }
 
     @Test
-    public void parseCommand_editBookmarkWhenIncomesTab() throws Exception {
+    public void parseCommand_editBookmarkCommandOnOverviewTab_throwsParseException() {
+        parseCommand_editBookmarkCommandOnInvalidTab_throwsParseException(overviewUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_editBookmarkCommandOnIncomesTab_returnsEditBookmarkCommand() throws ParseException {
         BookmarkIncome bookmarkIncome = new BookmarkTransactionBuilder().buildBookmarkIncome();
         EditBookmarkTransactionDescriptor descriptor = new EditBookmarkTransactionDescriptorBuilder(bookmarkIncome)
                 .build();
         EditBookmarkCommand command = (EditBookmarkCommand) parser.parseCommand(EditBookmarkCommand.COMMAND_WORD + " "
                 + INDEX_FIRST.getOneBased() + " "
                 + BookmarkTransactionUtil
-                .getEditBookmarkTransactionDescriptorDetails(descriptor), incomeUiStateStub);
+                .getEditBookmarkTransactionDescriptorDetails(descriptor), incomesUiStateStub);
         assertEquals(new EditBookmarkCommand(INDEX_FIRST, descriptor), command);
     }
 
     @Test
-    public void parseCommand_editBookmarkWhenExpensesTab() throws Exception {
+    public void parseCommand_editBookmarkCommandOnExpensesTab_returnsEditBookmarkCommand() throws ParseException {
         BookmarkExpense bookmarkExpense = new BookmarkTransactionBuilder().buildBookmarkExpense();
         EditBookmarkTransactionDescriptor descriptor = new EditBookmarkTransactionDescriptorBuilder(bookmarkExpense)
                 .build();
@@ -407,444 +473,622 @@ public class FinanceTrackerParserTest {
     }
 
     @Test
-    public void parseCommand_editBookmarkWhenAnalyticsTab() {
-        BookmarkExpense bookmarkExpense = new BookmarkTransactionBuilder().buildBookmarkExpense();
-        EditBookmarkTransactionDescriptor descriptor = new EditBookmarkTransactionDescriptorBuilder(bookmarkExpense)
-                .build();
-        assertThrows(ParseException.class, () -> parser.parseCommand(EditBookmarkCommand.COMMAND_WORD + " "
-                + INDEX_FIRST.getOneBased() + " "
-                + BookmarkTransactionUtil
-                .getEditBookmarkTransactionDescriptorDetails(descriptor), overviewUiStateStub));
+    public void parseCommand_editBookmarkCommandOnAnalyticsTab_throwsParseException() {
+        parseCommand_editBookmarkCommandOnInvalidTab_throwsParseException(analyticsUiStateStub);
     }
 
     @Test
-    public void parseCommand_convertBookmarkWhenOverviewTab() {
-        assertThrows(ParseException.class, () -> parser.parseCommand(
-                ConvertBookmarkCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased(), overviewUiStateStub));
+    public void parseCommand_editBookmarkCommandOnUserGuideTab_throwsParseException() {
+        parseCommand_editBookmarkCommandOnInvalidTab_throwsParseException(userGuideUiStateStub);
     }
 
-    @Test
-    public void parseCommand_convertBookmarkWhenIncomesTab() throws Exception {
+    private void parseCommand_convertBookmarkCommandOnValidTab_returnsConvertBookmarkCommand(UiStateStub uiStateStub)
+            throws ParseException {
         Date testDate = new Date(VALID_DATE_INTERNSHIP);
         ConvertBookmarkCommand command = (ConvertBookmarkCommand) parser.parseCommand(
                 ConvertBookmarkCommand.COMMAND_WORD + " "
                         + INDEX_FIRST.getOneBased() + " "
                         + PREFIX_DATE + VALID_DATE_INTERNSHIP,
-                incomeUiStateStub);
+                uiStateStub);
         assertEquals(new ConvertBookmarkCommand(INDEX_FIRST, testDate), command);
     }
 
-    @Test
-    public void parseCommand_convertBookmarkWhenExpensesTab() throws Exception {
-        Date testDate = new Date(VALID_DATE_INTERNSHIP);
-        ConvertBookmarkCommand command = (ConvertBookmarkCommand) parser.parseCommand(
-                ConvertBookmarkCommand.COMMAND_WORD + " "
-                        + INDEX_FIRST.getOneBased() + " "
-                        + PREFIX_DATE + VALID_DATE_INTERNSHIP,
-                expensesUiStateStub);
-        assertEquals(new ConvertBookmarkCommand(INDEX_FIRST, testDate), command);
-    }
-
-    @Test
-    public void parseCommand_convertBookmarkWhenAnalyticsTab() {
+    private void parseCommand_convertBookmarkCommandOnInvalidTab_throwsParseException(UiStateStub uiStateStub) {
         assertThrows(ParseException.class, () -> parser.parseCommand(
-                ConvertBookmarkCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased(), analyticsUiStateStub));
+                ConvertBookmarkCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased(), uiStateStub));
     }
 
     @Test
-    public void parseCommand_exitWhenOverviewTab() throws Exception {
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, overviewUiStateStub) instanceof ExitCommand);
+    public void parseCommand_convertBookmarkCommandOnOverviewTab_throwsParseException() {
+        parseCommand_convertBookmarkCommandOnInvalidTab_throwsParseException(overviewUiStateStub);
     }
 
     @Test
-    public void parseCommand_exitWhenIncomeTab() throws Exception {
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, incomeUiStateStub) instanceof ExitCommand);
+    public void parseCommand_convertBookmarkCommandOnIncomesTab_returnsConvertBookmarkCommand() throws ParseException {
+        parseCommand_convertBookmarkCommandOnValidTab_returnsConvertBookmarkCommand(incomesUiStateStub);
     }
 
     @Test
-    public void parseCommand_exitWhenExpensesTab() throws Exception {
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, expensesUiStateStub) instanceof ExitCommand);
+    public void parseCommand_convertBookmarkCommandOnExpensesTab_returnsConvertBookmarkCommand() throws ParseException {
+        parseCommand_convertBookmarkCommandOnValidTab_returnsConvertBookmarkCommand(expensesUiStateStub);
     }
 
     @Test
-    public void parseCommand_exitWhenAnalyticsTab() throws Exception {
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, analyticsUiStateStub) instanceof ExitCommand);
+    public void parseCommand_convertBookmarkCommandOnAnalyticsTab_throwsParseException() {
+        parseCommand_convertBookmarkCommandOnInvalidTab_throwsParseException(analyticsUiStateStub);
     }
 
     @Test
-    public void parseCommand_exitWithArgsWhenOverviewTab() {
+    public void parseCommand_convertBookmarkCommandOnUserGuideTab_throwsParseException() {
+        parseCommand_convertBookmarkCommandOnInvalidTab_throwsParseException(userGuideUiStateStub);
+    }
+
+    private void parseCommand_exitCommandOnValidTab_returnsExitCommand(UiStateStub uiStateStub) throws ParseException {
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, uiStateStub) instanceof ExitCommand);
+    }
+
+    @Test
+    public void parseCommand_exitCommandOnOverviewTab_returnsExitCommand() throws ParseException {
+        parseCommand_exitCommandOnValidTab_returnsExitCommand(overviewUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_exitCommandOnIncomesTab_returnsExitCommand() throws ParseException {
+        parseCommand_exitCommandOnValidTab_returnsExitCommand(incomesUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_exitCommandOnExpensesTab_returnsExitCommand() throws ParseException {
+        parseCommand_exitCommandOnValidTab_returnsExitCommand(expensesUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_exitCommandOnAnalyticsTab_returnsExitCommand() throws ParseException {
+        parseCommand_exitCommandOnValidTab_returnsExitCommand(analyticsUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_exitCommandOnUserGuideTab_returnsExitCommand() throws ParseException {
+        parseCommand_exitCommandOnValidTab_returnsExitCommand(userGuideUiStateStub);
+    }
+
+    private void parseCommand_exitCommandWithArgsOnValidTab_throwsParseException(UiStateStub uiStateStub) {
         assertThrows(ParseException.class, () ->
-                parser.parseCommand(ExitCommand.COMMAND_WORD + "a", overviewUiStateStub));
+                parser.parseCommand(ExitCommand.COMMAND_WORD + " a", uiStateStub));
     }
 
     @Test
-    public void parseCommand_exitWithArgsWhenIncomeTab() {
-        assertThrows(ParseException.class, () ->
-                parser.parseCommand(ExitCommand.COMMAND_WORD + "a", incomeUiStateStub));
+    public void parseCommand_exitCommandWithArgsOnOverviewTab_throwsParseException() {
+        parseCommand_exitCommandWithArgsOnValidTab_throwsParseException(overviewUiStateStub);
     }
 
     @Test
-    public void parseCommand_exitWithArgsWhenExpensesTab() {
-        assertThrows(ParseException.class, () ->
-                parser.parseCommand(ExitCommand.COMMAND_WORD + "a", expensesUiStateStub));
+    public void parseCommand_exitCommandWithArgsOnIncomesTab_throwsParseException() {
+        parseCommand_exitCommandWithArgsOnValidTab_throwsParseException(incomesUiStateStub);
     }
 
     @Test
-    public void parseCommand_exitWithArgsWhenAnalyticsTab() {
-        assertThrows(ParseException.class, () ->
-                parser.parseCommand(ExitCommand.COMMAND_WORD + "a", analyticsUiStateStub));
+    public void parseCommand_exitCommandWithArgsOnExpensesTab_throwsParseException() {
+        parseCommand_exitCommandWithArgsOnValidTab_throwsParseException(expensesUiStateStub);
     }
 
     @Test
-    public void parseCommand_findWhenOverviewTab() throws Exception {
+    public void parseCommand_exitCommandWithArgsOnAnalyticsTab_throwsParseException() {
+        parseCommand_exitCommandWithArgsOnValidTab_throwsParseException(analyticsUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_exitCommandWithArgsOnUserGuideTab_throwsParseException() {
+        parseCommand_exitCommandWithArgsOnValidTab_throwsParseException(userGuideUiStateStub);
+    }
+
+    private void parseCommand_findCommandOnValidTab_returnsFindCommand(UiStateStub uiStateStub) throws ParseException {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " t/" + keywords.stream()
-                        .collect(Collectors.joining(" t/")), overviewUiStateStub);
+                FindCommand.COMMAND_WORD + " " + PREFIX_TITLE + keywords.stream()
+                        .collect(Collectors.joining(" " + PREFIX_TITLE)), uiStateStub);
         List<Predicate<Transaction>> predicateList = new ArrayList<>();
         predicateList.add(new TitleContainsKeyphrasesPredicate(keywords));
         assertEquals(new FindCommand(predicateList), command);
     }
 
-    @Test
-    public void parseCommand_findWhenIncomeTab() throws Exception {
-        List<String> keyphrases = Arrays.asList("foo", "bar", "baz");
-        FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " t/" + keyphrases.stream()
-                        .collect(Collectors.joining(" t/")), incomeUiStateStub);
-        List<Predicate<Transaction>> predicateList = new ArrayList<>();
-        predicateList.add(new TitleContainsKeyphrasesPredicate(keyphrases));
-        assertEquals(new FindCommand(predicateList), command);
-    }
-
-    @Test
-    public void parseCommand_findWhenExpensesTab() throws Exception {
-        List<String> keyphrases = Arrays.asList("foo", "bar", "baz");
-        FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " t/" + keyphrases.stream()
-                        .collect(Collectors.joining(" t/")), expensesUiStateStub);
-        List<Predicate<Transaction>> predicateList = new ArrayList<>();
-        predicateList.add(new TitleContainsKeyphrasesPredicate(keyphrases));
-        assertEquals(new FindCommand(predicateList), command);
-    }
-
-    @Test
-    public void parseCommand_findWhenAnalyticsTab() throws Exception {
+    private void parseCommand_findCommandOnInvalidTab_throwsParseException(UiStateStub uiStateStub) {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         assertThrows(ParseException.class, () -> parser.parseCommand(
-                FindCommand.COMMAND_WORD + " t/" + keywords.stream()
-                        .collect(Collectors.joining(" t/")), analyticsUiStateStub));
+                FindCommand.COMMAND_WORD + " " + PREFIX_TITLE + keywords.stream()
+                        .collect(Collectors.joining(" " + PREFIX_TITLE)), uiStateStub));
     }
 
     @Test
-    public void parseCommand_helpWhenOverviewTab() throws Exception {
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, overviewUiStateStub) instanceof HelpCommand);
+    public void parseCommand_findCommandOnOverviewTab_returnsFindCommand() throws ParseException {
+        parseCommand_findCommandOnValidTab_returnsFindCommand(overviewUiStateStub);
     }
 
     @Test
-    public void parseCommand_helpWhenIncomeTab() throws Exception {
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, incomeUiStateStub) instanceof HelpCommand);
+    public void parseCommand_findCommandOnIncomesTab_returnsFindCommand() throws ParseException {
+        parseCommand_findCommandOnValidTab_returnsFindCommand(incomesUiStateStub);
     }
 
     @Test
-    public void parseCommand_helpWhenExpensesTab() throws Exception {
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, expensesUiStateStub) instanceof HelpCommand);
+    public void parseCommand_findCommandOnExpensesTab_returnsFindCommand() throws ParseException {
+        parseCommand_findCommandOnValidTab_returnsFindCommand(expensesUiStateStub);
     }
 
     @Test
-    public void parseCommand_helpWhenAnalyticsTab() throws Exception {
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, analyticsUiStateStub) instanceof HelpCommand);
+    public void parseCommand_findCommandOnAnalyticsTab_throwsParseException() {
+        parseCommand_findCommandOnInvalidTab_throwsParseException(analyticsUiStateStub);
     }
 
     @Test
-    public void parseCommand_helpWithArgsWhenOverviewTab() {
+    public void parseCommand_findCommandOnUserGuideTab_throwsParseException() {
+        parseCommand_findCommandOnInvalidTab_throwsParseException(userGuideUiStateStub);
+    }
+
+    private void parseCommand_helpCommandOnValidTab_returnsHelpCommand(UiStateStub uiStateStub) throws ParseException {
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, uiStateStub) instanceof HelpCommand);
+    }
+
+    @Test
+    public void parseCommand_helpCommandOnOverviewTab_returnsHelpCommand() throws ParseException {
+        parseCommand_helpCommandOnValidTab_returnsHelpCommand(overviewUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_helpCommandOnIncomesTab_returnsHelpCommand() throws ParseException {
+        parseCommand_helpCommandOnValidTab_returnsHelpCommand(incomesUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_helpCommandOnExpensesTab_returnsHelpCommand() throws ParseException {
+        parseCommand_helpCommandOnValidTab_returnsHelpCommand(expensesUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_helpCommandOnAnalyticsTab_returnsHelpCommand() throws ParseException {
+        parseCommand_helpCommandOnValidTab_returnsHelpCommand(analyticsUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_helpCommandOnUserGuideTab_returnsHelpCommand() throws ParseException {
+        parseCommand_helpCommandOnValidTab_returnsHelpCommand(userGuideUiStateStub);
+    }
+
+    private void parseCommand_helpCommandWithArgsOnValidTab_throwsParseException(UiStateStub uiStateStub) {
         assertThrows(ParseException.class, () ->
-                parser.parseCommand(HelpCommand.COMMAND_WORD + "a", overviewUiStateStub));
+                parser.parseCommand(HelpCommand.COMMAND_WORD + " a", uiStateStub));
     }
 
     @Test
-    public void parseCommand_helpWithArgsWhenIncomeTab() {
+    public void parseCommand_helpCommandWithArgsOnOverviewTab_throwsParseException() {
+        parseCommand_helpCommandWithArgsOnValidTab_throwsParseException(overviewUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_helpCommandWithArgsOnIncomesTab_throwsParseException() {
+        parseCommand_helpCommandWithArgsOnValidTab_throwsParseException(incomesUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_helpCommandWithArgsOnExpensesTab_throwsParseException() {
+        parseCommand_helpCommandWithArgsOnValidTab_throwsParseException(expensesUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_helpCommandWithArgsOnAnalyticsTab_throwsParseException() {
+        parseCommand_helpCommandWithArgsOnValidTab_throwsParseException(analyticsUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_helpCommandWithArgsOnUserGuideTab_throwsParseException() {
+        parseCommand_helpCommandWithArgsOnValidTab_throwsParseException(userGuideUiStateStub);
+    }
+
+    private void parseCommand_setExpenseLimitCommandOnValidTab_returnsSetExpenseLimitCommand(UiStateStub uiStateStub)
+            throws ParseException {
+        String amount = "$500.00";
+        SetExpenseLimitCommand command = (SetExpenseLimitCommand) parser.parseCommand(
+                SetExpenseLimitCommand.COMMAND_WORD + " " + PREFIX_AMOUNT + amount, uiStateStub);
+        assertEquals(new SetExpenseLimitCommand(new Amount(amount)), command);
+    }
+
+    @Test
+    public void parseCommand_setExpenseLimitCommandOnOverviewTab_returnsSetExpenseLimitCommand() throws ParseException {
+        parseCommand_setExpenseLimitCommandOnValidTab_returnsSetExpenseLimitCommand(overviewUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_setExpenseLimitCommandOnIncomesTab_returnsSetExpenseLimitCommand() throws ParseException {
+        parseCommand_setExpenseLimitCommandOnValidTab_returnsSetExpenseLimitCommand(incomesUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_setExpenseLimitCommandOnExpensesTab_returnsSetExpenseLimitCommand() throws ParseException {
+        parseCommand_setExpenseLimitCommandOnValidTab_returnsSetExpenseLimitCommand(expensesUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_setExpenseLimitCommandOnAnalyticsTab_returnsSetExpenseLimitCommand()
+            throws ParseException {
+        parseCommand_setExpenseLimitCommandOnValidTab_returnsSetExpenseLimitCommand(analyticsUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_setExpenseLimitCommandOnUserGuideTab_returnsSetExpenseLimitCommand()
+            throws ParseException {
+        parseCommand_setExpenseLimitCommandOnValidTab_returnsSetExpenseLimitCommand(userGuideUiStateStub);
+    }
+
+    private void parseCommand_setSavingsGoalCommandOnValidTab_returnsSetSavingsGoalCommand(UiStateStub uiStateStub)
+            throws ParseException {
+        String amount = "$500.00";
+        SetSavingsGoalCommand command = (SetSavingsGoalCommand) parser.parseCommand(
+                SetSavingsGoalCommand.COMMAND_WORD + " " + PREFIX_AMOUNT + amount, uiStateStub);
+        assertEquals(new SetSavingsGoalCommand(new Amount(amount)), command);
+    }
+
+    @Test
+    public void parseCommand_setSavingsGoalCommandOnOverviewTab_returnsSetSavingsGoalCommand() throws ParseException {
+        parseCommand_setSavingsGoalCommandOnValidTab_returnsSetSavingsGoalCommand(overviewUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_setSavingsGoalCommandOnIncomesTab_returnsSetSavingsGoalCommand() throws ParseException {
+        parseCommand_setSavingsGoalCommandOnValidTab_returnsSetSavingsGoalCommand(incomesUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_setSavingsGoalCommandOnExpensesTab_returnsSetSavingsGoalCommand() throws ParseException {
+        parseCommand_setSavingsGoalCommandOnValidTab_returnsSetSavingsGoalCommand(expensesUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_setSavingsGoalCommandOnAnalyticsTab_returnsSetSavingsGoalCommand() throws ParseException {
+        parseCommand_setSavingsGoalCommandOnValidTab_returnsSetSavingsGoalCommand(analyticsUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_setSavingsGoalCommandOnUserGuideTab_returnsSetSavingsGoalCommand() throws ParseException {
+        parseCommand_setSavingsGoalCommandOnValidTab_returnsSetSavingsGoalCommand(userGuideUiStateStub);
+    }
+
+    private void parseCommand_listCommandOnInvalidTab_throwsParseException(UiStateStub uiStateStub) {
         assertThrows(ParseException.class, () ->
-                parser.parseCommand(HelpCommand.COMMAND_WORD + "a", incomeUiStateStub));
+                parser.parseCommand(ListCommand.COMMAND_WORD, uiStateStub));
     }
 
     @Test
-    public void parseCommand_helpWithArgsWhenExpensesTab() {
-        assertThrows(ParseException.class, () ->
-                parser.parseCommand(HelpCommand.COMMAND_WORD + "a", expensesUiStateStub));
-    }
-
-    @Test
-    public void parseCommand_helpWithArgsWhenAnalyticsTab() {
-        assertThrows(ParseException.class, () ->
-                parser.parseCommand(HelpCommand.COMMAND_WORD + "a", analyticsUiStateStub));
-    }
-
-    @Test
-    public void parseCommand_listWhenOverviewTab() throws Exception {
+    public void parseCommand_listCommandOnOverviewTab_returnsListCommand() throws ParseException {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, overviewUiStateStub)
                 instanceof ListTransactionCommand);
     }
 
     @Test
-    public void parseCommand_listWhenIncomeTab() throws Exception {
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, incomeUiStateStub)
+    public void parseCommand_listCommandOnIncomesTab_returnsListCommand() throws ParseException {
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, incomesUiStateStub)
                 instanceof ListIncomeCommand);
     }
 
     @Test
-    public void parseCommand_listWhenExpensesTab() throws Exception {
+    public void parseCommand_listCommandOnExpensesTab_returnsListCommand() throws ParseException {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, expensesUiStateStub)
                 instanceof ListExpenseCommand);
     }
 
     @Test
-    public void parseCommand_listWhenAnalyticsTab() {
-        assertThrows(ParseException.class, () -> parser.parseCommand(ListCommand.COMMAND_WORD, analyticsUiStateStub));
+    public void parseCommand_listCommandOnAnalyticsTab_returnsListCommand() {
+        parseCommand_listCommandOnInvalidTab_throwsParseException(analyticsUiStateStub);
     }
 
     @Test
-    public void parseCommand_listWithArgsWhenOverviewTab() {
+    public void parseCommand_listCommandOnUserGuideTab_returnsListCommand() {
+        parseCommand_listCommandOnInvalidTab_throwsParseException(userGuideUiStateStub);
+    }
+
+    private void parseCommand_listCommandWithArgsOnValidTab_throwsParseException(UiStateStub uiStateStub) {
         assertThrows(ParseException.class, () ->
-                parser.parseCommand(ListCommand.COMMAND_WORD + "a", overviewUiStateStub));
+                parser.parseCommand(ListCommand.COMMAND_WORD + " a", uiStateStub));
     }
 
     @Test
-    public void parseCommand_listWithArgsWhenIncomeTab() {
-        assertThrows(ParseException.class, () ->
-                parser.parseCommand(ListCommand.COMMAND_WORD + "a", incomeUiStateStub));
+    public void parseCommand_listCommandWithArgsOnOverviewTab_throwsParseException() {
+        parseCommand_listCommandWithArgsOnValidTab_throwsParseException(overviewUiStateStub);
     }
 
     @Test
-    public void parseCommand_listWithArgsWhenExpensesTab() {
-        assertThrows(ParseException.class, () ->
-                parser.parseCommand(ListCommand.COMMAND_WORD + "a", expensesUiStateStub));
+    public void parseCommand_listCommandWithArgsOnIncomesTab_throwsParseException() {
+        parseCommand_listCommandWithArgsOnValidTab_throwsParseException(incomesUiStateStub);
     }
 
     @Test
-    public void parseCommand_listWithArgsWhenAnalyticsTab() {
-        assertThrows(ParseException.class, () ->
-                parser.parseCommand(ListCommand.COMMAND_WORD + "a", analyticsUiStateStub));
+    public void parseCommand_listCommandWithArgsOnExpensesTab_throwsParseException() {
+        parseCommand_listCommandWithArgsOnValidTab_throwsParseException(expensesUiStateStub);
     }
 
     @Test
-    public void parseCommand_listTransactionWhenOverviewTab() throws Exception {
-        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD, overviewUiStateStub)
+    public void parseCommand_listCommandWithArgsOnAnalyticsTab_throwsParseException() {
+        parseCommand_listCommandWithArgsOnValidTab_throwsParseException(analyticsUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_listCommandWithArgsOnUserGuideTab_throwsParseException() {
+        parseCommand_listCommandWithArgsOnValidTab_throwsParseException(userGuideUiStateStub);
+    }
+
+    private void parseCommand_listTransactionCommandOnValidTab_returnsListTransactionCommand(UiStateStub uiStateStub)
+            throws ParseException {
+        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD, uiStateStub)
                 instanceof ListTransactionCommand);
     }
 
     @Test
-    public void parseCommand_listTransactionWhenIncomeTab() throws Exception {
-        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD, incomeUiStateStub)
-                instanceof ListTransactionCommand);
+    public void parseCommand_listTransactionCommandOnOverviewTab_returnsListTransactionCommand() throws ParseException {
+        parseCommand_listTransactionCommandOnValidTab_returnsListTransactionCommand(overviewUiStateStub);
     }
 
     @Test
-    public void parseCommand_listTransactionWhenExpensesTab() throws Exception {
-        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD, expensesUiStateStub)
-                instanceof ListTransactionCommand);
+    public void parseCommand_listTransactionCommandOnIncomesTab_returnsListTransactionCommand() throws ParseException {
+        parseCommand_listTransactionCommandOnValidTab_returnsListTransactionCommand(incomesUiStateStub);
     }
 
     @Test
-    public void parseCommand_listTransactionWhenAnalyticsTab() throws Exception {
-        assertTrue(parser.parseCommand(ListTransactionCommand.COMMAND_WORD, analyticsUiStateStub)
-                instanceof ListTransactionCommand);
+    public void parseCommand_listTransactionCommandOnExpensesTab_returnsListTransactionCommand() throws ParseException {
+        parseCommand_listTransactionCommandOnValidTab_returnsListTransactionCommand(expensesUiStateStub);
     }
 
     @Test
-    public void parseCommand_listTransactionWithArgsWhenOverviewTab() {
+    public void parseCommand_listTransactionCommandOnAnalyticsTab_returnsListTransactionCommand()
+            throws ParseException {
+        parseCommand_listTransactionCommandOnValidTab_returnsListTransactionCommand(analyticsUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_listTransactionCommandOnUserGuideTab_returnsListTransactionCommand()
+            throws ParseException {
+        parseCommand_listTransactionCommandOnValidTab_returnsListTransactionCommand(userGuideUiStateStub);
+    }
+
+    private void parseCommand_listTransactionCommandWithArgsOnValidTab_throwsParseException(UiStateStub uiStateStub) {
         assertThrows(ParseException.class, () ->
-                parser.parseCommand(ListTransactionCommand.COMMAND_WORD + "a", overviewUiStateStub));
+                parser.parseCommand(ListTransactionCommand.COMMAND_WORD + " a", uiStateStub));
     }
 
     @Test
-    public void parseCommand_listTransactionWithArgsWhenIncomeTab() {
-        assertThrows(ParseException.class, () ->
-                parser.parseCommand(ListTransactionCommand.COMMAND_WORD + "a", incomeUiStateStub));
+    public void parseCommand_listTransactionCommandWithArgsOnOverviewTab_throwsParseException() {
+        parseCommand_listTransactionCommandWithArgsOnValidTab_throwsParseException(overviewUiStateStub);
     }
 
     @Test
-    public void parseCommand_listTransactionWithArgsWhenExpensesTab() {
-        assertThrows(ParseException.class, () ->
-                parser.parseCommand(ListTransactionCommand.COMMAND_WORD + "a", expensesUiStateStub));
+    public void parseCommand_listTransactionCommandWithArgsOnIncomesTab_throwsParseException() {
+        parseCommand_listTransactionCommandWithArgsOnValidTab_throwsParseException(incomesUiStateStub);
     }
 
     @Test
-    public void parseCommand_listTransactionWithArgsWhenAnalyticsTab() {
-        assertThrows(ParseException.class, () ->
-                parser.parseCommand(ListTransactionCommand.COMMAND_WORD + "a", analyticsUiStateStub));
+    public void parseCommand_listTransactionCommandWithArgsOnExpensesTab_throwsParseException() {
+        parseCommand_listTransactionCommandWithArgsOnValidTab_throwsParseException(expensesUiStateStub);
     }
 
     @Test
-    public void parseCommand_listExpenseWhenOverviewTab() throws Exception {
-        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD, overviewUiStateStub)
+    public void parseCommand_listTransactionCommandWithArgsOnAnalyticsTab_throwsParseException() {
+        parseCommand_listTransactionCommandWithArgsOnValidTab_throwsParseException(analyticsUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_listTransactionCommandWithArgsOnUserGuideTab_throwsParseException() {
+        parseCommand_listTransactionCommandWithArgsOnValidTab_throwsParseException(userGuideUiStateStub);
+    }
+
+    private void parseCommand_listExpenseCommandOnValidTab_returnsListExpenseCommand(UiStateStub uiStateStub)
+            throws ParseException {
+        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD, uiStateStub)
                 instanceof ListExpenseCommand);
     }
 
     @Test
-    public void parseCommand_listExpenseWhenIncomeTab() throws Exception {
-        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD, incomeUiStateStub)
-                instanceof ListExpenseCommand);
+    public void parseCommand_listExpenseCommandOnOverviewTab_returnsListExpenseCommand() throws ParseException {
+        parseCommand_listExpenseCommandOnValidTab_returnsListExpenseCommand(overviewUiStateStub);
     }
 
     @Test
-    public void parseCommand_listExpenseWhenExpensesTab() throws Exception {
-        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD, expensesUiStateStub)
-                instanceof ListExpenseCommand);
+    public void parseCommand_listExpenseCommandOnIncomesTab_returnsListExpenseCommand() throws ParseException {
+        parseCommand_listExpenseCommandOnValidTab_returnsListExpenseCommand(incomesUiStateStub);
     }
 
     @Test
-    public void parseCommand_listExpenseWhenAnalyticsTab() throws Exception {
-        assertTrue(parser.parseCommand(ListExpenseCommand.COMMAND_WORD, analyticsUiStateStub)
-                instanceof ListExpenseCommand);
+    public void parseCommand_listExpenseCommandOnExpensesTab_returnsListExpenseCommand() throws ParseException {
+        parseCommand_listExpenseCommandOnValidTab_returnsListExpenseCommand(expensesUiStateStub);
     }
 
     @Test
-    public void parseCommand_listExpenseWithArgsWhenOverviewTab() {
+    public void parseCommand_listExpenseCommandOnAnalyticsTab_returnsListExpenseCommand() throws ParseException {
+        parseCommand_listExpenseCommandOnValidTab_returnsListExpenseCommand(analyticsUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_listExpenseCommandOnUserGuideTab_returnsListExpenseCommand() throws ParseException {
+        parseCommand_listExpenseCommandOnValidTab_returnsListExpenseCommand(userGuideUiStateStub);
+    }
+
+    private void parseCommand_listExpenseCommandWithArgsOnValidTab_throwsParseException(UiStateStub uiStateStub) {
         assertThrows(ParseException.class, () ->
-                parser.parseCommand(ListExpenseCommand.COMMAND_WORD + "a", overviewUiStateStub));
+                parser.parseCommand(ListExpenseCommand.COMMAND_WORD + " a", uiStateStub));
     }
 
     @Test
-    public void parseCommand_listExpenseWithArgsWhenIncomeTab() {
-        assertThrows(ParseException.class, () ->
-                parser.parseCommand(ListExpenseCommand.COMMAND_WORD + "a", incomeUiStateStub));
+    public void parseCommand_listExpenseCommandWithArgsOnOverviewTab_throwsParseException() {
+        parseCommand_listExpenseCommandWithArgsOnValidTab_throwsParseException(overviewUiStateStub);
     }
 
     @Test
-    public void parseCommand_listExpenseWithArgsWhenExpensesTab() {
-        assertThrows(ParseException.class, () ->
-                parser.parseCommand(ListExpenseCommand.COMMAND_WORD + "a", expensesUiStateStub));
+    public void parseCommand_listExpenseCommandWithArgsOnIncomesTab_throwsParseException() {
+        parseCommand_listExpenseCommandWithArgsOnValidTab_throwsParseException(incomesUiStateStub);
     }
 
     @Test
-    public void parseCommand_listExpenseWithArgsWhenAnalyticsTab() {
-        assertThrows(ParseException.class, () ->
-                parser.parseCommand(ListExpenseCommand.COMMAND_WORD + "a", analyticsUiStateStub));
+    public void parseCommand_listExpenseCommandWithArgsOnExpensesTab_throwsParseException() {
+        parseCommand_listExpenseCommandWithArgsOnValidTab_throwsParseException(expensesUiStateStub);
     }
 
     @Test
-    public void parseCommand_listIncomeWhenOverviewTab() throws Exception {
-        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD, overviewUiStateStub)
+    public void parseCommand_listExpenseCommandWithArgsOnAnalyticsTab_throwsParseException() {
+        parseCommand_listExpenseCommandWithArgsOnValidTab_throwsParseException(analyticsUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_listExpenseCommandWithArgsOnUserGuideTab_throwsParseException() {
+        parseCommand_listExpenseCommandWithArgsOnValidTab_throwsParseException(userGuideUiStateStub);
+    }
+
+    private void parseCommand_listIncomeCommandOnValidTab_returnsListIncomeCommand(UiStateStub uiStateStub)
+            throws ParseException {
+        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD, uiStateStub)
                 instanceof ListIncomeCommand);
     }
 
     @Test
-    public void parseCommand_listIncomeWhenIncomeTab() throws Exception {
-        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD, incomeUiStateStub)
-                instanceof ListIncomeCommand);
+    public void parseCommand_listIncomeCommandOnOverviewTab_returnsListIncomeCommand() throws ParseException {
+        parseCommand_listIncomeCommandOnValidTab_returnsListIncomeCommand(overviewUiStateStub);
     }
 
     @Test
-    public void parseCommand_listIncomeWhenExpensesTab() throws Exception {
-        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD, expensesUiStateStub)
-                instanceof ListIncomeCommand);
+    public void parseCommand_listIncomeCommandOnIncomesTab_returnsListIncomeCommand() throws ParseException {
+        parseCommand_listIncomeCommandOnValidTab_returnsListIncomeCommand(incomesUiStateStub);
     }
 
     @Test
-    public void parseCommand_listIncomeWhenAnalyticsTab() throws Exception {
-        assertTrue(parser.parseCommand(ListIncomeCommand.COMMAND_WORD, analyticsUiStateStub)
-                instanceof ListIncomeCommand);
+    public void parseCommand_listIncomeCommandOnExpensesTab_returnsListIncomeCommand() throws ParseException {
+        parseCommand_listIncomeCommandOnValidTab_returnsListIncomeCommand(expensesUiStateStub);
     }
 
     @Test
-    public void parseCommand_listIncomeWithArgsWhenOverviewTab() {
+    public void parseCommand_listIncomeCommandOnAnalyticsTab_returnsListIncomeCommand() throws ParseException {
+        parseCommand_listIncomeCommandOnValidTab_returnsListIncomeCommand(analyticsUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_listIncomeCommandOnUserGuideTab_returnsListIncomeCommand() throws ParseException {
+        parseCommand_listIncomeCommandOnValidTab_returnsListIncomeCommand(userGuideUiStateStub);
+    }
+
+    private void parseCommand_listIncomeCommandWithArgsOnValidTab_throwsParseException(UiStateStub uiStateStub) {
         assertThrows(ParseException.class, () ->
-                parser.parseCommand(ListIncomeCommand.COMMAND_WORD + "a", overviewUiStateStub));
+                parser.parseCommand(ListIncomeCommand.COMMAND_WORD + " a", uiStateStub));
     }
 
     @Test
-    public void parseCommand_listIncomeWithArgsWhenIncomeTab() {
-        assertThrows(ParseException.class, () ->
-                parser.parseCommand(ListIncomeCommand.COMMAND_WORD + "a", incomeUiStateStub));
+    public void parseCommand_listIncomeCommandWithArgsOnOverviewTab_throwParseException() {
+        parseCommand_listIncomeCommandWithArgsOnValidTab_throwsParseException(overviewUiStateStub);
     }
 
     @Test
-    public void parseCommand_listIncomeWithArgsWhenExpensesTab() {
-        assertThrows(ParseException.class, () ->
-                parser.parseCommand(ListIncomeCommand.COMMAND_WORD + "a", expensesUiStateStub));
+    public void parseCommand_listIncomeCommandWithArgsOnIncomesTab_throwsParseException() {
+        parseCommand_listIncomeCommandWithArgsOnValidTab_throwsParseException(incomesUiStateStub);
     }
 
     @Test
-    public void parseCommand_listIncomeWithArgsWhenAnalyticsTab() {
-        assertThrows(ParseException.class, () ->
-                parser.parseCommand(ListIncomeCommand.COMMAND_WORD + "a", analyticsUiStateStub));
+    public void parseCommand_listIncomeCommandWithArgsOnExpensesTab_throwsParseException() {
+        parseCommand_listIncomeCommandWithArgsOnValidTab_throwsParseException(expensesUiStateStub);
     }
 
     @Test
-    public void parseCommand_tabWhenOverviewTab() throws Exception {
+    public void parseCommand_listIncomeCommandWithArgsOnAnalyticsTab_throwsParseException() {
+        parseCommand_listIncomeCommandWithArgsOnValidTab_throwsParseException(analyticsUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_listIncomeCommandWithArgsOnUserGuideTab_throwsParseException() {
+        parseCommand_listIncomeCommandWithArgsOnValidTab_throwsParseException(userGuideUiStateStub);
+    }
+
+    private void parseCommand_tabCommandOnValidTab_returnsTabCommand(UiStateStub uiStateStub) throws ParseException {
         TabCommand command = (TabCommand) parser.parseCommand(
-                TabCommand.COMMAND_WORD + " 1", overviewUiStateStub);
+                TabCommand.COMMAND_WORD + " 1", uiStateStub);
         assertEquals(new TabCommand(Index.fromOneBased(1)), command);
     }
 
     @Test
-    public void parseCommand_tabWhenIncomeTab() throws Exception {
-        TabCommand command = (TabCommand) parser.parseCommand(
-                TabCommand.COMMAND_WORD + " 1", incomeUiStateStub);
-        assertEquals(new TabCommand(Index.fromOneBased(1)), command);
+    public void parseCommand_tabCommandOnOverviewTab_returnsTabCommand() throws ParseException {
+        parseCommand_tabCommandOnValidTab_returnsTabCommand(overviewUiStateStub);
     }
 
     @Test
-    public void parseCommand_tabWhenExpensesTab() throws Exception {
-        TabCommand command = (TabCommand) parser.parseCommand(
-                TabCommand.COMMAND_WORD + " 1", expensesUiStateStub);
-        assertEquals(new TabCommand(Index.fromOneBased(1)), command);
+    public void parseCommand_tabCommandOnIncomesTab_returnsTabCommand() throws ParseException {
+        parseCommand_tabCommandOnValidTab_returnsTabCommand(incomesUiStateStub);
     }
 
     @Test
-    public void parseCommand_tabWhenAnalyticsTab() throws Exception {
-        TabCommand command = (TabCommand) parser.parseCommand(
-                TabCommand.COMMAND_WORD + " 1", analyticsUiStateStub);
-        assertEquals(new TabCommand(Index.fromOneBased(1)), command);
+    public void parseCommand_tabCommandOnExpensesTab_returnsTabCommand() throws ParseException {
+        parseCommand_tabCommandOnValidTab_returnsTabCommand(expensesUiStateStub);
     }
 
     @Test
-    public void parseCommand_unrecognisedInputWhenOverviewTab_throwsParseException() {
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-            -> parser.parseCommand("", overviewUiStateStub));
+    public void parseCommand_tabCommandOnAnalyticsTab_returnsTabCommand() throws ParseException {
+        parseCommand_tabCommandOnValidTab_returnsTabCommand(analyticsUiStateStub);
     }
 
     @Test
-    public void parseCommand_unrecognisedInputWhenIncomeTab_throwsParseException() {
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-            -> parser.parseCommand("", incomeUiStateStub));
+    public void parseCommand_tabCommandOnUserGuideTab_returnsTabCommand() throws ParseException {
+        parseCommand_tabCommandOnValidTab_returnsTabCommand(userGuideUiStateStub);
+    }
+
+    private void parseCommand_unrecognizedInputOnValidTab_throwsParseException(UiStateStub uiStateStub) {
+        assertThrows(ParseException.class,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), () ->
+                        parser.parseCommand("", uiStateStub));
     }
 
     @Test
-    public void parseCommand_unrecognisedInputWhenExpensesTab_throwsParseException() {
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-            -> parser.parseCommand("", expensesUiStateStub));
+    public void parseCommand_unrecognizedInputOnOverviewTab_throwsParseException() {
+        parseCommand_unrecognizedInputOnValidTab_throwsParseException(overviewUiStateStub);
     }
 
     @Test
-    public void parseCommand_unrecognisedInputWhenAnalyticsTab_throwsParseException() {
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-            -> parser.parseCommand("", analyticsUiStateStub));
+    public void parseCommand_unrecognizedInputOnIncomesTab_throwsParseException() {
+        parseCommand_unrecognizedInputOnValidTab_throwsParseException(incomesUiStateStub);
     }
 
     @Test
-    public void parseCommand_unknownCommandWhenOverviewTab_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, ()
-            -> parser.parseCommand("unknownCommand", overviewUiStateStub));
+    public void parseCommand_unrecognizedInputOnExpensesTab_throwsParseException() {
+        parseCommand_unrecognizedInputOnValidTab_throwsParseException(expensesUiStateStub);
     }
 
     @Test
-    public void parseCommand_unknownCommandWhenIncomeTab_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, ()
-            -> parser.parseCommand("unknownCommand", incomeUiStateStub));
+    public void parseCommand_unrecognizedInputOnAnalyticsTab_throwsParseException() {
+        parseCommand_unrecognizedInputOnValidTab_throwsParseException(analyticsUiStateStub);
     }
 
     @Test
-    public void parseCommand_unknownCommandWhenExpensesTab_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, ()
-            -> parser.parseCommand("unknownCommand", expensesUiStateStub));
+    public void parseCommand_unrecognizedInputOnUserGuideTab_throwsParseException() {
+        parseCommand_unrecognizedInputOnValidTab_throwsParseException(userGuideUiStateStub);
+    }
+
+    private void parseCommand_unknownCommandOnValidTab_throwsParseException(UiStateStub uiStateStub) {
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () ->
+                parser.parseCommand("unknownCommand", uiStateStub));
     }
 
     @Test
-    public void parseCommand_unknownCommandWhenAnalyticsTab_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, ()
-            -> parser.parseCommand("unknownCommand", analyticsUiStateStub));
+    public void parseCommand_unknownCommandOnOverviewTab_throwsParseException() {
+        parseCommand_unknownCommandOnValidTab_throwsParseException(overviewUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_unknownCommandOnIncomesTab_throwsParseException() {
+        parseCommand_unknownCommandOnValidTab_throwsParseException(incomesUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_unknownCommandOnExpensesTab_throwsParseException() {
+        parseCommand_unknownCommandOnValidTab_throwsParseException(expensesUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_unknownCommandOnAnalyticsTab_throwsParseException() {
+        parseCommand_unknownCommandOnValidTab_throwsParseException(analyticsUiStateStub);
+    }
+
+    @Test
+    public void parseCommand_unknownCommandOnUserGuideTab_throwsParseException() {
+        parseCommand_unknownCommandOnValidTab_throwsParseException(userGuideUiStateStub);
     }
 
     /**
@@ -875,7 +1119,7 @@ public class FinanceTrackerParserTest {
     /**
      * A {@code UiState} stub that always returns the 'Income' tab as the current tab.
      */
-    public static class IncomeUiStateStub extends UiStateStub {
+    public static class IncomesUiStateStub extends UiStateStub {
         @Override
         public Tab getCurrentTab() {
             return Tab.INCOME;
@@ -899,6 +1143,16 @@ public class FinanceTrackerParserTest {
         @Override
         public Tab getCurrentTab() {
             return Tab.ANALYTICS;
+        }
+    }
+
+    /**
+     * A {@code UiState} stub that always returns the 'User Guide' tab as the current tab.
+     */
+    public static class UserGuideUiStateStub extends UiStateStub {
+        @Override
+        public Tab getCurrentTab() {
+            return Tab.USER_GUIDE;
         }
     }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtilTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/ParserUtilTest.java
@@ -1,5 +1,9 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.parser;
 
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_CATEGORY;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_DATE;
+import static ay2021s1_cs2103_w16_3.finesse.logic.parser.CliSyntax.PREFIX_TITLE;
 import static ay2021s1_cs2103_w16_3.finesse.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.Assert.assertThrows;
 import static ay2021s1_cs2103_w16_3.finesse.testutil.TypicalIndexes.INDEX_FIRST;
@@ -13,6 +17,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import ay2021s1_cs2103_w16_3.finesse.logic.parser.bookmarkparsers.BookmarkTransactionBuilder;
 import ay2021s1_cs2103_w16_3.finesse.logic.parser.exceptions.ParseException;
 import ay2021s1_cs2103_w16_3.finesse.model.category.Category;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Amount;
@@ -20,7 +25,7 @@ import ay2021s1_cs2103_w16_3.finesse.model.transaction.Date;
 import ay2021s1_cs2103_w16_3.finesse.model.transaction.Title;
 
 public class ParserUtilTest {
-    private static final String INVALID_TITLE = "R\u2416chel";
+    private static final String INVALID_TITLE = "\u2416Bubble Tea";
     private static final String INVALID_AMOUNT = "+651234";
     private static final String INVALID_DATE = "example.com";
     private static final String INVALID_CATEGORY = "\u2416friend";
@@ -32,6 +37,8 @@ public class ParserUtilTest {
     private static final String VALID_CATEGORY_2 = "neighbour";
 
     private static final String WHITESPACE = " \t\r\n";
+
+    private static final String EXCEPTION_MESSAGE = "This is an exception message.";
 
     @Test
     public void parseIndex_invalidInput_throwsParseException() {
@@ -197,5 +204,60 @@ public class ParserUtilTest {
                 new Category(VALID_CATEGORY_2)));
 
         assertEquals(expectedCategorySet, actualCategorySet);
+    }
+
+    @Test
+    public void parseBookmarkTransactionBuilder_missingTitle_throwsParseException() {
+        String args = " " + PREFIX_AMOUNT + VALID_AMOUNT;
+        assertThrows(ParseException.class, () ->
+                ParserUtil.parseBookmarkTransactionBuilder(args, EXCEPTION_MESSAGE));
+    }
+
+    @Test
+    public void parseBookmarkTransactionBuilder_missingAmount_throwsParseException() {
+        String args = " " + PREFIX_TITLE + VALID_TITLE;
+        assertThrows(ParseException.class, () ->
+                ParserUtil.parseBookmarkTransactionBuilder(args, EXCEPTION_MESSAGE));
+    }
+
+    @Test
+    public void parseBookmarkTransactionBuilder_nonEmptyPreamble_throwsParseException() {
+        String args = "hello " + PREFIX_TITLE + VALID_TITLE + " " + PREFIX_AMOUNT + VALID_AMOUNT;
+        assertThrows(ParseException.class, () ->
+                ParserUtil.parseBookmarkTransactionBuilder(args, EXCEPTION_MESSAGE));
+    }
+
+    @Test
+    public void parseBookmarkTransactionBuilder_moreThanOneTitle_throwsParseException() {
+        String args = " " + PREFIX_TITLE + VALID_TITLE + " " + PREFIX_TITLE + VALID_TITLE;
+        assertThrows(ParseException.class, () ->
+                ParserUtil.parseBookmarkTransactionBuilder(args, EXCEPTION_MESSAGE));
+    }
+
+    @Test
+    public void parseBookmarkTransactionBuilder_moreThanOneAmount_throwsParseException() {
+        String args = " " + PREFIX_AMOUNT + VALID_AMOUNT + " " + PREFIX_AMOUNT + VALID_AMOUNT;
+        assertThrows(ParseException.class, () ->
+                ParserUtil.parseBookmarkTransactionBuilder(args, EXCEPTION_MESSAGE));
+    }
+
+    @Test
+    public void parseBookmarkTransactionBuilder_datePresent_throwsParseException() {
+        String args = " " + PREFIX_TITLE + VALID_TITLE + " " + PREFIX_AMOUNT + VALID_AMOUNT
+                + " " + PREFIX_DATE + VALID_DATE;
+        assertThrows(ParseException.class, () ->
+                ParserUtil.parseBookmarkTransactionBuilder(args, EXCEPTION_MESSAGE));
+    }
+
+    @Test
+    public void parseBookmarkTransactionBuilder_validInputs_returnsBookmarkTransactionBuilder() throws ParseException {
+        String args = " " + PREFIX_TITLE + VALID_TITLE + " " + PREFIX_AMOUNT + VALID_AMOUNT
+                + " " + PREFIX_CATEGORY + VALID_CATEGORY_1;
+        Title title = new Title(VALID_TITLE);
+        Amount amount = new Amount(VALID_AMOUNT);
+        Set<Category> categorySet = new HashSet<>();
+        categorySet.add(new Category(VALID_CATEGORY_1));
+        assertEquals(new BookmarkTransactionBuilder(title, amount, categorySet),
+                ParserUtil.parseBookmarkTransactionBuilder(args, EXCEPTION_MESSAGE));
     }
 }

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/PrefixTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/PrefixTest.java
@@ -1,0 +1,49 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class PrefixTest {
+    private static final String PREFIX_T = "t/";
+
+    private final Prefix prefix = new Prefix(PREFIX_T);
+
+    @Test
+    public void constructor_nullPrefix_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Prefix(null));
+    }
+
+    @Test
+    public void getPrefix() {
+        assertEquals(PREFIX_T, prefix.getPrefix());
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals(PREFIX_T, prefix.toString());
+    }
+
+    @Test
+    public void testHashCode() {
+        assertEquals(PREFIX_T.hashCode(), prefix.hashCode());
+    }
+
+    @Test
+    public void equals() {
+        // Same prefix -> returns true
+        assertTrue(prefix.equals(new Prefix(PREFIX_T)));
+
+        // Same object -> returns true
+        assertTrue(prefix.equals(prefix));
+
+        // null -> returns false
+        assertFalse(prefix.equals(null));
+
+        // Different types -> returns false
+        assertFalse(prefix.equals(5));
+    }
+}

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/BookmarkTransactionBuilderTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/parser/bookmark/BookmarkTransactionBuilderTest.java
@@ -1,0 +1,36 @@
+package ay2021s1_cs2103_w16_3.finesse.logic.parser.bookmark;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import ay2021s1_cs2103_w16_3.finesse.logic.parser.bookmarkparsers.BookmarkTransactionBuilder;
+
+public class BookmarkTransactionBuilderTest {
+    @Test
+    public void equals() {
+        BookmarkTransactionBuilder bookmarkTransactionBuilder = new BookmarkTransactionBuilder();
+
+        // Same values -> returns true
+        assertTrue(bookmarkTransactionBuilder.equals(new BookmarkTransactionBuilder()));
+
+        // Different titles -> returns false
+        assertFalse(bookmarkTransactionBuilder.equals(new BookmarkTransactionBuilder().withTitle("Internship")));
+
+        // Different amounts -> returns false
+        assertFalse(bookmarkTransactionBuilder.equals(new BookmarkTransactionBuilder().withAmount("5")));
+
+        // Different categories -> returns false
+        assertFalse(bookmarkTransactionBuilder.equals(new BookmarkTransactionBuilder().withCategories("Work")));
+
+        // Same object -> returns true
+        assertTrue(bookmarkTransactionBuilder.equals(bookmarkTransactionBuilder));
+
+        // null -> returns false
+        assertFalse(bookmarkTransactionBuilder.equals(null));
+
+        // Different types -> returns false
+        assertFalse(bookmarkTransactionBuilder.equals(5));
+    }
+}

--- a/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/time/SystemClockTest.java
+++ b/src/test/java/ay2021s1_cs2103_w16_3/finesse/logic/time/SystemClockTest.java
@@ -1,14 +1,17 @@
 package ay2021s1_cs2103_w16_3.finesse.logic.time;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
 public class SystemClockTest {
+    /** Time difference acceptance threshold (in milliseconds) for slower systems. */
+    private static final int TIME_DIFFERENCE_THRESHOLD = 100;
+
     private final SystemClock systemClock = new SystemClock();
 
     @Test
     public void getCurrentTime_sameAsCurrentSystemTime() {
-        assertEquals(System.currentTimeMillis(), systemClock.getCurrentTime());
+        assertTrue(Math.abs(System.currentTimeMillis() - systemClock.getCurrentTime()) <= TIME_DIFFERENCE_THRESHOLD);
     }
 }


### PR DESCRIPTION
Changes:
- Add private constructors to `ArgumentTokenizer` and `CliSyntax` to bring code coverage up.
- Prevent `Prefix` from having a `null` prefix string.
- Add `equals` method to `BookmarkTransactionBuilder` for testing purposes.
- Add tests for `BookmarkTransactionBuilder`.
- Update `FinanceTrackerParserTest` to be more comprehensive.
- Add tests for `ParserUtil.parseBookmarkTransactionBuilder`.
- Add tests for `Prefix`.
- Make the `getCurrentTime_sameAsCurrentSystemTime` test in `SystemClockTest` more forgiving.
  - Previously, this test could fail on rare occasions.

Partially resolves #115.